### PR TITLE
docs: update README.md to remove dead links in installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,6 @@ Our mid-term goals:
 ## Installation
 
 You can download the existing pre-releases from the [Releases](https://github.com/matter-labs/solx/releases) GitHub page.
-Or, you can take a build used in our [solx_demo](https://github.com/popzxc/solx_demo):
-
-- [MacOS](https://github.com/matter-labs/solx/releases/download/d5a98e5/solx-macosx)
-- [Linux/AMD64](https://github.com/matter-labs/solx/releases/download/d5a98e5/solx-linux-amd64-gnu)
-- [Linux/Arm64](https://github.com/matter-labs/solx/releases/download/d5a98e5/solx-linux-arm64-gnu)
 
 ## Usage
 


### PR DESCRIPTION
# What and Why ❔

We have broken links to some old builds as part of our installation instructions, but they point to the Releases page anyway. 

I suggest just removing the links to the Builds related to the solx_demo.

## Checklist

- [x] PR title corresponds to the body of PR.
- [N/A] Tests for the changes have been added / updated.
- [N/A] Documentation comments have been added / updated.
- [N/A] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
