### PR TITLE
feat: support LLVM-EVM assembly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 [submodule "era-solidity"]
 	path = era-solidity
 	url = https://github.com/matter-labs/era-solidity
-	branch = app-console-backup
+	branch = 0.8.29
 	update = none

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#26eff8c398d0ffe2509846a9ec1f0f346aedcf55"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-support-evm-assembly#b63b0b9c7f00b5feae9e491d369b8966c0c52f85"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -519,7 +519,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "era-compiler-common"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9bafeabc66d33694409208c51749634a86c1772a"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#59e8048671cf86341d3f330d8fa57354ad33db81"
 dependencies = [
  "anyhow",
  "base58",
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -1261,7 +1261,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1614,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1645,9 +1645,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1743,15 +1743,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1911,9 +1911,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -1938,18 +1938,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -26,7 +26,7 @@ The rest of this section describes the available CLI options and their usage. Yo
 
 ### `--bin`
 
-Enables the output of compiled bytecode. The following command compiles a Solidity file and prints the bytecode:
+Enables the output of compiled bytecode.
 
 ```bash
 solx 'Simple.sol' --bin
@@ -38,6 +38,41 @@ Output:
 ======= Simple.sol:Simple =======
 Binary:
 5b60806040525f341415601c5763...
+```
+
+
+
+### `--asm`
+
+Enables the output of text assembly produced by LLVM.
+
+```bash
+solx 'Simple.sol' --asm
+```
+
+Output:
+
+```text
+======= Simple.sol:Simple =======
+Deploy assembly:
+        .text
+        .file   "Simple.sol:Test"
+main:
+.func_begin0:
+        JUMPDEST
+        PUSH1 128
+        PUSH1 64
+...
+
+Runtime assembly:
+        .text
+        .file   "Simple.sol:Test.runtime"
+main:
+.func_begin0:
+        JUMPDEST
+        PUSH1 128
+        PUSH1 64
+...
 ```
 
 

--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -126,8 +126,12 @@ On the other hand, parameters that are not mentioned here but are parts of **sol
           "irOptimized",
           // Deploy bytecode produced by solx.
           "evm.bytecode.object",
+          // Deploy code assembly produced by solx.
+          "evm.bytecode.llvmAssembly",
           // Runtime bytecode produced by solx.
-          "evm.deployedBytecode.object"
+          "evm.deployedBytecode.object",
+          // Runtime code assembly produced by solx.
+          "evm.deployedBytecode.llvmAssembly"
         ]
       }
     },
