### PR TITLE
fix: show contract path in --recursive-process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/matter-labs/era-compiler-llvm
-	branch = v1.5.8
+	branch = main
 [submodule "era-solidity"]
 	path = era-solidity
 	url = https://github.com/matter-labs/era-solidity

--- a/solx/src/process/mod.rs
+++ b/solx/src/process/mod.rs
@@ -65,6 +65,7 @@ where
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
     command.arg("--recursive-process");
+    command.arg(path);
 
     let mut process = command
         .spawn()

--- a/solx/src/solx/arguments.rs
+++ b/solx/src/solx/arguments.rs
@@ -165,15 +165,6 @@ impl Arguments {
             ));
         }
 
-        if self.recursive_process && std::env::args().count() > 2 {
-            messages.push(solx_solc::StandardJsonOutputError::new_error(
-                None,
-                "No other options are allowed in recursive mode.",
-                None,
-                None,
-            ));
-        }
-
         let modes_count = [
             self.yul,
             self.llvm_ir,

--- a/solx/tests/cli/recursive_process.rs
+++ b/solx/tests/cli/recursive_process.rs
@@ -17,20 +17,3 @@ fn missing_input() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-#[test]
-fn excess_arguments() -> anyhow::Result<()> {
-    crate::common::setup()?;
-
-    let args = &[
-        "--recursive-process",
-        crate::common::TEST_SOLIDITY_CONTRACT_PATH,
-    ];
-
-    let result = crate::cli::execute_solx(args)?;
-    result.failure().stderr(predicate::str::contains(
-        "No other options are allowed in recursive mode.",
-    ));
-
-    Ok(())
-}


### PR DESCRIPTION
Shows contract path in `--recursive-process`.
It helps to debug when one translation unit's process hangs.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
