### PR TITLE
feat: add the solc version to --version output

### DIFF
--- a/solx/src/solx/main.rs
+++ b/solx/src/solx/main.rs
@@ -74,10 +74,22 @@ fn main_inner(
     if arguments.version {
         writeln!(
             std::io::stdout(),
-            "{} v{} (LLVM build {})",
+            "{} v{}, {} statically linked with:",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
             env!("CARGO_PKG_DESCRIPTION"),
-            solx::version(),
+        )?;
+        writeln!(
+            std::io::stdout(),
+            "    LLVM build {}",
             inkwell::support::get_commit_id().to_string(),
+        )?;
+        let solc = solx_solc::Compiler::default();
+        writeln!(
+            std::io::stdout(),
+            "    solc v{}, LLVM revision v{}",
+            solc.version.default,
+            solc.version.llvm_revision,
         )?;
         return Ok(());
     }


### PR DESCRIPTION
Adds the solc version to `solx --version` output.

New output:
```
solx v1.0.0, LLVM-based Solidity compiler statically linked with:
    LLVM build a5e647c4b495d5a1754bfb279113faf2d1d92780
    solc v0.8.28, LLVM revision v1.0.1
```

Earlier, only LLVM was included here.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
