### PR TITLE
feat: add the --no-import-callback flag

### DIFF
--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -373,6 +373,20 @@ solx 'Simple.sol' --bin --metadata --metadata-literal
 
 
 
+### `--no-import-callback`
+
+Disables the default import resolution callback in **solc**.
+
+> This parameter is used by some tooling that resolves all imports by itself, such as Hardhat.
+
+Usage:
+
+```shell
+solx 'Simple.sol' --no-import-callback
+```
+
+
+
 ## Multi-Language Support
 
 **solx** supports input in multiple programming languages:

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -52,8 +52,8 @@ impl Selection {
     pub fn new_compilation(bytecode: bool, metadata: bool, via_ir: Option<bool>) -> Self {
         let mut selectors = BTreeSet::new();
         if bytecode {
-            selectors.insert(Selector::BytecodeObject);
-            selectors.insert(Selector::RuntimeBytecodeObject);
+            selectors.insert(Selector::Bytecode);
+            selectors.insert(Selector::RuntimeBytecode);
         }
         if metadata {
             selectors.insert(Selector::Metadata);

--- a/solx-standard-json/src/input/settings/selection/selector.rs
+++ b/solx-standard-json/src/input/settings/selection/selector.rs
@@ -41,11 +41,11 @@ pub enum Selector {
     Yul,
 
     /// The deploy bytecode.
-    #[serde(rename = "evm.bytecode.object")]
-    BytecodeObject,
+    #[serde(rename = "evm.bytecode", alias = "evm.bytecode.object")]
+    Bytecode,
     /// The runtime bytecode.
-    #[serde(rename = "evm.deployedBytecode.object")]
-    RuntimeBytecodeObject,
+    #[serde(rename = "evm.deployedBytecode", alias = "evm.deployedBytecode.object")]
+    RuntimeBytecode,
 
     /// The catch-all variant.
     #[serde(other)]
@@ -57,10 +57,7 @@ impl Selector {
     /// Whether the data source is `solc`.
     ///
     pub fn is_received_from_solc(&self) -> bool {
-        !matches!(
-            self,
-            Self::BytecodeObject | Self::RuntimeBytecodeObject | Self::Other
-        )
+        !matches!(self, Self::Bytecode | Self::RuntimeBytecode | Self::Other)
     }
 }
 

--- a/solx/src/lib.rs
+++ b/solx/src/lib.rs
@@ -172,6 +172,7 @@ pub fn standard_output_evm(
     base_path: Option<String>,
     include_paths: Vec<String>,
     allow_paths: Option<String>,
+    use_import_callback: bool,
     remappings: BTreeSet<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
@@ -194,6 +195,7 @@ pub fn standard_output_evm(
     let mut solc_output = solc_compiler.standard_json(
         &mut solc_input,
         messages,
+        use_import_callback,
         base_path,
         include_paths,
         allow_paths,
@@ -257,6 +259,7 @@ pub fn standard_json_evm(
     base_path: Option<String>,
     include_paths: Vec<String>,
     allow_paths: Option<String>,
+    use_import_callback: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<()> {
     let solc_compiler = solx_solc::Compiler::default();
@@ -267,11 +270,11 @@ pub fn standard_json_evm(
     let output_bytecode = solc_input
         .settings
         .output_selection
-        .is_set_for_any(solx_standard_json::InputSelector::BytecodeObject)
+        .is_set_for_any(solx_standard_json::InputSelector::Bytecode)
         || solc_input
             .settings
             .output_selection
-            .is_set_for_any(solx_standard_json::InputSelector::RuntimeBytecodeObject);
+            .is_set_for_any(solx_standard_json::InputSelector::RuntimeBytecode);
     let linker_symbols = solc_input.settings.libraries.as_linker_symbols()?;
 
     let mut optimizer_settings = era_compiler_llvm_context::OptimizerSettings::try_from_cli(
@@ -313,6 +316,7 @@ pub fn standard_json_evm(
             let mut solc_output = solc_compiler.standard_json(
                 &mut solc_input,
                 messages,
+                use_import_callback,
                 base_path,
                 include_paths,
                 allow_paths,

--- a/solx/src/solx/arguments.rs
+++ b/solx/src/solx/arguments.rs
@@ -124,6 +124,10 @@ pub struct Arguments {
     #[arg(long)]
     pub no_cbor_metadata: bool,
 
+    /// Turn off the default `solc` import resolution callback.
+    #[arg(long)]
+    pub no_import_callback: bool,
+
     /// Output metadata of the compiled project.
     #[arg(long = "metadata")]
     pub output_metadata: bool,

--- a/solx/src/solx/main.rs
+++ b/solx/src/solx/main.rs
@@ -136,6 +136,7 @@ fn main_inner(
         .metadata_hash
         .unwrap_or(era_compiler_common::EVMMetadataHashType::IPFS);
     let append_cbor = !arguments.no_cbor_metadata;
+    let use_import_callback = !arguments.no_import_callback;
 
     let build = if arguments.yul {
         solx::yul_to_evm(
@@ -172,6 +173,7 @@ fn main_inner(
             arguments.base_path,
             arguments.include_path,
             arguments.allow_paths,
+            use_import_callback,
             debug_config,
         );
     } else if arguments.output_bytecode || arguments.output_metadata {
@@ -188,6 +190,7 @@ fn main_inner(
             arguments.base_path,
             arguments.include_path,
             arguments.allow_paths,
+            use_import_callback,
             remappings,
             optimizer_settings,
             llvm_options,

--- a/solx/tests/cli/mod.rs
+++ b/solx/tests/cli/mod.rs
@@ -21,6 +21,7 @@ mod metadata;
 mod metadata_hash;
 mod metadata_literal;
 mod no_cbor_metadata;
+mod no_import_callback;
 mod optimization;
 mod optimization_size_fallback;
 mod output_dir;

--- a/solx/tests/cli/no_import_callback.rs
+++ b/solx/tests/cli/no_import_callback.rs
@@ -1,0 +1,21 @@
+//!
+//! CLI tests for the eponymous option.
+//!
+
+use predicates::prelude::*;
+
+#[test]
+fn default() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+        "--no-import-callback",
+        "--bin",
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result.success().stdout(predicate::str::contains("Binary"));
+
+    Ok(())
+}

--- a/solx/tests/common/mod.rs
+++ b/solx/tests/common/mod.rs
@@ -86,7 +86,7 @@ pub fn build_solidity_standard_json(
 
     let mut solc_output = {
         let _lock = UNIT_TEST_LOCK.lock();
-        solc_compiler.standard_json(&mut solc_input, &mut vec![], None, vec![], None)
+        solc_compiler.standard_json(&mut solc_input, &mut vec![], true, None, vec![], None)
     }?;
     solc_output.check_errors()?;
 


### PR DESCRIPTION
# What ❔

Supports the `--no-import-callback` parameter.

## Why ❔

It is passed by Hardhat, that manages import resolution by itself.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
