### PR TITLE
feat: rebuild solx if static library deps are changed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,9 +23,9 @@ linker = "rust-lld"
 strip = true
 
 [env]
-LLVM_SYS_170_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = false }
 BOOST_PREFIX = { value = "/opt/homebrew/lib/", relative = false, force = false }
-SOLC_PREFIX = { value = "./era-solidity/build/", relative = false, force = false }
+LLVM_SYS_170_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = false }
+SOLC_PREFIX = { value = "./era-solidity/build/", relative = true, force = false }
 
 [tools.clippy]
 warn = [

--- a/solx-solc/build.rs
+++ b/solx-solc/build.rs
@@ -6,9 +6,17 @@
 /// Links solc and Boost libraries statically.
 ///
 fn main() {
+    // Re-run if the `Boost` path environment variable is changed.
+    println!("cargo:rerun-if-env-changed={}", env!("BOOST_PREFIX"));
+    // Re-run if the `solc` path environment variable is changed.
+    println!("cargo:rerun-if-env-changed={}", env!("SOLC_PREFIX"));
+    // Re-run if the `solc` directory contents are changed.
+    if let Ok(path) = std::env::var("SOLC_PREFIX") {
+        println!("cargo:rerun-if-changed={}", path);
+    }
+
     // Where to find Boost libraries.
     println!("cargo:rustc-link-search=native={}", env!("BOOST_PREFIX"));
-
     // Where to find solc libraries.
     for directory in [
         "libsolc",
@@ -25,15 +33,14 @@ fn main() {
         );
     }
 
-    // Link against the static libraries.
+    // Link with Boost libraries.
+    for library in ["boost_filesystem", "boost_system", "boost_program_options"] {
+        println!("cargo:rustc-link-lib=static={library}");
+    }
+    // Link with solc libraries.
     for library in [
         "solc", "solidity", "solutil", "langutil", "evmasm", "yul", "smtutil",
     ] {
-        println!("cargo:rustc-link-lib=static={library}");
-    }
-
-    // Link the Boost libraries.
-    for library in ["boost_filesystem", "boost_system", "boost_program_options"] {
         println!("cargo:rustc-link-lib=static={library}");
     }
 }


### PR DESCRIPTION
# What ❔

Rebuilds solx if static library deps are changed.

## Why ❔

It required `cargo clean` if LLVM or solc were changed externally.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
