### PR TITLE
fix: solc solidity_compiler foreign function signature

### DIFF
--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -29,7 +29,8 @@ extern "C" {
     ///
     fn solidity_compile(
         input: *const ::libc::c_char,
-        error_pointer: *mut *mut ::libc::c_char,
+        callback: *const ::libc::c_void,
+        context: *const ::libc::c_void,
     ) -> *const std::os::raw::c_char;
 
     ///
@@ -137,7 +138,7 @@ impl Compiler {
                     error_pointer,
                 )
             } else {
-                solidity_compile(input_c_string.as_ptr(), error_pointer)
+                solidity_compile(input_c_string.as_ptr(), std::ptr::null(), std::ptr::null())
             };
             if !error_message.is_null() {
                 let error_message = CStr::from_ptr(error_message).to_string_lossy().into_owned();


### PR DESCRIPTION
# What ❔

Fixes the solc's `solidity_compiler` foreign function signature.

## Why ❔

It wasn't matching its solc counterpart.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
