### PR TITLE
feat: do not copy Yul into the lexer

### DIFF
--- a/solx-yul/src/yul/lexer/mod.rs
+++ b/solx-yul/src/yul/lexer/mod.rs
@@ -21,9 +21,9 @@ use self::token::Token;
 ///
 /// The compiler lexer.
 ///
-pub struct Lexer {
+pub struct Lexer<'a> {
     /// The input source code.
-    input: String,
+    input: &'a str,
     /// The number of characters processed so far.
     offset: usize,
     /// The current location.
@@ -32,13 +32,11 @@ pub struct Lexer {
     peeked: Option<Token>,
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(mut input: String) -> Self {
-        input.push('\n');
-
+    pub fn new(input: &'a str) -> Self {
         Self {
             input,
             offset: 0,

--- a/solx-yul/src/yul/lexer/tests.rs
+++ b/solx-yul/src/yul/lexer/tests.rs
@@ -72,7 +72,7 @@ object "Test" {
 }
     "#;
 
-    let mut lexer = Lexer::new(input.to_owned());
+    let mut lexer = Lexer::new(input);
     loop {
         match lexer.next() {
             Ok(token) => assert_ne!(token.lexeme, Lexeme::EndOfFile),

--- a/solx-yul/src/yul/lexer/token/lexeme/symbol.rs
+++ b/solx-yul/src/yul/lexer/token/lexeme/symbol.rs
@@ -34,11 +34,11 @@ impl Symbol {
     /// Parses the symbol, returning it as a token.
     ///
     pub fn parse(input: &str) -> Option<Token> {
-        let (symbol, length) = match &input[..2] {
+        let (symbol, length) = match &input[..std::cmp::min(input.len(), 2)] {
             ":=" => (Self::Assignment, 2),
             "->" => (Self::Arrow, 2),
 
-            _ => match &input[..1] {
+            _ => match &input[..std::cmp::min(input.len(), 1)] {
                 "{" => (Self::BracketCurlyLeft, 1),
                 "}" => (Self::BracketCurlyRight, 1),
                 "(" => (Self::ParenthesisLeft, 1),

--- a/solx-yul/src/yul/parser/statement/block.rs
+++ b/solx-yul/src/yul/parser/statement/block.rs
@@ -180,7 +180,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -217,7 +217,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/code.rs
+++ b/solx-yul/src/yul/parser/statement/code.rs
@@ -102,7 +102,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/function_definition.rs
+++ b/solx-yul/src/yul/parser/statement/function_definition.rs
@@ -202,7 +202,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -242,7 +242,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -282,7 +282,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -322,7 +322,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -362,7 +362,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/object.rs
+++ b/solx-yul/src/yul/parser/statement/object.rs
@@ -233,7 +233,7 @@ object "Init" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -261,7 +261,7 @@ class "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -297,7 +297,7 @@ object 256 {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -333,7 +333,7 @@ object "Test" (
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -369,7 +369,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/switch/case.rs
+++ b/solx-yul/src/yul/parser/statement/switch/case.rs
@@ -112,7 +112,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/switch/mod.rs
+++ b/solx-yul/src/yul/parser/statement/switch/mod.rs
@@ -176,7 +176,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/src/yul/parser/statement/variable_declaration.rs
+++ b/solx-yul/src/yul/parser/statement/variable_declaration.rs
@@ -133,7 +133,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,
@@ -162,7 +162,7 @@ object "Test" {
 }
     "#;
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result = Object::<DefaultDialect>::parse(
             &mut lexer,
             None,

--- a/solx-yul/tests/printer.rs
+++ b/solx-yul/tests/printer.rs
@@ -12,8 +12,8 @@ use solx_yul::yul::parser::statement::Statement;
 use solx_yul::yul::visitor::Visitor;
 
 fn print_expression(input: &str) -> String {
-    let mut lexer = Lexer::new(input.to_string());
-    let expression = Expression::parse(&mut lexer, None).unwrap();
+    let mut lexer = Lexer::new(input);
+    let expression = Expression::parse(&mut lexer, None).expect("Always valid");
     let mut result = String::new();
     let mut writer = WritePrinter::<&mut String>::new(&mut result);
     Visitor::<DefaultDialect>::visit_expression(&mut writer, &expression);
@@ -21,7 +21,7 @@ fn print_expression(input: &str) -> String {
 }
 
 fn print_statement(input: &str) -> String {
-    let mut lexer = Lexer::new(input.to_string());
+    let mut lexer = Lexer::new(input);
     let statement = Statement::<DefaultDialect>::parse(&mut lexer, None)
         .unwrap()
         .0;

--- a/solx/src/project/contract/ir/yul.rs
+++ b/solx/src/project/contract/ir/yul.rs
@@ -25,7 +25,7 @@ impl Yul {
     ///
     pub fn try_from_source(
         path: &str,
-        source_code: String,
+        source_code: &str,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Option<Self>> {
         if source_code.is_empty() {
@@ -33,7 +33,7 @@ impl Yul {
         };
 
         if let Some(debug_config) = debug_config {
-            debug_config.dump_yul(path, source_code.as_str())?;
+            debug_config.dump_yul(path, source_code)?;
         }
 
         let mut lexer = Lexer::new(source_code);

--- a/solx/src/project/mod.rs
+++ b/solx/src/project/mod.rs
@@ -143,7 +143,7 @@ impl Project {
                 let result = if via_ir {
                     ContractYul::try_from_source(
                         name.full_path.as_str(),
-                        contract.ir_optimized.clone()?,
+                        contract.ir_optimized.as_deref()?,
                         debug_config,
                     )
                     .map(|yul| yul.map(ContractIR::from))
@@ -260,11 +260,14 @@ impl Project {
                     None
                 };
 
-                let ir =
-                    match ContractYul::try_from_source(path.as_str(), source_code, debug_config) {
-                        Ok(ir) => ir?,
-                        Err(error) => return Some((path, Err(error))),
-                    };
+                let ir = match ContractYul::try_from_source(
+                    path.as_str(),
+                    source_code.as_str(),
+                    debug_config,
+                ) {
+                    Ok(ir) => ir?,
+                    Err(error) => return Some((path, Err(error))),
+                };
 
                 let name = era_compiler_common::ContractName::new(
                     path.clone(),

--- a/solx/src/yul/parser/statement/function_definition.rs
+++ b/solx/src/yul/parser/statement/function_definition.rs
@@ -177,7 +177,7 @@ object "Test" {
         let mut invalid_attributes = BTreeSet::new();
         invalid_attributes.insert("UnknownAttribute".to_owned());
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result =
             Object::<EraDialect>::parse(&mut lexer, None, era_compiler_common::CodeSegment::Deploy);
         assert_eq!(
@@ -216,7 +216,7 @@ object "Test" {
         invalid_attributes.insert("UnknownAttribute1".to_owned());
         invalid_attributes.insert("UnknownAttribute2".to_owned());
 
-        let mut lexer = Lexer::new(input.to_owned());
+        let mut lexer = Lexer::new(input);
         let result =
             Object::<EraDialect>::parse(&mut lexer, None, era_compiler_common::CodeSegment::Deploy);
         assert_eq!(


### PR DESCRIPTION
Removes redundant copying of the Yul string into the lexer.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
