### PR TITLE
feat: make IPFS hash and CBOR equivalent again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arrayref"
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -311,6 +311,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -498,13 +518,14 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "era-compiler-common"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#8d33194da0c25b16edc09781103509af939d0a8a"
+version = "2.0.0"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9bafeabc66d33694409208c51749634a86c1772a"
 dependencies = [
  "anyhow",
  "base58",
  "hex",
  "ipfs-hasher",
+ "semver",
  "serde",
  "serde_arrays",
  "serde_json",
@@ -514,8 +535,8 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-llvm-context"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#58f13d13c5edabdfa0427d8c7201744cbf8dbcbe"
+version = "2.0.0"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4785cde7dbc949d89cd15ebc13fb5d43bd0e2b9a"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -524,15 +545,15 @@ dependencies = [
  "num",
  "semver",
  "serde",
- "thiserror 1.0.64",
+ "thiserror",
  "zkevm_opcode_defs",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -607,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -639,7 +660,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -720,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -740,7 +773,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -784,9 +817,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -845,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "llvm-sys"
@@ -1009,15 +1042,17 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
@@ -1092,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1188,6 +1223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1261,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1245,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1315,9 +1356,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -1325,6 +1366,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -1354,36 +1401,36 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_arrays"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1392,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1404,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "serde_stacker"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babfccff5773ff80657f0ecf553c7c516bdc2eb16389c0918b36b73e7015276e"
+checksum = "69c8defe6c780725cce4ec6ad3bd91e321baf6fa4e255df1f31e345d507ef01a"
 dependencies = [
  "serde",
  "stacker",
@@ -1489,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "solx"
@@ -1516,7 +1563,7 @@ dependencies = [
  "solx-yul",
  "tempfile",
  "test-case",
- "thiserror 1.0.64",
+ "thiserror",
  "zkevm_opcode_defs",
 ]
 
@@ -1552,7 +1599,7 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "serde",
- "thiserror 1.0.64",
+ "thiserror",
 ]
 
 [[package]]
@@ -1615,12 +1662,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1667,31 +1714,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
-dependencies = [
- "thiserror-impl 1.0.64",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1756,6 +1783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1826,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1874,6 +1916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 **solx** passes [our test suite](https://github.com/matter-labs/era-compiler-tester), which includes:
 
 - [tests](https://github.com/ethereum/solidity/tree/develop/test/libsolidity/semanticTests) from the **solc** project
-- [real-world projects](https://github.com/matter-labs/era-compiler-tests/tree/main/solidity/complex/defi) such as UniswapV2 and Mooniswap
+- [real-life projects](https://github.com/matter-labs/era-compiler-tests/tree/main/solidity/complex/defi) such as UniswapV2 and Mooniswap
 - [additional tests](https://github.com/matter-labs/era-compiler-tests/tree/main/solidity) written by the **solx** team
 
 Our pool of tests is updated with every **solc** release. Arbitrary contracts are expected to compile correctly, but some may be temporary affected by stack-too-deep errors. Benchmarks indicate that **solx** generates larger code than **solc**, but reduces the gas consumption on average.
@@ -36,7 +36,7 @@ Or, you can take a build used in our [solx_demo](https://github.com/popzxc/solx_
 
 ## Usage
 
-We recommend using **solx** via [Foundry](https://github.com/foundry-rs/foundry). It behaves the same way as
+We recommend using **solx** via [Foundry](https://github.com/foundry-rs/foundry). It behaves in the same way as
 **solc** v0.8.29, so you can download the executable and specify:
 
 ```toml

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -47,7 +47,7 @@ Binary:
 **solx** supports multiple input files. The following command compiles two Solidity files and prints the bytecode:
 
 ```bash
-solx 'Simple.sol' './Complex.sol' --bin
+solx 'Simple.sol' 'Complex.sol' --bin
 ```
 
 [Solidity import remappings](https://docs.soliditylang.org/en/latest/path-resolution.html#import-remapping) are passed in the way as input files, but they are distinguished by a `=` symbol between source and destination. The following command compiles a Solidity file with a remapping and prints the bytecode:
@@ -245,15 +245,49 @@ Specifies the hash format used for contract metadata.
 Usage with `ipfs`:
 
 ```bash
-solx './Test.sol' --bin --metadata-hash 'ipfs'
+solx 'Simple.sol' --bin --metadata-hash 'ipfs'
 ```
 
 Output with `ipfs`:
 
 ```text
-======= .../Test.sol:Test =======
+======= Simple.sol:Simple =======
 Binary:
 5b60806040525f341415601c5763000000488063000000245f395ff35b5f80...
+a2646970667358221220ba14ea4e52366f139a845913d41e98933393bd1c1126331611687003d4aa92de64736f6c6378247a6b736f6c633a312e352e31333b736f6c633a302e382e32393b6c6c766d3a312e302e310055
+```
+
+The byte array starting with `a2` at the end of the bytecode is a CBOR-encoded compiler version data and an optional metadata hash.
+
+JSON representation of a CBOR payload:
+
+```javascript
+{
+    // Optional: included if `--metadata-hash` is set to `ipfs`.
+    "ipfs": "1220ba14ea4e52366f139a845913d41e98933393bd1c1126331611687003d4aa92de",
+
+    // Required: consists of semicolon-separated pairs of colon-separated compiler names and versions.
+    // `solx:<version>` is always included.
+    // `solc:<version>;llvm:<version>` is only included for Solidity and Yul contracts, but not included for LLVM IR ones.
+    // `llvm` stands for the revision of Matter Labs fork of solc, that solx is statically linked with.
+    "solc": "solx:0.1.0;solc:0.8.29;llvm:1.0.2"
+}
+```
+
+For more information on these formats, see the [CBOR](https://cbor.io/) and [IPFS](https://docs.ipfs.tech/) documentation.
+
+
+
+### `--no-cbor-metadata`
+
+Disables the CBOR metadata that is appended at the end of bytecode. This option is useful for debugging and research purposes.
+
+> It is not recommended to use this option in production, as it is not possible to verify contracts deployed without metadata.
+
+Usage:
+
+```shell
+solx 'Simple.sol' --no-cbor-metadata
 ```
 
 
@@ -356,7 +390,7 @@ Enables the Yul mode. In this mode, input is expected to be in the Yul language.
 Usage:
 
 ```bash
-solx --yul './Simple.yul' --bin
+solx --yul 'Simple.yul' --bin
 ```
 
 Output:
@@ -378,7 +412,7 @@ Unlike **solc**, **solx** is an LLVM-based compiler toolchain, so it uses LLVM I
 Usage:
 
 ```bash
-solx --llvm-ir './Simple.ll' --bin
+solx --llvm-ir 'Simple.ll' --bin
 ```
 
 Output:

--- a/solx-solc/Cargo.toml
+++ b/solx-solc/Cargo.toml
@@ -10,11 +10,11 @@ description = "solc client for solx"
 doctest = false
 
 [dependencies]
-anyhow = "=1.0.89"
-serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
-semver = { version = "=1.0.23", features = [ "serde" ] }
-libc = "=0.2.171"
+anyhow = "1.0"
+serde = { version = "1.0", "features" = [ "derive" ] }
+serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
+semver = { version = "1.0", features = [ "serde" ] }
+libc = "0.2"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -71,7 +71,11 @@ impl Compiler {
         input_json
             .settings
             .output_selection
-            .set_ir(input_json.settings.via_ir);
+            .set_selector(solx_standard_json::InputSelector::Metadata);
+        input_json
+            .settings
+            .output_selection
+            .set_selector(input_json.settings.via_ir.into());
 
         let input_string = serde_json::to_string(input_json).expect("Always valid");
         let input_c_string = CString::new(input_string).expect("Always valid");
@@ -183,7 +187,10 @@ impl Compiler {
         solc_input: &mut solx_standard_json::Input,
         messages: &mut Vec<solx_standard_json::OutputError>,
     ) -> anyhow::Result<solx_standard_json::Output> {
-        solc_input.settings.output_selection.set_ir(true);
+        solc_input
+            .settings
+            .output_selection
+            .set_selector(solx_standard_json::InputSelector::Yul);
         let solc_output = self.standard_json(solc_input, messages, None, vec![], None)?;
         Ok(solc_output)
     }

--- a/solx-standard-json/Cargo.toml
+++ b/solx-standard-json/Cargo.toml
@@ -10,11 +10,11 @@ description = "Standard JSON protocol for solx"
 doctest = false
 
 [dependencies]
-anyhow = "=1.0.89"
-rayon = "=1.10.0"
-serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
-semver = { version = "=1.0.23", features = [ "serde" ] }
-num = "=0.4.3"
+anyhow = "1.0"
+rayon = "1.10"
+serde = { version = "1.0", "features" = [ "derive" ] }
+serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
+semver = { version = "1.0", features = [ "serde" ] }
+num = "0.4"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }

--- a/solx-standard-json/src/input/settings/metadata.rs
+++ b/solx-standard-json/src/input/settings/metadata.rs
@@ -11,14 +11,23 @@ pub struct Metadata {
     /// Whether to use literal content.
     #[serde(default)]
     pub use_literal_content: bool,
+
+    /// Whether to append CBOR metadata.
+    #[serde(
+        rename = "appendCBOR",
+        default = "Metadata::default_append_cbor",
+        skip_serializing
+    )]
+    pub append_cbor: bool,
+
     /// The metadata hash type.
     #[serde(default = "Metadata::default_bytecode_hash", skip_serializing)]
-    pub bytecode_hash: era_compiler_common::HashType,
+    pub bytecode_hash: era_compiler_common::EVMMetadataHashType,
 }
 
 impl Default for Metadata {
     fn default() -> Self {
-        Self::new(false, Self::default_bytecode_hash())
+        Self::new(false, true, Self::default_bytecode_hash())
     }
 }
 
@@ -26,9 +35,14 @@ impl Metadata {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(use_literal_content: bool, hash_type: era_compiler_common::HashType) -> Self {
+    pub fn new(
+        use_literal_content: bool,
+        append_cbor: bool,
+        hash_type: era_compiler_common::EVMMetadataHashType,
+    ) -> Self {
         Self {
             bytecode_hash: hash_type,
+            append_cbor,
             use_literal_content,
         }
     }
@@ -36,7 +50,14 @@ impl Metadata {
     ///
     /// The default metadata hash type.
     ///
-    fn default_bytecode_hash() -> era_compiler_common::HashType {
-        era_compiler_common::HashType::Ipfs
+    fn default_bytecode_hash() -> era_compiler_common::EVMMetadataHashType {
+        era_compiler_common::EVMMetadataHashType::IPFS
+    }
+
+    ///
+    /// The default append CBOR flag.
+    ///
+    fn default_append_cbor() -> bool {
+        true
     }
 }

--- a/solx-standard-json/src/input/settings/mod.rs
+++ b/solx-standard-json/src/input/settings/mod.rs
@@ -73,7 +73,7 @@ impl Settings {
 
         llvm_options: Vec<String>,
     ) -> Self {
-        output_selection.set_ir(via_ir);
+        output_selection.set_selector(via_ir.into());
 
         Self {
             optimizer,

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -84,12 +84,12 @@ impl Selection {
     }
 
     ///
-    /// Extends the output selection with the IR required for compilation.
+    /// Adds the specified selector to the output selection of all contracts.
     ///
-    pub fn set_ir(&mut self, via_ir: bool) {
+    pub fn set_selector(&mut self, selector: Selector) {
         for file in self.inner.values_mut() {
             for contract in file.values_mut() {
-                contract.insert(via_ir.into());
+                contract.insert(selector);
             }
         }
     }
@@ -117,18 +117,6 @@ impl Selection {
             }
         }
         false
-    }
-
-    ///
-    /// Returns flags that are going to be automatically added by the compiler,
-    /// but were not explicitly requested by the user.
-    ///
-    /// Afterwards, the flags are used to prune JSON output before returning it.
-    ///
-    pub fn to_prune(&self, via_ir: bool) -> BTreeSet<Selector> {
-        let mut selection = BTreeSet::new();
-        selection.insert(via_ir.into());
-        selection
     }
 
     ///

--- a/solx-yul/Cargo.toml
+++ b/solx-yul/Cargo.toml
@@ -10,7 +10,7 @@ description = "Yul lexer and parser for solx"
 doctest = false
 
 [dependencies]
-thiserror = "=1.0.64"
-anyhow = "=1.0.89"
+anyhow = "1.0"
+thiserror = "2.0"
 
-serde = { version = "=1.0.210", "features" = [ "derive" ] }
+serde = { version = "1.0", "features" = [ "derive" ] }

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -15,17 +15,17 @@ path = "src/solx/main.rs"
 doctest = false
 
 [dependencies]
-clap = { version = "=4.5.21", features = ["derive"] }
-thiserror = "=1.0.64"
-anyhow = "=1.0.89"
-path-slash = "=0.2.1"
-rayon = "=1.10.0"
+clap = { version = "4.5", features = ["derive"] }
+thiserror = "2.0"
+anyhow = "1.0"
+path-slash = "0.2"
+rayon = "1.10"
 
-serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
-semver = { version = "=1.0.23", features = [ "serde" ] }
-hex = "=0.4.3"
-num = "=0.4.3"
+serde = { version = "1.0", "features" = [ "derive" ] }
+serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
+semver = { version = "1.0", features = [ "serde" ] }
+hex = "0.4"
+num = "0.4"
 
 zkevm_opcode_defs = "=0.150.6"
 
@@ -37,10 +37,10 @@ solx-standard-json = { path = "../solx-standard-json" }
 solx-yul = { path = "../solx-yul" }
 
 [dev-dependencies]
-assert_cmd = "=2.0.16"
-predicates = "=3.1.2"
-tempfile = "=3.12.0"
-test-case = "=3.3.1"
+assert_cmd = "2.0"
+predicates = "3.1"
+tempfile = "3.19"
+test-case = "3.3"
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/solx/src/build/contract/mod.rs
+++ b/solx/src/build/contract/mod.rs
@@ -50,7 +50,7 @@ impl Contract {
     ///
     /// Writes the contract text assembly and bytecode to terminal.
     ///
-    pub fn write_to_terminal(self, path: String) -> anyhow::Result<()> {
+    pub fn write_to_terminal(self, path: String, output_metadata: bool) -> anyhow::Result<()> {
         writeln!(std::io::stdout(), "\n======= {path} =======")?;
 
         if self.deploy_object.is_some() || self.runtime_object.is_some() {
@@ -64,8 +64,12 @@ impl Contract {
             )?;
         }
 
-        if let Some(metadata) = self.metadata {
-            writeln!(std::io::stdout(), "Metadata:\n{}", metadata)?;
+        if output_metadata {
+            writeln!(
+                std::io::stdout(),
+                "Metadata:\n{}",
+                self.metadata.expect("Always exists")
+            )?;
         }
 
         Ok(())
@@ -74,7 +78,12 @@ impl Contract {
     ///
     /// Writes the contract text assembly and bytecode to files.
     ///
-    pub fn write_to_directory(self, output_path: &Path, overwrite: bool) -> anyhow::Result<()> {
+    pub fn write_to_directory(
+        self,
+        output_path: &Path,
+        overwrite: bool,
+        output_metadata: bool,
+    ) -> anyhow::Result<()> {
         let file_path = PathBuf::from(self.name.path);
         let file_name = file_path
             .file_name()
@@ -112,7 +121,7 @@ impl Contract {
             }
         }
 
-        if let Some(metadata) = self.metadata {
+        if output_metadata {
             let output_name = format!(
                 "{}_meta.{}",
                 self.name.name.as_deref().unwrap_or(file_name),
@@ -126,7 +135,7 @@ impl Contract {
                     "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                 );
             } else {
-                std::fs::write(output_path.as_path(), metadata)
+                std::fs::write(output_path.as_path(), self.metadata.expect("Always exists"))
                     .map_err(|error| anyhow::anyhow!("File {output_path:?} writing: {error}"))?;
             }
         }

--- a/solx/src/const.rs
+++ b/solx/src/const.rs
@@ -2,6 +2,15 @@
 //! Solidity compiler constants.
 //!
 
+/// The default executable name.
+pub static DEFAULT_EXECUTABLE_NAME: &str = "solx";
+
+/// The `solc` compiler production name.
+pub static SOLC_PRODUCTION_NAME: &str = "solc";
+
+/// The `solc` LLVM revision metadata tag.
+pub static SOLC_LLVM_REVISION_METADATA_TAG: &str = "llvm";
+
 /// The worker thread stack size.
 pub const WORKER_THREAD_STACK_SIZE: usize = 64 * 1024 * 1024;
 

--- a/solx/src/evmla/assembly/mod.rs
+++ b/solx/src/evmla/assembly/mod.rs
@@ -157,7 +157,7 @@ impl Assembly {
     ///
     pub fn keccak256(&self) -> String {
         let json: Vec<u8> = serde_json::to_vec(self).expect("Always valid");
-        era_compiler_common::Hash::keccak256(json.as_slice()).to_string()
+        era_compiler_common::Keccak256Hash::from_slice(json.as_slice()).to_string()
     }
 
     ///

--- a/solx/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
+++ b/solx/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
@@ -57,7 +57,7 @@ impl Stack {
                 _ => preimages.push(vec![0]),
             }
         }
-        era_compiler_common::Hash::keccak256_multiple(preimages.as_slice())
+        era_compiler_common::Keccak256Hash::from_slices(preimages.as_slice())
             .as_bytes()
             .try_into()
             .expect("Always valid")

--- a/solx/src/process/input.rs
+++ b/solx/src/process/input.rs
@@ -23,7 +23,7 @@ pub struct Input {
     /// Already deployed libraries.
     pub deployed_libraries: BTreeSet<String>,
     /// The metadata hash type.
-    pub metadata_hash_type: era_compiler_common::HashType,
+    pub metadata_hash_type: era_compiler_common::EVMMetadataHashType,
     /// The optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     /// The extra LLVM arguments.
@@ -41,7 +41,7 @@ impl Input {
         identifier_paths: BTreeMap<String, String>,
         output_bytecode: bool,
         deployed_libraries: BTreeSet<String>,
-        metadata_hash_type: era_compiler_common::HashType,
+        metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -63,7 +63,7 @@ impl Contract {
         identifier_paths: BTreeMap<String, String>,
         output_bytecode: bool,
         deployed_libraries: BTreeSet<String>,
-        metadata_hash_type: era_compiler_common::HashType,
+        metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -83,12 +83,9 @@ impl Contract {
         let metadata_hash = metadata
             .as_ref()
             .and_then(|metadata| match metadata_hash_type {
-                era_compiler_common::HashType::None => None,
-                era_compiler_common::HashType::Keccak256 => {
-                    Some(era_compiler_common::Hash::keccak256(metadata.as_bytes()))
-                }
-                era_compiler_common::HashType::Ipfs => {
-                    Some(era_compiler_common::Hash::ipfs(metadata.as_bytes()))
+                era_compiler_common::EVMMetadataHashType::None => None,
+                era_compiler_common::EVMMetadataHashType::IPFS => {
+                    Some(era_compiler_common::IPFSHash::from_slice(metadata.as_bytes()).into())
                 }
             });
 

--- a/solx/src/project/mod.rs
+++ b/solx/src/project/mod.rs
@@ -130,7 +130,7 @@ impl Project {
     pub fn try_from_yul_paths(
         paths: &[PathBuf],
         libraries: era_compiler_common::Libraries,
-        output_selection: solx_standard_json::InputSelection,
+        output_selection: &solx_standard_json::InputSelection,
         solc_output: Option<&mut solx_standard_json::Output>,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Self> {
@@ -156,7 +156,7 @@ impl Project {
     pub fn try_from_yul_sources(
         sources: BTreeMap<String, solx_standard_json::InputSource>,
         libraries: era_compiler_common::Libraries,
-        output_selection: solx_standard_json::InputSelection,
+        output_selection: &solx_standard_json::InputSelection,
         mut solc_output: Option<&mut solx_standard_json::Output>,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Self> {
@@ -181,7 +181,8 @@ impl Project {
                     None,
                     solx_standard_json::InputSelector::Metadata,
                 ) {
-                    let source_hash = era_compiler_common::Hash::keccak256(source_code.as_bytes());
+                    let source_hash =
+                        era_compiler_common::Keccak256Hash::from_slice(source_code.as_bytes());
                     let metadata_json = serde_json::json!({
                         "source_hash": source_hash.to_string(),
                         "solc_version": solx_solc::Compiler::default().version,
@@ -226,7 +227,7 @@ impl Project {
     pub fn try_from_llvm_ir_paths(
         paths: &[PathBuf],
         libraries: era_compiler_common::Libraries,
-        output_selection: solx_standard_json::InputSelection,
+        output_selection: &solx_standard_json::InputSelection,
         solc_output: Option<&mut solx_standard_json::Output>,
     ) -> anyhow::Result<Self> {
         let sources = paths
@@ -245,7 +246,7 @@ impl Project {
     pub fn try_from_llvm_ir_sources(
         sources: BTreeMap<String, solx_standard_json::InputSource>,
         libraries: era_compiler_common::Libraries,
-        output_selection: solx_standard_json::InputSelection,
+        output_selection: &solx_standard_json::InputSelection,
         mut solc_output: Option<&mut solx_standard_json::Output>,
     ) -> anyhow::Result<Self> {
         let results = sources
@@ -261,7 +262,8 @@ impl Project {
                     None,
                     solx_standard_json::InputSelector::Metadata,
                 ) {
-                    let source_hash = era_compiler_common::Hash::keccak256(source_code.as_bytes());
+                    let source_hash =
+                        era_compiler_common::Keccak256Hash::from_slice(source_code.as_bytes());
                     let metadata_json = serde_json::json!({
                         "source_hash": source_hash.to_string(),
                         "llvm_version": era_compiler_llvm_context::LLVM_VERSION,
@@ -307,7 +309,7 @@ impl Project {
         self,
         messages: &mut Vec<solx_standard_json::OutputError>,
         output_bytecode: bool,
-        metadata_hash_type: era_compiler_common::HashType,
+        metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,

--- a/solx/src/solx/arguments.rs
+++ b/solx/src/solx/arguments.rs
@@ -110,15 +110,19 @@ pub struct Arguments {
     pub via_ir: bool,
 
     /// Set the metadata hash type.
-    /// Available types: `none`, `keccak256`, `ipfs`.
-    /// The default is `keccak256`.
+    /// Available types: `none`, `ipfs`.
+    /// The default is `ipfs`.
     #[arg(long)]
-    pub metadata_hash: Option<era_compiler_common::HashType>,
+    pub metadata_hash: Option<era_compiler_common::EVMMetadataHashType>,
 
     /// Sets the literal content flag for contract metadata.
     /// If enabled, the metadata will contain the literal content of the source files.
     #[arg(long)]
     pub metadata_literal: bool,
+
+    /// Turn off CBOR metadata at the end of bytecode.
+    #[arg(long)]
+    pub no_cbor_metadata: bool,
 
     /// Output metadata of the compiled project.
     #[arg(long = "metadata")]

--- a/solx/tests/cli/metadata_hash.rs
+++ b/solx/tests/cli/metadata_hash.rs
@@ -2,72 +2,48 @@
 //! CLI tests for the eponymous option.
 //!
 
-use era_compiler_common::HashType;
+// use era_compiler_common::EVMMetadataHashType;
 use predicates::prelude::*;
-use test_case::test_case;
 
-#[test_case(HashType::None)]
-#[test_case(HashType::Keccak256)]
-#[test_case(HashType::Ipfs)]
-fn default(hash_type: HashType) -> anyhow::Result<()> {
-    crate::common::setup()?;
+// TODO: move metadata to linker
+// #[test]
+// fn none() -> anyhow::Result<()> {
+//     crate::common::setup()?;
 
-    let hash_type = hash_type.to_string();
-    let args = &[
-        "--metadata-hash",
-        hash_type.as_str(),
-        "--bin",
-        crate::common::TEST_SOLIDITY_CONTRACT_PATH,
-    ];
+//     let hash_type = EVMMetadataHashType::None.to_string();
+//     let args = &[
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--bin",
+//         crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+//     ];
 
-    let result = crate::cli::execute_solx(args)?;
-    result
-        .success()
-        .stdout(predicate::str::contains("Binary:\n"));
+//     let result = crate::cli::execute_solx(args)?;
+//     result.success().stdout(predicate::str::contains("a164"));
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn standard_json_none() -> anyhow::Result<()> {
-    crate::common::setup()?;
+// #[test]
+// fn ipfs() -> anyhow::Result<()> {
+//     crate::common::setup()?;
 
-    let args = &[
-        "--standard-json",
-        crate::common::TEST_SOLIDITY_STANDARD_JSON_SOLC_PATH,
-        "--metadata-hash",
-        "none",
-    ];
+//     let hash_type = EVMMetadataHashType::IPFS.to_string();
+//     let args = &[
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--bin",
+//         crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+//     ];
 
-    let result = crate::cli::execute_solx(args)?;
-    result.success().stdout(predicate::str::contains(
-        "Metadata hash mode must be specified in standard JSON input settings.",
-    ));
+//     let result = crate::cli::execute_solx(args)?;
+//     result.success().stdout(predicate::str::contains("a264"));
 
-    Ok(())
-}
+//     Ok(())
+// }
 
 #[test]
-fn standard_json_keccak256() -> anyhow::Result<()> {
-    crate::common::setup()?;
-
-    let args = &[
-        "--standard-json",
-        crate::common::TEST_SOLIDITY_STANDARD_JSON_SOLC_PATH,
-        "--metadata-hash",
-        "keccak256",
-    ];
-
-    let result = crate::cli::execute_solx(args)?;
-    result.success().stdout(predicate::str::contains(
-        "Metadata hash mode must be specified in standard JSON input settings.",
-    ));
-
-    Ok(())
-}
-
-#[test]
-fn standard_json_ipfs() -> anyhow::Result<()> {
+fn standard_json_cli_excess_arg() -> anyhow::Result<()> {
     crate::common::setup()?;
 
     let args = &[

--- a/solx/tests/cli/mod.rs
+++ b/solx/tests/cli/mod.rs
@@ -8,6 +8,7 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_cmd::cargo::CommandCargoExt;
 
 mod allow_paths;
+// mod no_cbor_metadata; TODO: move metadata to linker
 mod base_path;
 mod bin;
 mod debug_output_dir;

--- a/solx/tests/cli/no_cbor_metadata.rs
+++ b/solx/tests/cli/no_cbor_metadata.rs
@@ -1,0 +1,117 @@
+//!
+//! CLI tests for the eponymous option.
+//!
+
+use era_compiler_common::EVMMetadataHashType;
+use era_compiler_common::Target;
+use predicates::prelude::*;
+use test_case::test_case;
+
+// #[test_case(EVMMetadataHashType::None.to_string())] TODO: move metadata to linker
+// fn none(hash_type: era_compiler_common::EVMMetadataHashType) -> anyhow::Result<()> {
+//     let _ = crate::common::setup();
+
+//     let hash_type = hash_type.to_string();
+//     let args = &[
+//         crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--no-cbor-metadata",
+//         "--bin",
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("Binary"))
+//         .stdout(predicate::str::contains("a165").not())
+//         .stdout(predicate::str::ends_with("0023").not());
+
+//     Ok(())
+// }
+
+// #[test_case(EVMMetadataHashType::IPFS.to_string())] TODO: move metadata to linker
+// fn ipfs_solidity(hash_type: era_compiler_common::EVMMetadataHashType) -> anyhow::Result<()> {
+//     let _ = crate::common::setup();
+
+//     let hash_type = hash_type.to_string();
+//     let args = &[
+//         crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--no-cbor-metadata",
+//         "--bin",
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("Binary"))
+//         .stdout(predicate::str::contains("a264").not())
+//         .stdout(predicate::str::ends_with("0055").not());
+
+//     Ok(())
+// }
+
+// #[test_case(EVMMetadataHashType::IPFS.to_string())] TODO: move metadata to linker
+// fn ipfs_yul(hash_type: era_compiler_common::EVMMetadataHashType) -> anyhow::Result<()> {
+//     let _ = crate::common::setup();
+
+//     let hash_type = hash_type.to_string();
+//     let args = &[
+//         "--yul",
+//         crate::common::TEST_YUL_CONTRACT_PATH,
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--no-cbor-metadata",
+//         "--bin",
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("Binary"))
+//         .stdout(predicate::str::contains("a264").not())
+//         .stdout(predicate::str::ends_with("003e").not());
+
+//     Ok(())
+// }
+
+// #[test_case(EVMMetadataHashType::IPFS.to_string())] TODO: move metadata to linker
+// fn ipfs_llvm_ir(hash_type: era_compiler_common::EVMMetadataHashType) -> anyhow::Result<()> {
+//     let _ = crate::common::setup();
+
+//     let hash_type = hash_type.to_string();
+//     let args = &[
+//         "--llvm-ir",
+//         crate::common::TEST_LLVM_IR_CONTRACT_PATH,
+//         "--metadata-hash",
+//         hash_type.as_str(),
+//         "--no-cbor-metadata",
+//         "--bin",
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("Binary"))
+//         .stdout(predicate::str::contains("a264").not())
+//         .stdout(predicate::str::ends_with("003e").not());
+
+//     Ok(())
+// }
+
+// #[test] TODO: move metadata to linker
+// fn standard_json() -> anyhow::Result<()> {
+//     crate::common::setup()?;
+
+//     let args = &["--standard-json", crate::common::TEST_JSON_NO_CBOR_METADATA];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("a264").not())
+//         .stdout(predicate::str::ends_with("0055").not());
+
+//     Ok(())
+// }

--- a/solx/tests/cli/standard_json.rs
+++ b/solx/tests/cli/standard_json.rs
@@ -170,3 +170,76 @@ fn yul() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// TODO: move metadata to linker
+// #[test]
+// fn metadata_hash_ipfs_and_metadata() -> anyhow::Result<()> {
+//     crate::common::setup()?;
+
+//     let args = &[
+//         "--standard-json",
+//         crate::common::TEST_JSON_METADATA_HASH_IPFS_AND_METADATA,
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("a264"))
+//         .stdout(predicate::str::contains("\"metadata\""));
+
+//     Ok(())
+// }
+
+// #[test]
+// fn metadata_hash_ipfs_no_metadata() -> anyhow::Result<()> {
+//     crate::common::setup()?;
+
+//     let args = &[
+//         "--standard-json",
+//         crate::common::TEST_JSON_METADATA_HASH_IPFS_NO_METADATA,
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("a264"))
+//         .stdout(predicate::str::contains("\"metadata\"").not());
+
+//     Ok(())
+// }
+
+// #[test]
+// fn metadata_hash_none_and_metadata() -> anyhow::Result<()> {
+//     crate::common::setup()?;
+
+//     let args = &[
+//         "--standard-json",
+//         crate::common::TEST_JSON_METADATA_HASH_NONE_AND_METADATA,
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("a164"))
+//         .stdout(predicate::str::contains("\"metadata\""));
+
+//     Ok(())
+// }
+
+// #[test]
+// fn metadata_hash_none_no_metadata() -> anyhow::Result<()> {
+//     crate::common::setup()?;
+
+//     let args = &[
+//         "--standard-json",
+//         crate::common::TEST_JSON_METADATA_HASH_NONE_NO_METADATA,
+//     ];
+
+//     let result = crate::cli::execute_solx(args)?;
+//     result
+//         .success()
+//         .stdout(predicate::str::contains("a164"))
+//         .stdout(predicate::str::contains("\"metadata\"").not());
+
+//     Ok(())
+// }

--- a/solx/tests/common/const.rs
+++ b/solx/tests/common/const.rs
@@ -110,6 +110,25 @@ pub const TEST_LLVM_IR_STANDARD_JSON_MISSING_FILE_PATH: &str =
     "tests/data/standard_json_input/llvm_ir_urls_missing_file.json";
 
 /// A test input file.
+pub const TEST_JSON_METADATA_HASH_IPFS_AND_METADATA: &str =
+    "tests/data/standard_json_input/metadata_hash_ipfs_and_metadata.json";
+
+/// A test input file.
+pub const TEST_JSON_METADATA_HASH_IPFS_NO_METADATA: &str =
+    "tests/data/standard_json_input/metadata_hash_ipfs_no_metadata.json";
+
+/// A test input file.
+pub const TEST_JSON_METADATA_HASH_NONE_AND_METADATA: &str =
+    "tests/data/standard_json_input/metadata_hash_none_and_metadata.json";
+
+/// A test input file.
+pub const TEST_JSON_METADATA_HASH_NONE_NO_METADATA: &str =
+    "tests/data/standard_json_input/metadata_hash_none_no_metadata.json";
+
+/// A test input file.
+pub const TEST_JSON_NO_CBOR_METADATA: &str = "tests/data/standard_json_input/no_cbor_metadata.json";
+
+/// A test input file.
 pub const TEST_LINKER_BYTECODE_PATH: &str = "tests/data/bytecodes/linker.bin";
 
 /// A test input file.

--- a/solx/tests/data/standard_json_input/metadata_hash_ipfs_and_metadata.json
+++ b/solx/tests/data/standard_json_input/metadata_hash_ipfs_and_metadata.json
@@ -1,0 +1,32 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "sizeFallback": false
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers",
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object",
+          "metadata"
+        ]
+      }
+    },
+    "metadata": {
+      "bytecodeHash": "ipfs"
+    },
+    "libraries": {}
+  }
+}

--- a/solx/tests/data/standard_json_input/metadata_hash_ipfs_no_metadata.json
+++ b/solx/tests/data/standard_json_input/metadata_hash_ipfs_no_metadata.json
@@ -1,0 +1,31 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "sizeFallback": false
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers",
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object"
+        ]
+      }
+    },
+    "metadata": {
+      "bytecodeHash": "ipfs"
+    },
+    "libraries": {}
+  }
+}

--- a/solx/tests/data/standard_json_input/metadata_hash_none_and_metadata.json
+++ b/solx/tests/data/standard_json_input/metadata_hash_none_and_metadata.json
@@ -1,0 +1,32 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "sizeFallback": false
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers",
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object",
+          "metadata"
+        ]
+      }
+    },
+    "metadata": {
+      "bytecodeHash": "none"
+    },
+    "libraries": {}
+  }
+}

--- a/solx/tests/data/standard_json_input/metadata_hash_none_no_metadata.json
+++ b/solx/tests/data/standard_json_input/metadata_hash_none_no_metadata.json
@@ -1,0 +1,31 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "sizeFallback": false
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers",
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object"
+        ]
+      }
+    },
+    "metadata": {
+      "bytecodeHash": "none"
+    },
+    "libraries": {}
+  }
+}

--- a/solx/tests/data/standard_json_input/no_cbor_metadata.json
+++ b/solx/tests/data/standard_json_input/no_cbor_metadata.json
@@ -1,0 +1,32 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "sizeFallback": true
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers",
+          "evm.bytecode.object",
+          "evm.deployedBytecode.object"
+        ]
+      }
+    },
+    "metadata": {
+      "bytecodeHash": "ipfs",
+      "appendCBOR": false
+    },
+    "libraries": {}
+  }
+}

--- a/solx/tests/unit/ir_artifacts.rs
+++ b/solx/tests/unit/ir_artifacts.rs
@@ -13,7 +13,7 @@ fn evmla() {
     let build = crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         false,
         era_compiler_llvm_context::OptimizerSettings::cycles(),
@@ -53,7 +53,7 @@ fn yul() {
     let build = crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         true,
         era_compiler_llvm_context::OptimizerSettings::cycles(),
@@ -96,7 +96,7 @@ fn yul_empty_solidity_interface() {
     let build = crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         true,
         era_compiler_llvm_context::OptimizerSettings::cycles(),

--- a/solx/tests/unit/libraries.rs
+++ b/solx/tests/unit/libraries.rs
@@ -15,7 +15,7 @@ fn not_specified(via_ir: bool) {
     let output = crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
         era_compiler_llvm_context::OptimizerSettings::cycles(),
@@ -64,7 +64,7 @@ fn specified(via_ir: bool) {
     let output = crate::common::build_solidity_standard_json(
         sources,
         libraries,
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
         era_compiler_llvm_context::OptimizerSettings::cycles(),

--- a/solx/tests/unit/linker.rs
+++ b/solx/tests/unit/linker.rs
@@ -19,7 +19,7 @@ fn get_bytecode(
     let build = crate::common::build_solidity_standard_json(
         sources,
         libraries,
-        era_compiler_common::HashType::None,
+        era_compiler_common::EVMMetadataHashType::None,
         BTreeSet::new(),
         version,
         via_ir,
@@ -323,7 +323,7 @@ fn libraries_passed_post_compile_time_complex(
     let build = crate::common::build_solidity_standard_json(
         sources,
         solx_standard_json::InputLibraries::default(),
-        era_compiler_common::HashType::None,
+        era_compiler_common::EVMMetadataHashType::None,
         BTreeSet::new(),
         &solx_solc::Compiler::LAST_SUPPORTED_VERSION,
         via_ir,
@@ -382,7 +382,7 @@ fn libraries_not_passed_post_compile_time_complex(sources: &[&str], via_ir: bool
     let build = crate::common::build_solidity_standard_json(
         sources,
         solx_standard_json::InputLibraries::default(),
-        era_compiler_common::HashType::None,
+        era_compiler_common::EVMMetadataHashType::None,
         BTreeSet::new(),
         &solx_solc::Compiler::LAST_SUPPORTED_VERSION,
         via_ir,

--- a/solx/tests/unit/optimizer.rs
+++ b/solx/tests/unit/optimizer.rs
@@ -15,7 +15,7 @@ fn default(via_ir: bool) {
     let build_optimized_for_cycles = crate::common::build_solidity_standard_json(
         sources.clone(),
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Keccak256,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
         era_compiler_llvm_context::OptimizerSettings::cycles(),
@@ -24,7 +24,7 @@ fn default(via_ir: bool) {
     let build_optimized_for_size = crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Keccak256,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
         era_compiler_llvm_context::OptimizerSettings::size(),

--- a/solx/tests/unit/remappings.rs
+++ b/solx/tests/unit/remappings.rs
@@ -20,7 +20,7 @@ fn default(via_ir: bool) {
     crate::common::build_solidity_standard_json(
         sources,
         era_compiler_common::Libraries::default(),
-        era_compiler_common::HashType::Keccak256,
+        era_compiler_common::EVMMetadataHashType::IPFS,
         remappings,
         via_ir,
         era_compiler_llvm_context::OptimizerSettings::cycles(),


### PR DESCRIPTION
# What ❔

Supports the CBOR payload with `vyper` compiler version at the end of bytecode.

## Why ❔

It is usefull for contract verification purposes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
