### PR TITLE
chore: update auto-changelog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,11 +198,60 @@ jobs:
         with:
           subject-path: 'releases/**/**'
 
+      # Gets the tag of the published release marked `latest`
+      # ignoring all intermediate releases and tags for manual releases
+      - name: Get latest release tag
+        id: latest_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(gh release view --json tagName --jq .tagName)
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build changelog
+        if: github.ref_type == 'tag'
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          fromTag: ${{ steps.latest_release.outputs.tag || '' }}
+          toTag: ${{ github.ref_name }}
+          mode: "COMMIT"
+          configurationJson: |
+            {
+              "template": "# 📝 Changelog\n\n{{CHANGELOG}}",
+              "categories": [
+                {
+                  "title": "## ✨ Features",
+                  "labels": ["feat", "feature"]
+                },
+                {
+                  "title": "## 🐛 Fixes",
+                  "labels": ["fix", "bug"]
+                },
+                {
+                  "title": "## 📚 Documentation",
+                  "labels": ["docs", "documentation"]
+                },
+                {
+                  "title": "## 📦 Other Changes",
+                  "labels": []
+                }
+              ],
+              "label_extractor": [
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+                  "on_property": "title",
+                  "target": "$1"
+                }
+              ]
+            }
+
       - name: Prepare release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.release.outputs.release_title }}
-          generate_release_notes: true
+          generate_release_notes: false
+          body: ${{ steps.build_changelog.outputs.changelog }}
           tag_name: ${{ steps.release.outputs.version_or_sha }}
           target_commitish: ${{ steps.release.outputs.full_sha }}
           make_latest: ${{ github.ref_type == 'tag' }}


### PR DESCRIPTION
# What ❔

Update auto-changelog generation.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To automatically generate changelog from the latest release to a new one ignoring intermediate manual releases if any.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
