### PR TITLE
fix: sets the stack limit back to 64 MB

### DIFF
--- a/solx/src/const.rs
+++ b/solx/src/const.rs
@@ -2,17 +2,8 @@
 //! Solidity compiler constants.
 //!
 
-/// The `keccak256` scratch space offset.
-pub const OFFSET_SCRATCH_SPACE: usize = 0;
-
-/// The memory pointer offset.
-pub const OFFSET_MEMORY_POINTER: usize = 2 * era_compiler_common::BYTE_LENGTH_FIELD;
-
-/// The empty slot offset.
-pub const OFFSET_EMPTY_SLOT: usize = 3 * era_compiler_common::BYTE_LENGTH_FIELD;
-
-/// The non-reserved memory offset.
-pub const OFFSET_NON_RESERVED: usize = 4 * era_compiler_common::BYTE_LENGTH_FIELD;
+/// The worker thread stack size.
+pub const WORKER_THREAD_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 ///
 /// The compiler version default function.

--- a/solx/src/solx/main.rs
+++ b/solx/src/solx/main.rs
@@ -12,9 +12,6 @@ use clap::Parser;
 
 use self::arguments::Arguments;
 
-/// The rayon worker stack size.
-const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
-
 ///
 /// The application entry point.
 ///
@@ -92,7 +89,7 @@ fn main_inner(
         thread_pool_builder = thread_pool_builder.num_threads(threads);
     }
     thread_pool_builder
-        .stack_size(RAYON_WORKER_STACK_SIZE)
+        .stack_size(solx::WORKER_THREAD_STACK_SIZE)
         .build_global()
         .expect("Thread pool configuration failure");
 


### PR DESCRIPTION
Fixes the stack limit that was regressed during migration to one-process-per-translation-unit approach.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
