### PR TITLE
chore: set the LLVM branch back to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/matter-labs/era-compiler-llvm
-	branch = dborisenkov-llvm19
+	branch = main
 	update = none
 [submodule "era-solidity"]
 	path = era-solidity


### PR DESCRIPTION
Sets the LLVM branch back to main after the LLVM update.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
