### PR TITLE
fix: LLVM IR standard JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4785cde7dbc949d89cd15ebc13fb5d43bd0e2b9a"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#aa3667e7f0f9af5044b2b977fce1f33bc32901c6"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1911,9 +1911,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/solx-solc/Cargo.toml
+++ b/solx-solc/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solx-solc"
 authors.workspace = true
-license = "GPL-3.0"
 edition.workspace = true
 version.workspace = true
 description = "solc client for solx"
+license = "GPL-3.0"
 
 [lib]
 doctest = false

--- a/solx-standard-json/Cargo.toml
+++ b/solx-standard-json/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solx-standard-json"
 authors.workspace = true
-license = "MIT OR Apache-2.0"
 edition.workspace = true
 version.workspace = true
 description = "Standard JSON protocol for solx"
+license = "MIT OR Apache-2.0"
 
 [lib]
 doctest = false

--- a/solx-standard-json/src/input/mod.rs
+++ b/solx-standard-json/src/input/mod.rs
@@ -55,7 +55,7 @@ impl Input {
     }
 
     ///
-    /// A shortcut constructor from Solidity source paths.
+    /// A shortcut constructor from paths to Solidity source files.
     ///
     pub fn try_from_solidity_paths(
         paths: &[PathBuf],
@@ -126,34 +126,7 @@ impl Input {
     }
 
     ///
-    /// A shortcut constructor from source code.
-    ///
-    pub fn from_yul_sources(
-        sources: BTreeMap<String, Source>,
-        libraries: era_compiler_common::Libraries,
-        optimizer: InputSettingsOptimizer,
-        output_selection: InputSettingsSelection,
-        metadata: InputSettingsMetadata,
-        llvm_options: Vec<String>,
-    ) -> Self {
-        Self {
-            language: Language::Yul,
-            sources,
-            settings: Settings::new(
-                optimizer,
-                libraries,
-                BTreeSet::new(),
-                None,
-                false,
-                output_selection,
-                metadata,
-                llvm_options,
-            ),
-        }
-    }
-
-    ///
-    /// A shortcut constructor from source code.
+    /// A shortcut constructor from paths to Yul source files.
     ///
     pub fn from_yul_paths(
         paths: &[PathBuf],
@@ -180,6 +153,90 @@ impl Input {
             metadata,
             llvm_options,
         )
+    }
+
+    ///
+    /// A shortcut constructor from Yul source code.
+    ///
+    pub fn from_yul_sources(
+        sources: BTreeMap<String, Source>,
+        libraries: era_compiler_common::Libraries,
+        optimizer: InputSettingsOptimizer,
+        output_selection: InputSettingsSelection,
+        metadata: InputSettingsMetadata,
+        llvm_options: Vec<String>,
+    ) -> Self {
+        Self {
+            language: Language::Yul,
+            sources,
+            settings: Settings::new(
+                optimizer,
+                libraries,
+                BTreeSet::new(),
+                None,
+                false,
+                output_selection,
+                metadata,
+                llvm_options,
+            ),
+        }
+    }
+
+    ///
+    /// A shortcut constructor from paths to LLVM IR source files.
+    ///
+    pub fn from_llvm_ir_paths(
+        paths: &[PathBuf],
+        libraries: era_compiler_common::Libraries,
+        optimizer: InputSettingsOptimizer,
+        output_selection: InputSettingsSelection,
+        metadata: InputSettingsMetadata,
+        llvm_options: Vec<String>,
+    ) -> Self {
+        let sources = paths
+            .iter()
+            .map(|path| {
+                (
+                    path.to_string_lossy().to_string(),
+                    Source::from(path.as_path()),
+                )
+            })
+            .collect();
+        Self::from_yul_sources(
+            sources,
+            libraries,
+            optimizer,
+            output_selection,
+            metadata,
+            llvm_options,
+        )
+    }
+
+    ///
+    /// A shortcut constructor from LLVM IR source code.
+    ///
+    pub fn from_llvm_ir_sources(
+        sources: BTreeMap<String, Source>,
+        libraries: era_compiler_common::Libraries,
+        optimizer: InputSettingsOptimizer,
+        output_selection: InputSettingsSelection,
+        metadata: InputSettingsMetadata,
+        llvm_options: Vec<String>,
+    ) -> Self {
+        Self {
+            language: Language::LLVMIR,
+            sources,
+            settings: Settings::new(
+                optimizer,
+                libraries,
+                BTreeSet::new(),
+                None,
+                false,
+                output_selection,
+                metadata,
+                llvm_options,
+            ),
+        }
     }
 
     ///

--- a/solx-yul/Cargo.toml
+++ b/solx-yul/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solx-yul"
 authors.workspace = true
-license = "MIT OR Apache-2.0"
 edition.workspace = true
 version.workspace = true
 description = "Yul lexer and parser for solx"
+license = "MIT OR Apache-2.0"
 
 [lib]
 doctest = false

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solx"
 authors.workspace = true
-license = "GPL-3.0"
 edition.workspace = true
 version.workspace = true
-description = "LLVM-based Solidity compiler"
+description = "eXtremely optimizing SOLidity compiler"
+license = "GPL-3.0"
 links = "compiler-rt-solx"
 
 [[bin]]

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -161,51 +161,16 @@ impl Build {
                     Some(object) => object,
                     None => continue,
                 };
-                let memory_buffer = inkwell::memory_buffer::MemoryBuffer::create_from_memory_range(
-                    object.bytecode.as_slice(),
-                    object.identifier.as_str(),
-                    false,
-                );
-
-                let (linked_object, object_format) =
-                    match era_compiler_llvm_context::evm_link(memory_buffer, &linker_symbols) {
-                        Ok((linked_object, object_format)) => (linked_object, object_format),
-                        Err(error) => {
-                            self.messages
-                                .push(solx_standard_json::OutputError::new_error(
-                                    None, error, None, None,
-                                ));
-                            continue;
-                        }
-                    };
-                object.format = object_format;
-
-                object.bytecode = linked_object.as_slice().to_owned();
-                // if let era_compiler_common::CodeSegment::Deploy = object.code_segment {
-                //     let metadata = match contract.metadata_hash {
-                //         Some(era_compiler_common::Hash::IPFS(ref hash)) => {
-                //             let cbor = era_compiler_common::CBOR::new(
-                //                 Some((
-                //                     era_compiler_common::EVMMetadataHashType::IPFS,
-                //                     hash.as_bytes(),
-                //                 )),
-                //                 crate::r#const::SOLC_PRODUCTION_NAME.to_owned(),
-                //                 cbor_data.clone(),
-                //             );
-                //             cbor.to_vec()
-                //         }
-                //         Some(era_compiler_common::Hash::Keccak256(ref hash)) => hash.to_vec(),
-                //         None => {
-                //             let cbor = era_compiler_common::CBOR::<'_, String>::new(
-                //                 None,
-                //                 crate::r#const::SOLC_PRODUCTION_NAME.to_owned(),
-                //                 cbor_data.clone(),
-                //             );
-                //             cbor.to_vec()
-                //         }
-                //     };
-                //     object.bytecode.extend(metadata);
-                // }
+                match object.link(&linker_symbols) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        self.messages
+                            .push(solx_standard_json::OutputError::new_error(
+                                None, error, None, None,
+                            ));
+                        continue;
+                    }
+                }
             }
         }
 

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -150,6 +150,7 @@ impl Contract {
                     runtime_code_segment,
                     runtime_code_dependecies,
                     runtime_code_libraries,
+                    era_compiler_common::ObjectFormat::ELF,
                     runtime_code_errors,
                 );
 
