### PR TITLE
fix: reduce Yul object identifier to their last segment

### DIFF
--- a/solx-yul/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/solx-yul/src/yul/parser/statement/expression/function_call/mod.rs
@@ -122,18 +122,18 @@ impl FunctionCall {
     ///
     pub fn accumulate_evm_dependencies(&self, dependencies: &mut Dependencies) {
         match self.name {
-            Name::CodeCopy | Name::DataCopy | Name::DataSize | Name::DataOffset => {
+            Name::DataSize | Name::DataOffset => {
                 if let Expression::Literal(Literal {
                     inner: LexicalLiteral::String(identifier),
                     ..
                 }) = self.arguments.first().expect("Always exists")
                 {
+                    let object_name = identifier.inner.split(".").last().expect("Always exists");
                     let is_runtime_code = dependencies.identifier.as_str()
-                        == identifier
-                            .inner
+                        == object_name
                             .strip_suffix("_deployed")
                             .unwrap_or(dependencies.identifier.as_str());
-                    dependencies.push(identifier.to_string(), is_runtime_code);
+                    dependencies.push(object_name.to_owned(), is_runtime_code);
                 }
                 return;
             }

--- a/solx/src/build/contract/object.rs
+++ b/solx/src/build/contract/object.rs
@@ -115,20 +115,4 @@ impl Object {
     pub fn requires_assembling(&self) -> bool {
         !self.is_assembled && !self.dependencies.inner.is_empty()
     }
-
-    ///
-    /// Checks whether the object name matches a dot-separated dependency name.
-    ///
-    /// This function is only useful for Yul codegen where object names like `A_25.A_25_deployed` are found.
-    /// For EVM assembly codegen, it performs a simple comparison.
-    ///
-    pub fn matches_dependency(&self, dependency: &str) -> bool {
-        let dependency = if self.via_ir {
-            dependency.split('.').next().expect("Always exists")
-        } else {
-            dependency
-        };
-
-        self.identifier.as_str() == dependency
-    }
 }

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -71,7 +71,9 @@ impl Build {
                             && object.dependencies.inner.iter().all(|dependency| {
                                 all_objects
                                     .iter()
-                                    .find(|object| object.matches_dependency(dependency.as_str()))
+                                    .find(|object| {
+                                        object.identifier.as_str() == dependency.as_str()
+                                    })
                                     .map(|object| !object.requires_assembling())
                                     .unwrap_or_default()
                             })
@@ -98,7 +100,7 @@ impl Build {
                         let original_dependency_identifier = dependency.to_owned();
                         let dependency = all_objects
                             .iter()
-                            .find(|object| object.matches_dependency(dependency.as_str()))
+                            .find(|object| object.identifier.as_str() == dependency.as_str())
                             .expect("Dependency not found");
                         let memory_buffer =
                             inkwell::memory_buffer::MemoryBuffer::create_from_memory_range(

--- a/solx/src/yul/parser/statement/expression/function_call.rs
+++ b/solx/src/yul/parser/statement/expression/function_call.rs
@@ -670,8 +670,8 @@ impl FunctionCall {
                 let object_name = arguments[0].original.take().ok_or_else(|| {
                     anyhow::anyhow!("{} `dataoffset` literal is missing", location)
                 })?;
-                era_compiler_llvm_context::evm_code::data_offset(context, object_name.as_str())
-                    .map(Some)
+                let object_name = object_name.split('.').last().expect("Always exists");
+                era_compiler_llvm_context::evm_code::data_offset(context, object_name).map(Some)
             }
             Name::DataSize => {
                 let mut arguments = self.pop_arguments::<1>(context)?;
@@ -679,8 +679,8 @@ impl FunctionCall {
                     .original
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("{} `datasize` literal is missing", location))?;
-                era_compiler_llvm_context::evm_code::data_size(context, object_name.as_str())
-                    .map(Some)
+                let object_name = object_name.split('.').last().expect("Always exists");
+                era_compiler_llvm_context::evm_code::data_size(context, object_name).map(Some)
             }
             Name::DataCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;


### PR DESCRIPTION
# What ❔

Removes all segments but the last one in Yul object identifiers such as `D_25.D_25_deployed`, so only `D_25_deployed` is used from now on.

## Why ❔

It creates a discrepancy between Yul object names themselves and references used in `dataoffset` and `datasize`, so the names do not match during linkage.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
