### PR TITLE
fix: do not emit unreachable in entry function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#aa3667e7f0f9af5044b2b977fce1f33bc32901c6"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-fix-unreachable#e1beccdd3d15af5a9dca455cc9ea720be4d824ab"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -29,7 +29,7 @@ num = "0.4"
 
 zkevm_opcode_defs = "=0.150.6"
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-fix-unreachable" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 solx-solc = { path = "../solx-solc" }


### PR DESCRIPTION
# What ❔

Emits proper `ret` in `entry` function instead of `unreachable`.

## Why ❔

If `STOP` is not emitted everywhere in Yul and LLVM IR, the entry function can actually return.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
