### PR TITLE
fix: Yul object naming assumptions and keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ name = "solx-yul"
 version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
+ "era-compiler-common",
  "serde",
  "thiserror 2.0.12",
 ]

--- a/solx-yul/Cargo.toml
+++ b/solx-yul/Cargo.toml
@@ -14,3 +14,5 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 serde = { version = "1.0", "features" = [ "derive" ] }
+
+era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }

--- a/solx-yul/src/yul/lexer/token/lexeme/keyword.rs
+++ b/solx-yul/src/yul/lexer/token/lexeme/keyword.rs
@@ -13,10 +13,6 @@ use crate::yul::lexer::token::Token;
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Keyword {
-    /// The `object` keyword.
-    Object,
-    /// The `code` keyword.
-    Code,
     /// The `function` keyword.
     Function,
     /// The `let` keyword.
@@ -91,8 +87,6 @@ impl Keyword {
         }
 
         Some(match input {
-            "object" => Self::Object,
-            "code" => Self::Code,
             "function" => Self::Function,
             "let" => Self::Let,
             "if" => Self::If,
@@ -136,8 +130,6 @@ impl Keyword {
 impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Object => write!(f, "object"),
-            Self::Code => write!(f, "code"),
             Self::Function => write!(f, "function"),
             Self::Let => write!(f, "let"),
             Self::If => write!(f, "if"),

--- a/solx-yul/src/yul/parser/error.rs
+++ b/solx-yul/src/yul/parser/error.rs
@@ -41,18 +41,6 @@ pub enum Error {
         /// The actual number of arguments.
         found: usize,
     },
-    /// Invalid object name.
-    #[error(
-        "{location} Objects must be named as '<name>' (deploy) and '<name>_deployed' (runtime)"
-    )]
-    InvalidObjectName {
-        /// The invalid token location.
-        location: Location,
-        /// The expected identifier.
-        expected: String,
-        /// The invalid identifier.
-        found: String,
-    },
     /// Invalid attributes.
     #[error("{location} Found invalid LLVM attributes: {values:?}")]
     InvalidAttributes {

--- a/solx-yul/src/yul/parser/statement/block.rs
+++ b/solx-yul/src/yul/parser/statement/block.rs
@@ -181,7 +181,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {
@@ -214,7 +218,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {

--- a/solx-yul/src/yul/parser/statement/code.rs
+++ b/solx-yul/src/yul/parser/statement/code.rs
@@ -6,7 +6,6 @@ use std::collections::BTreeSet;
 
 use crate::dependencies::Dependencies;
 use crate::yul::error::Error;
-use crate::yul::lexer::token::lexeme::keyword::Keyword;
 use crate::yul::lexer::token::lexeme::Lexeme;
 use crate::yul::lexer::token::location::Location;
 use crate::yul::lexer::token::Token;
@@ -42,10 +41,10 @@ where
 
         let location = match token {
             Token {
-                lexeme: Lexeme::Keyword(Keyword::Code),
+                lexeme: Lexeme::Identifier(identifier),
                 location,
                 ..
-            } => location,
+            } if identifier.inner.as_str() == "code" => location,
             token => {
                 return Err(ParserError::InvalidToken {
                     location: token.location,
@@ -104,7 +103,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {

--- a/solx-yul/src/yul/parser/statement/function_definition.rs
+++ b/solx-yul/src/yul/parser/statement/function_definition.rs
@@ -203,7 +203,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {
@@ -239,7 +243,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {
@@ -275,7 +283,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {
@@ -311,7 +323,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {
@@ -347,7 +363,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::ReservedIdentifier {

--- a/solx-yul/src/yul/parser/statement/mod.rs
+++ b/solx-yul/src/yul/parser/statement/mod.rs
@@ -88,14 +88,23 @@ where
         let token = crate::yul::parser::take_or_next(initial, lexer)?;
 
         match token {
-            token @ Token {
-                lexeme: Lexeme::Keyword(Keyword::Object),
+            ref token @ Token {
+                lexeme: Lexeme::Identifier(ref identifier),
                 ..
-            } => Ok((Statement::Object(Object::parse(lexer, Some(token))?), None)),
+            } if identifier.inner.as_str() == "object" => Ok((
+                Statement::Object(Object::parse(
+                    lexer,
+                    Some(token.to_owned()),
+                    era_compiler_common::CodeSegment::Deploy,
+                )?),
+                None,
+            )),
             Token {
-                lexeme: Lexeme::Keyword(Keyword::Code),
+                lexeme: Lexeme::Identifier(identifier),
                 ..
-            } => Ok((Statement::Code(Code::parse(lexer, None)?), None)),
+            } if identifier.inner.as_str() == "code" => {
+                Ok((Statement::Code(Code::parse(lexer, None)?), None))
+            }
             Token {
                 lexeme: Lexeme::Keyword(Keyword::Function),
                 ..

--- a/solx-yul/src/yul/parser/statement/switch/case.rs
+++ b/solx-yul/src/yul/parser/statement/switch/case.rs
@@ -113,7 +113,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {

--- a/solx-yul/src/yul/parser/statement/switch/mod.rs
+++ b/solx-yul/src/yul/parser/statement/switch/mod.rs
@@ -177,7 +177,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::InvalidToken {

--- a/solx-yul/src/yul/parser/statement/variable_declaration.rs
+++ b/solx-yul/src/yul/parser/statement/variable_declaration.rs
@@ -113,6 +113,36 @@ mod tests {
     use crate::yul::parser::statement::object::Object;
 
     #[test]
+    fn unreserved_keyword() {
+        let input = r#"
+object "Test" {
+    code {
+        {
+            return(0, 0)
+        }
+    }
+    object "Test_deployed" {
+        code {
+            {
+                let object := 42
+                let code := 84
+                return(0, 0)
+            }
+        }
+    }
+}
+    "#;
+
+        let mut lexer = Lexer::new(input.to_owned());
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn error_reserved_identifier() {
         let input = r#"
 object "Test" {
@@ -133,7 +163,11 @@ object "Test" {
     "#;
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<DefaultDialect>::parse(&mut lexer, None);
+        let result = Object::<DefaultDialect>::parse(
+            &mut lexer,
+            None,
+            era_compiler_common::CodeSegment::Deploy,
+        );
         assert_eq!(
             result,
             Err(Error::ReservedIdentifier {

--- a/solx/src/project/contract/ir/yul.rs
+++ b/solx/src/project/contract/ir/yul.rs
@@ -37,7 +37,7 @@ impl Yul {
         }
 
         let mut lexer = Lexer::new(source_code.to_owned());
-        let object = Object::parse(&mut lexer, None)
+        let object = Object::parse(&mut lexer, None, era_compiler_common::CodeSegment::Deploy)
             .map_err(|error| anyhow::anyhow!("Yul parsing: {error:?}"))?;
 
         Ok(Some(Self {

--- a/solx/src/yul/parser/statement/function_definition.rs
+++ b/solx/src/yul/parser/statement/function_definition.rs
@@ -178,7 +178,8 @@ object "Test" {
         invalid_attributes.insert("UnknownAttribute".to_owned());
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<EraDialect>::parse(&mut lexer, None);
+        let result =
+            Object::<EraDialect>::parse(&mut lexer, None, era_compiler_common::CodeSegment::Deploy);
         assert_eq!(
             result,
             Err(Error::InvalidAttributes {
@@ -216,7 +217,8 @@ object "Test" {
         invalid_attributes.insert("UnknownAttribute2".to_owned());
 
         let mut lexer = Lexer::new(input.to_owned());
-        let result = Object::<EraDialect>::parse(&mut lexer, None);
+        let result =
+            Object::<EraDialect>::parse(&mut lexer, None, era_compiler_common::CodeSegment::Deploy);
         assert_eq!(
             result,
             Err(Error::InvalidAttributes {

--- a/solx/tests/cli/yul.rs
+++ b/solx/tests/cli/yul.rs
@@ -17,6 +17,22 @@ fn default() -> anyhow::Result<()> {
 }
 
 #[test]
+fn object_naming() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        crate::common::TEST_YUL_CONTRACT_OBJECT_NAMING_PATH,
+        "--yul",
+        "--bin",
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result.success().stdout(predicate::str::contains("Binary"));
+
+    Ok(())
+}
+
+#[test]
 fn solc() -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/solx/tests/common/const.rs
+++ b/solx/tests/common/const.rs
@@ -49,6 +49,9 @@ pub const SOLIDITY_BIN_OUTPUT_NAME: &str = "Test.bin";
 pub const TEST_YUL_CONTRACT_PATH: &str = "tests/data/contracts/yul/Test.yul";
 
 /// A test input file.
+pub const TEST_YUL_CONTRACT_OBJECT_NAMING_PATH: &str = "tests/data/contracts/yul/ObjectNaming.yul";
+
+/// A test input file.
 pub const TEST_LLVM_IR_CONTRACT_PATH: &str = "tests/data/contracts/llvm_ir/Test.ll";
 
 /// A test input file.

--- a/solx/tests/data/contracts/yul/ObjectNaming.yul
+++ b/solx/tests/data/contracts/yul/ObjectNaming.yul
@@ -1,0 +1,16 @@
+object "Deploy" {
+    code {
+        {
+            return(0, 0)
+        }
+    }
+
+    object "Runtime" {
+        code {
+            {
+                mstore(0, 42)
+                return(0, 32)
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Removes the requirement for Yul objects to be naming strictly as pairs with a `_deployed` suffix (e.g. `Contract`/`Contract_deployed`). Now runtime code is detected solely by its position in solc Yul output.
2. Removes `object` and `code` from reserved keywords similarly to how `data` has been handled. Now all 3 are treated as identifiers according to the Yul spec.

Resolves https://github.com/matter-labs/solx/issues/61

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