@@ -207,26 +211,30 @@ The output JSON contains all artifacts produced by **solx** and **solc** togethe
         "evm": {
           // Required: Deploy EVM bytecode.
           "bytecode": {
-            // Required: Bytecode (string).
+            // Optional: Bytecode (string).
             "object": "0000008003000039000000400030043f0000000100200190000000130000c13d...",
-            // Required: Mapping between full contract identifiers and library identifiers that must be linked after compilation.
+            // Optional: LLVM text assembly (string).
+            "assembly": "/* ... */",
+            // Optional: Mapping between full contract identifiers and library identifiers that must be linked after compilation.
             // Only unlinked libraries are listed here.
             // Example: { "default.sol:Test": "library.sol:Library" }.
             "unlinkedLibraries": {/* ... */},
-            // Required: Binary object format.
+            // Optional: Binary object format.
             // Tells whether the bytecode has been linked.
             // Possible values: "elf" (unlinked), "raw" (linked).
             "objectFormat": "elf"
           },
           // Required: Runtime EVM bytecode.
           "deployedBytecode": {
-            // Required: Bytecode (string).
+            // Optional: Bytecode (string).
             "object": "0000008003000039000000400030043f0000000100200190000000130000c13d...",
-            // Required: Mapping between full contract identifiers and library identifiers that must be linked after compilation.
+            // Optional: LLVM text assembly (string).
+            "assembly": "/* ... */",
+            // Optional: Mapping between full contract identifiers and library identifiers that must be linked after compilation.
             // Only unlinked libraries are listed here.
             // Example: { "default.sol:Test": "library.sol:Library" }.
             "unlinkedLibraries": {/* ... */},
-            // Required: Binary object format.
+            // Optional: Binary object format.
             // Tells whether the bytecode has been linked.
             // Possible values: "elf" (unlinked), "raw" (linked).
             "objectFormat": "elf"

--- a/solx-standard-json/src/input/settings/selection/selector.rs
+++ b/solx-standard-json/src/input/settings/selection/selector.rs
@@ -43,9 +43,15 @@ pub enum Selector {
     /// The deploy bytecode.
     #[serde(rename = "evm.bytecode", alias = "evm.bytecode.object")]
     Bytecode,
+    /// The deploy LLVM assembly.
+    #[serde(rename = "evm.bytecode.llvmAssembly")]
+    DeployLLVMAssembly,
     /// The runtime bytecode.
     #[serde(rename = "evm.deployedBytecode", alias = "evm.deployedBytecode.object")]
     RuntimeBytecode,
+    /// The runtime LLVM assembly.
+    #[serde(rename = "evm.deployedBytecode.llvmAssembly")]
+    RuntimeLLVMAssembly,
 
     /// The catch-all variant.
     #[serde(other)]
@@ -57,7 +63,14 @@ impl Selector {
     /// Whether the data source is `solc`.
     ///
     pub fn is_received_from_solc(&self) -> bool {
-        !matches!(self, Self::Bytecode | Self::RuntimeBytecode | Self::Other)
+        !matches!(
+            self,
+            Self::Bytecode
+                | Self::RuntimeBytecode
+                | Self::DeployLLVMAssembly
+                | Self::RuntimeLLVMAssembly
+                | Self::Other
+        )
     }
 }
 

--- a/solx-standard-json/src/output/contract/evm/bytecode.rs
+++ b/solx-standard-json/src/output/contract/evm/bytecode.rs
@@ -11,7 +11,11 @@ use std::collections::BTreeSet;
 #[serde(rename_all = "camelCase")]
 pub struct Bytecode {
     /// Bytecode object.
-    pub object: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
+    pub object: Option<String>,
+    /// Text assembly from LLVM.
+    #[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
+    pub llvm_assembly: Option<String>,
 
     /// Unlinked deployable references.
     #[serde(
@@ -30,14 +34,23 @@ impl Bytecode {
     /// A shortcut constructor.
     ///
     pub fn new(
-        object: String,
+        object: Option<String>,
+        llvm_assembly: Option<String>,
         unlinked_references: BTreeSet<String>,
         format: era_compiler_common::ObjectFormat,
     ) -> Self {
         Self {
             object,
+            llvm_assembly,
             unlinked_references,
             format: Some(format),
         }
+    }
+
+    ///
+    /// Checks if all key fields are empty.
+    ///
+    pub fn is_empty(&self) -> bool {
+        self.object.is_none() && self.llvm_assembly.is_none()
     }
 }

--- a/solx-standard-json/src/output/contract/evm/mod.rs
+++ b/solx-standard-json/src/output/contract/evm/mod.rs
@@ -6,7 +6,6 @@ pub mod bytecode;
 pub mod extra_metadata;
 
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 
 use self::bytecode::Bytecode;
 use self::extra_metadata::ExtraMetadata;
@@ -37,35 +36,18 @@ pub struct EVM {
 
 impl EVM {
     ///
-    /// Sets the EVM and deploy and runtime bytecode.
-    ///
-    pub fn modify(
-        &mut self,
-        deploy_bytecode: String,
-        deploy_object_format: era_compiler_common::ObjectFormat,
-        deploy_unlinked_libraries: BTreeSet<String>,
-        runtime_bytecode: String,
-        runtime_object_format: era_compiler_common::ObjectFormat,
-        runtime_unlinked_libraries: BTreeSet<String>,
-    ) {
-        self.bytecode = Some(Bytecode::new(
-            deploy_bytecode,
-            deploy_unlinked_libraries,
-            deploy_object_format,
-        ));
-        self.deployed_bytecode = Some(Bytecode::new(
-            runtime_bytecode,
-            runtime_unlinked_libraries,
-            runtime_object_format,
-        ));
-    }
-
-    ///
     /// Checks if all fields are `None`.
     ///
     pub fn is_empty(&self) -> bool {
-        self.bytecode.is_none()
-            && self.deployed_bytecode.is_none()
+        self.bytecode
+            .as_ref()
+            .map(|bytecode| bytecode.is_empty())
+            .unwrap_or_default()
+            && self
+                .deployed_bytecode
+                .as_ref()
+                .map(|bytecode| bytecode.is_empty())
+                .unwrap_or_default()
             && self.legacy_assembly.is_null()
             && self.method_identifiers.is_empty()
             && self.extra_metadata.is_none()

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -29,7 +29,7 @@ num = "0.4"
 
 zkevm_opcode_defs = "=0.150.6"
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-support-evm-assembly" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 solx-solc = { path = "../solx-solc" }

--- a/solx/src/build/contract/mod.rs
+++ b/solx/src/build/contract/mod.rs
@@ -46,18 +46,47 @@ impl Contract {
     ///
     /// Writes the contract text assembly and bytecode to terminal.
     ///
-    pub fn write_to_terminal(self, path: String, output_metadata: bool) -> anyhow::Result<()> {
+    pub fn write_to_terminal(
+        mut self,
+        path: String,
+        output_bytecode: bool,
+        output_assembly: bool,
+        output_metadata: bool,
+    ) -> anyhow::Result<()> {
         writeln!(std::io::stdout(), "\n======= {path} =======")?;
 
-        if self.deploy_object.is_some() || self.runtime_object.is_some() {
-            let deploy_bytecode = self.deploy_object.map(|object| object.bytecode);
-            let runtime_bytecode = self.runtime_object.map(|object| object.bytecode);
+        if output_bytecode {
+            let deploy_bytecode = self
+                .deploy_object
+                .as_mut()
+                .and_then(|object| object.bytecode.take())
+                .expect("Always exists");
+            let runtime_bytecode = self
+                .runtime_object
+                .as_mut()
+                .and_then(|object| object.bytecode.take())
+                .expect("Always exists");
             writeln!(
                 std::io::stdout(),
                 "Binary:\n{}{}",
-                hex::encode(deploy_bytecode.unwrap_or_default()),
-                hex::encode(runtime_bytecode.unwrap_or_default()),
+                hex::encode(deploy_bytecode),
+                hex::encode(runtime_bytecode),
             )?;
+        }
+
+        if output_assembly {
+            let deploy_assembly = self
+                .deploy_object
+                .as_mut()
+                .and_then(|object| object.assembly.take())
+                .expect("Always exists");
+            let runtime_assembly = self
+                .runtime_object
+                .as_mut()
+                .and_then(|object| object.assembly.take())
+                .expect("Always exists");
+            writeln!(std::io::stdout(), "Deploy assembly:\n{deploy_assembly}")?;
+            writeln!(std::io::stdout(), "Runtime assembly:\n{runtime_assembly}")?;
         }
 
         if output_metadata {
@@ -75,9 +104,11 @@ impl Contract {
     /// Writes the contract text assembly and bytecode to files.
     ///
     pub fn write_to_directory(
-        self,
+        mut self,
         output_path: &Path,
         overwrite: bool,
+        output_bytecode: bool,
+        output_assembly: bool,
         output_metadata: bool,
     ) -> anyhow::Result<()> {
         let file_path = PathBuf::from(self.name.path);
@@ -91,7 +122,7 @@ impl Contract {
         output_path.push(file_name);
         std::fs::create_dir_all(output_path.as_path())?;
 
-        if self.deploy_object.is_some() || self.runtime_object.is_some() {
+        if output_bytecode {
             let output_name = format!(
                 "{}.{}",
                 self.name.name.as_deref().unwrap_or(file_name),
@@ -105,14 +136,53 @@ impl Contract {
                     "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                 );
             } else {
-                let deploy_bytecode = self.deploy_object.map(|object| object.bytecode);
-                let runtime_bytecode = self.runtime_object.map(|object| object.bytecode);
+                let deploy_bytecode = self
+                    .deploy_object
+                    .as_mut()
+                    .and_then(|object| object.bytecode.take())
+                    .expect("Always exists");
+                let runtime_bytecode = self
+                    .runtime_object
+                    .as_mut()
+                    .and_then(|object| object.bytecode.take())
+                    .expect("Always exists");
                 let bytecode = format!(
                     "{}{}",
-                    hex::encode(deploy_bytecode.unwrap_or_default()),
-                    hex::encode(runtime_bytecode.unwrap_or_default()),
+                    hex::encode(deploy_bytecode),
+                    hex::encode(runtime_bytecode),
                 );
                 std::fs::write(output_path.as_path(), bytecode)
+                    .map_err(|error| anyhow::anyhow!("File {output_path:?} writing: {error}"))?;
+            }
+        }
+
+        if output_assembly {
+            let output_name = format!(
+                "{}.{}",
+                self.name.name.as_deref().unwrap_or(file_name),
+                era_compiler_common::EXTENSION_ERAVM_ASSEMBLY,
+            );
+            let mut output_path = output_path.clone();
+            output_path.push(output_name.as_str());
+
+            if output_path.exists() && !overwrite {
+                anyhow::bail!(
+                    "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
+                );
+            } else {
+                let mut assembly = self
+                    .deploy_object
+                    .as_mut()
+                    .and_then(|object| object.assembly.take())
+                    .expect("Always exists");
+                assembly.push('\n');
+                assembly.push_str(
+                    self.runtime_object
+                        .as_ref()
+                        .and_then(|object| object.assembly.as_deref())
+                        .expect("Always exists"),
+                );
+                std::fs::write(output_path.as_path(), assembly)
                     .map_err(|error| anyhow::anyhow!("File {output_path:?} writing: {error}"))?;
             }
         }
@@ -153,14 +223,16 @@ impl Contract {
             .get_or_insert_with(solx_standard_json::OutputContractEVM::default);
         evm.bytecode = self.deploy_object.map(|object| {
             solx_standard_json::OutputContractEVMBytecode::new(
-                hex::encode(object.bytecode),
+                object.bytecode.map(hex::encode),
+                object.assembly,
                 object.unlinked_libraries,
                 object.format,
             )
         });
         evm.deployed_bytecode = self.runtime_object.map(|object| {
             solx_standard_json::OutputContractEVMBytecode::new(
-                hex::encode(object.bytecode),
+                object.bytecode.map(hex::encode),
+                object.assembly,
                 object.unlinked_libraries,
                 object.format,
             )

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -64,6 +64,7 @@ impl Build {
                     })
                     .flatten()
                     .collect::<Vec<&ContractObject>>();
+
                 let assembleable_objects = all_objects
                     .iter()
                     .filter(|object| {
@@ -116,7 +117,7 @@ impl Build {
                     era_compiler_common::CodeSegment::Runtime => &mut contract.runtime_object,
                 };
                 if let Some(object) = object {
-                    object.bytecode = assembled_object.as_slice().to_owned();
+                    object.bytecode = Some(assembled_object.as_slice().to_owned());
                     object.is_assembled = true;
                 }
             }
@@ -150,14 +151,22 @@ impl Build {
     ///
     /// Writes all contracts to the terminal.
     ///
-    pub fn write_to_terminal(mut self, output_metadata: bool) -> anyhow::Result<()> {
+    pub fn write_to_terminal(
+        mut self,
+        output_bytecode: bool,
+        output_assembly: bool,
+        output_metadata: bool,
+    ) -> anyhow::Result<()> {
         self.take_and_write_warnings();
         self.exit_on_error();
 
         for (path, build) in self.results.into_iter() {
-            build
-                .expect("Always valid")
-                .write_to_terminal(path, output_metadata)?;
+            build.expect("Always valid").write_to_terminal(
+                path,
+                output_bytecode,
+                output_assembly,
+                output_metadata,
+            )?;
         }
 
         Ok(())
@@ -170,6 +179,8 @@ impl Build {
         mut self,
         output_directory: &Path,
         overwrite: bool,
+        output_bytecode: bool,
+        output_assembly: bool,
         output_metadata: bool,
     ) -> anyhow::Result<()> {
         self.take_and_write_warnings();
@@ -181,6 +192,8 @@ impl Build {
             build.expect("Always valid").write_to_directory(
                 output_directory,
                 overwrite,
+                output_bytecode,
+                output_assembly,
                 output_metadata,
             )?;
         }

--- a/solx/src/process/input.rs
+++ b/solx/src/process/input.rs
@@ -18,7 +18,9 @@ pub struct Input {
     pub contract: Contract,
     /// The mapping of auxiliary identifiers, e.g. Yul object names, to full contract paths.
     pub identifier_paths: BTreeMap<String, String>,
-    /// Whether to output the bytecode, or only the metadata.
+    /// Whether to output assembly.
+    pub output_assembly: bool,
+    /// Whether to output bytecode.
     pub output_bytecode: bool,
     /// Already deployed libraries.
     pub deployed_libraries: BTreeSet<String>,
@@ -39,6 +41,7 @@ impl Input {
     pub fn new(
         contract: Contract,
         identifier_paths: BTreeMap<String, String>,
+        output_assembly: bool,
         output_bytecode: bool,
         deployed_libraries: BTreeSet<String>,
         metadata_hash_type: era_compiler_common::EVMMetadataHashType,
@@ -49,6 +52,7 @@ impl Input {
         Self {
             contract,
             identifier_paths,
+            output_assembly,
             output_bytecode,
             deployed_libraries,
             metadata_hash_type,

--- a/solx/src/process/mod.rs
+++ b/solx/src/process/mod.rs
@@ -36,6 +36,7 @@ pub fn run() -> anyhow::Result<()> {
                 .contract
                 .compile_to_evm(
                     input.identifier_paths,
+                    input.output_assembly,
                     input.output_bytecode,
                     input.deployed_libraries,
                     input.metadata_hash_type,

--- a/solx/src/project/mod.rs
+++ b/solx/src/project/mod.rs
@@ -308,6 +308,7 @@ impl Project {
     pub fn compile_to_evm(
         self,
         messages: &mut Vec<solx_standard_json::OutputError>,
+        output_assembly: bool,
         output_bytecode: bool,
         metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
@@ -322,6 +323,7 @@ impl Project {
                 let input = EVMProcessInput::new(
                     contract,
                     self.identifier_paths.clone(),
+                    output_assembly,
                     output_bytecode,
                     deployed_libraries.clone(),
                     metadata_hash_type,

--- a/solx/src/solx/arguments.rs
+++ b/solx/src/solx/arguments.rs
@@ -132,6 +132,10 @@ pub struct Arguments {
     #[arg(long = "metadata")]
     pub output_metadata: bool,
 
+    /// Output assembly of the compiled contracts.
+    #[arg(long = "asm")]
+    pub output_assembly: bool,
+
     /// Output bytecode of the compiled contracts.
     #[arg(long = "bin")]
     pub output_bytecode: bool,
@@ -257,7 +261,7 @@ impl Arguments {
         }
 
         if self.standard_json.is_some() {
-            if self.output_metadata || self.output_bytecode {
+            if self.output_metadata || self.output_assembly || self.output_bytecode {
                 messages.push(solx_standard_json::OutputError::new_error(
                     None,
                     "Cannot output data outside of JSON in standard JSON mode.",

--- a/solx/src/solx/main.rs
+++ b/solx/src/solx/main.rs
@@ -143,6 +143,7 @@ fn main_inner(
             input_files.as_slice(),
             arguments.libraries.as_slice(),
             arguments.output_bytecode,
+            arguments.output_assembly,
             arguments.output_metadata,
             messages,
             metadata_hash_type,
@@ -156,6 +157,7 @@ fn main_inner(
             input_files.as_slice(),
             arguments.libraries.as_slice(),
             arguments.output_bytecode,
+            arguments.output_assembly,
             arguments.output_metadata,
             messages,
             metadata_hash_type,
@@ -176,11 +178,12 @@ fn main_inner(
             use_import_callback,
             debug_config,
         );
-    } else if arguments.output_bytecode || arguments.output_metadata {
+    } else if arguments.output_bytecode || arguments.output_assembly || arguments.output_metadata {
         solx::standard_output_evm(
             input_files.as_slice(),
             arguments.libraries.as_slice(),
             arguments.output_bytecode,
+            arguments.output_assembly,
             messages,
             arguments.evm_version,
             arguments.via_ir,
@@ -208,10 +211,16 @@ fn main_inner(
         build.write_to_directory(
             &output_directory,
             arguments.overwrite,
+            arguments.output_bytecode,
+            arguments.output_assembly,
             arguments.output_metadata,
         )?;
     } else {
-        build.write_to_terminal(arguments.output_metadata)?;
+        build.write_to_terminal(
+            arguments.output_bytecode,
+            arguments.output_assembly,
+            arguments.output_metadata,
+        )?;
     }
 
     Ok(())

--- a/solx/tests/cli/asm.rs
+++ b/solx/tests/cli/asm.rs
@@ -1,0 +1,38 @@
+//!
+//! CLI tests for the eponymous option.
+//!
+
+use predicates::prelude::*;
+
+#[test]
+fn invalid_input() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[crate::common::TEST_YUL_CONTRACT_PATH, "--asm"];
+
+    let result = crate::cli::execute_solx(args)?;
+
+    result.failure().stderr(predicate::str::contains(
+        "Expected identifier but got 'StringLiteral'",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn standard_json() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::TEST_SOLIDITY_STANDARD_JSON_SOLC_PATH,
+        "--asm",
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result.success().stdout(predicate::str::contains(
+        "Cannot output data outside of JSON in standard JSON mode.",
+    ));
+
+    Ok(())
+}

--- a/solx/tests/common/mod.rs
+++ b/solx/tests/common/mod.rs
@@ -98,6 +98,7 @@ pub fn build_solidity_standard_json(
     let build = project.compile_to_evm(
         &mut vec![],
         true,
+        true,
         metadata_hash_type,
         optimizer_settings,
         vec![],
@@ -159,6 +160,7 @@ pub fn build_yul_standard_json(
     let build = project.compile_to_evm(
         &mut vec![],
         true,
+        true,
         era_compiler_common::EVMMetadataHashType::IPFS,
         optimizer_settings,
         vec![],
@@ -210,6 +212,7 @@ pub fn build_llvm_ir_standard_json(
     )?;
     let build = project.compile_to_evm(
         &mut vec![],
+        true,
         true,
         era_compiler_common::EVMMetadataHashType::IPFS,
         optimizer_settings,

--- a/solx/tests/unit/optimizer.rs
+++ b/solx/tests/unit/optimizer.rs
@@ -40,7 +40,7 @@ fn default(via_ir: bool) {
         .evm
         .as_ref()
         .expect("Missing EVM data")
-        .bytecode
+        .deployed_bytecode
         .as_ref()
         .expect("Missing bytecode")
         .object
@@ -56,7 +56,7 @@ fn default(via_ir: bool) {
         .evm
         .as_ref()
         .expect("Missing EVM data")
-        .bytecode
+        .deployed_bytecode
         .as_ref()
         .expect("Missing bytecode")
         .object

--- a/solx/tests/unit/optimizer.rs
+++ b/solx/tests/unit/optimizer.rs
@@ -44,6 +44,8 @@ fn default(via_ir: bool) {
         .as_ref()
         .expect("Missing bytecode")
         .object
+        .as_ref()
+        .expect("Missing bytecode object")
         .as_bytes();
     let optimized_for_size = build_optimized_for_size
         .contracts
@@ -58,6 +60,8 @@ fn default(via_ir: bool) {
         .as_ref()
         .expect("Missing bytecode")
         .object
+        .as_ref()
+        .expect("Missing bytecode object")
         .as_bytes();
 
     assert!(

--- a/solx/tests/unit/standard_json.rs
+++ b/solx/tests/unit/standard_json.rs
@@ -25,6 +25,8 @@ fn standard_json_yul_solc() {
         .as_ref()
         .expect("The `bytecode` field is missing")
         .object
+        .as_ref()
+        .expect("The `object` field is missing")
         .is_empty())
 }
 
@@ -50,6 +52,8 @@ fn standard_json_yul_solc_validated() {
         .as_ref()
         .expect("The `bytecode` field is missing")
         .object
+        .as_ref()
+        .expect("The `object` field is missing")
         .is_empty())
 }
 
@@ -74,6 +78,8 @@ fn standard_json_yul_solc_urls() {
         .as_ref()
         .expect("The `bytecode` field is missing")
         .object
+        .as_ref()
+        .expect("The `object` field is missing")
         .is_empty())
 }
 
@@ -99,6 +105,8 @@ fn standard_json_yul_solc_urls_validated() {
         .as_ref()
         .expect("The `bytecode` field is missing")
         .object
+        .as_ref()
+        .expect("The `object` field is missing")
         .is_empty())
 }
 
@@ -123,5 +131,7 @@ fn standard_json_llvm_ir_urls() {
         .as_ref()
         .expect("The `bytecode` field is missing")
         .object
+        .as_ref()
+        .expect("The `object` field is missing")
         .is_empty())
 }


### PR DESCRIPTION
# What ❔

Optionally etrieves EVM assembly from LLVM.

## Why ❔

It is required for the integration with Compiler Explorer.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
