### PR TITLE
fix: turn off size fallback by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#bbf2fa512b3cbfaa0268943142fd6c6a57896228"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5ab2d4b9852f72a55c54186a84a03a247c57446c"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -70,8 +70,8 @@ On the other hand, parameters that are not mentioned here but are parts of **sol
       "mode": "3",
       // Optional, solx-only: Re-run the compilation with "mode": "z" if the initial compilation exceeds the EVM bytecode size limit.
       // Used on a per-contract basis and applied automatically, so some contracts will end up compiled in the initial mode, and others with "mode": "z".
-      // Default: true.
-      "sizeFallback": true
+      // Default: false.
+      "sizeFallback": false
     },
 
     // Optional: Sorted list of remappings.

--- a/solx-standard-json/src/input/settings/optimizer.rs
+++ b/solx-standard-json/src/input/settings/optimizer.rs
@@ -60,7 +60,7 @@ impl Optimizer {
     /// The default flag to enable the size fallback.
     ///
     pub fn default_size_fallback() -> Option<bool> {
-        Some(true)
+        Some(false)
     }
 
     ///

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -174,6 +174,7 @@ impl Contract {
                         solx_standard_json::InputSelector::RuntimeBytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let runtime_object = EVMContractObject::new(
                     runtime_code_identifier,
@@ -218,6 +219,7 @@ impl Contract {
                         solx_standard_json::InputSelector::BytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let deploy_object = EVMContractObject::new(
                     deploy_code_identifier,
@@ -280,6 +282,7 @@ impl Contract {
                         solx_standard_json::InputSelector::RuntimeBytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let runtime_object = EVMContractObject::new(
                     runtime_code_identifier,
@@ -322,6 +325,7 @@ impl Contract {
                         solx_standard_json::InputSelector::BytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let deploy_object = EVMContractObject::new(
                     deploy_code_identifier,
@@ -395,6 +399,7 @@ impl Contract {
                         solx_standard_json::InputSelector::RuntimeBytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let runtime_object = EVMContractObject::new(
                     runtime_code_identifier,
@@ -427,6 +432,7 @@ impl Contract {
                         solx_standard_json::InputSelector::BytecodeLLVMAssembly,
                     ),
                     output_bytecode,
+                    false,
                 )?;
                 let deploy_object = EVMContractObject::new(
                     deploy_code_identifier,


### PR DESCRIPTION
`-Oz` mode is not ready yet, and sometimes leads to issues such as OOMs and infinite loops.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
