### PR TITLE
feat: make the version endpoint on pair with the CLI

### DIFF
--- a/solx-solc/src/version.rs
+++ b/solx-solc/src/version.rs
@@ -11,19 +11,19 @@ pub struct Version {
     pub long: String,
     /// The short `semver`.
     pub default: semver::Version,
-    /// The ZKsync revision additional versioning.
-    pub l2_revision: semver::Version,
+    /// The LLVM revision additional versioning.
+    pub llvm_revision: semver::Version,
 }
 
 impl Version {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(long: String, default: semver::Version, l2_revision: semver::Version) -> Self {
+    pub fn new(long: String, default: semver::Version, llvm_revision: semver::Version) -> Self {
         Self {
             long,
             default,
-            l2_revision,
+            llvm_revision,
         }
     }
 }

--- a/solx-yul/src/yul/parser/statement/expression/function_call/name.rs
+++ b/solx-yul/src/yul/parser/statement/expression/function_call/name.rs
@@ -206,7 +206,7 @@ pub enum Name {
     MSize,
 
     /// verbatim instruction with 0 inputs and 0 outputs
-    /// only works in the Yul mode, so it is mostly used as a tool for extending Yul for ZKsync
+    /// only works in the Yul mode, so it is mostly used as a tool for extending Yul
     Verbatim {
         /// the number of input arguments
         input_size: usize,

--- a/solx/src/project/contract/metadata.rs
+++ b/solx/src/project/contract/metadata.rs
@@ -13,11 +13,11 @@ pub struct Metadata<'a> {
     pub source_metadata: serde_json::Value,
     /// The `solc` version.
     pub solc_version: semver::Version,
-    /// The ZKsync `solc` edition.
-    pub solc_zkvm_edition: semver::Version,
-    /// The ZKsync compiler version.
-    pub zk_version: semver::Version,
-    /// The ZKsync compiler optimizer settings.
+    /// The LLVM `solc` edition.
+    pub solc_llvm_edition: semver::Version,
+    /// The LLVM compiler version.
+    pub version: semver::Version,
+    /// The LLVM compiler optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     /// The LLVM extra arguments.
     pub llvm_options: &'a [String],
@@ -30,7 +30,7 @@ impl<'a> Metadata<'a> {
     pub fn new(
         source_metadata: serde_json::Value,
         solc_version: semver::Version,
-        solc_zkvm_edition: semver::Version,
+        solc_llvm_edition: semver::Version,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: &'a [String],
     ) -> Self {
@@ -44,8 +44,8 @@ impl<'a> Metadata<'a> {
         Self {
             source_metadata,
             solc_version,
-            solc_zkvm_edition,
-            zk_version: crate::version().parse().expect("Always valid"),
+            solc_llvm_edition,
+            version: crate::version().parse().expect("Always valid"),
             optimizer_settings,
             llvm_options,
         }

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -82,7 +82,7 @@ impl Contract {
         let metadata = Metadata::new(
             self.source_metadata,
             solc_version.default.to_owned(),
-            solc_version.l2_revision.to_owned(),
+            solc_version.llvm_revision.to_owned(),
             optimizer.settings().to_owned(),
             llvm_options.as_slice(),
         );


### PR DESCRIPTION
# What ❔

Makes the solc version endpoint on pair with the CLI.

## Why ❔

It used to only return the long solc version, but not our LLVM-friendly revision.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