@@ -186,6 +187,7 @@ impl Contract {
                     deploy_code_segment,
                     deploy_code_dependecies,
                     deploy_code_libraries,
+                    era_compiler_common::ObjectFormat::ELF,
                     deploy_code_errors,
                 );
 
@@ -246,6 +248,7 @@ impl Contract {
                     runtime_code_segment,
                     runtime_code_dependecies,
                     runtime_code_libraries,
+                    era_compiler_common::ObjectFormat::ELF,
                     runtime_code_errors,
                 );
 
@@ -280,6 +283,7 @@ impl Contract {
                     deploy_code_segment,
                     deploy_code_dependecies,
                     deploy_code_libraries,
+                    era_compiler_common::ObjectFormat::ELF,
                     deploy_code_errors,
                 );
 
@@ -321,7 +325,7 @@ impl Contract {
                     debug_config,
                 );
                 let (runtime_buffer, runtime_code_warnings) = context.build()?;
-                let runtime_object = EVMContractObject::new(
+                let mut runtime_object = EVMContractObject::new(
                     self.name.full_path.clone(),
                     self.name.clone(),
                     runtime_buffer.as_slice().to_owned(),
@@ -329,19 +333,24 @@ impl Contract {
                     runtime_code_segment,
                     runtime_code_dependencies,
                     BTreeSet::new(),
+                    era_compiler_common::ObjectFormat::ELF,
                     runtime_code_warnings,
                 );
+                runtime_object.link(&BTreeMap::new())?;
 
+                let mut deploy_bytecode = era_compiler_llvm_context::evm_minimal_deploy_code(
+                    runtime_object.bytecode.len(),
+                );
+                deploy_bytecode.extend_from_slice(runtime_object.bytecode.as_slice());
                 let deploy_object = EVMContractObject::new(
                     self.name.full_path.clone(),
                     self.name.clone(),
-                    era_compiler_llvm_context::evm_minimal_deploy_code(
-                        runtime_object.bytecode.len(),
-                    ),
+                    deploy_bytecode,
                     false,
                     deploy_code_segment,
                     deploy_code_dependencies,
                     BTreeSet::new(),
+                    era_compiler_common::ObjectFormat::Raw,
                     vec![],
                 );
 

--- a/solx/tests/cli/version.rs
+++ b/solx/tests/cli/version.rs
@@ -11,9 +11,9 @@ fn default() -> anyhow::Result<()> {
     let args = &["--version"];
 
     let result = crate::cli::execute_solx(args)?;
-    result
-        .success()
-        .stdout(predicate::str::contains("LLVM-based Solidity compiler"));
+    result.success().stdout(predicate::str::contains(
+        "eXtremely optimizing SOLidity compiler",
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
Makes a few fixes in compilation of LLVM IR through standard JSON.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
