### PR TITLE
feat: support env-vars for solx-specific parameters

### DIFF
--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -16,101 +16,146 @@
 [solady]
 repo = "https://github.com/Vectorized/solady"
 description = "Gas optimized Solidity snippets."
+[solady.env]
+RUST_BACKTRACE = "1"
 
 [openzeppelin]
 repo = "https://github.com/OpenZeppelin/openzeppelin-contracts"
 description = "A library for secure smart contract development."
+[openzeppelin.env]
+RUST_BACKTRACE = "1"
 
 [forge-std]
 repo = "https://github.com/foundry-rs/forge-std"
 description = "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry."
+[forge-std.env]
+RUST_BACKTRACE = "1"
 
 [lil-web3]
 repo = "https://github.com/m1guelpf/lil-web3"
 description = "lil web3 aims to build really simple, intentionally-limited versions of web3 protocols & apps."
+[lil-web3.env]
+RUST_BACKTRACE = "1"
 
 [maple-erc20]
 repo = "https://github.com/maple-labs/erc20"
 description = "Basic ERC-20 contract designed to be inherited and extended."
+[maple-erc20.env]
+RUST_BACKTRACE = "1"
 
 [diamonds]
 repo = "https://github.com/Timidan/Foundry-Hardhat-Diamonds"
 description = "A minimal template for Diamonds EIP-2535."
+[diamonds.env]
+RUST_BACKTRACE = "1"
 
 [rollcall]
 repo = "https://github.com/withtally/rollcall"
 description = "A set of cross chain governance solutions."
+[rollcall.env]
+RUST_BACKTRACE = "1"
 
 [playpen]
 repo = "https://github.com/ZeframLou/playpen"
 description = "A set of modern, gas optimized staking pool contracts."
+[playpen.env]
+RUST_BACKTRACE = "1"
 
 [solmate]
 repo = "https://github.com/transmissions11/solmate"
 description = "Modern, opinionated, and gas optimized building blocks for smart contract development."
+[solmate.env]
+RUST_BACKTRACE = "1"
 
 [prb-math]
 repo = "https://github.com/paulrberg/prb-math"
 description = "Solidity library for advanced fixed-point math operations."
 requires_yarn = true
+[prb-math.env]
+RUST_BACKTRACE = "1"
 
 [unix]
 repo = "https://github.com/refcell/unix"
 description = "A lightweight, extensible foundry library for shell scripting."
+[unix.env]
+RUST_BACKTRACE = "1"
 
 [foundry-upgrades]
 repo = "https://github.com/odyslam/foundry-upgrades"
 description = "Helper smart contracts to deploy and manage upgradeable contracts."
+[foundry-upgrades.env]
+RUST_BACKTRACE = "1"
 
 [art-gobblers]
 repo = "https://github.com/artgobblers/art-gobblers"
 description = "A decentralized art factory and marketplace."
+[art-gobblers.env]
+RUST_BACKTRACE = "1"
 
 [balance-snapshot]
 repo = "https://github.com/pilagod/balance-snapshot"
 description = "A Solidity library to improve balance change check in Foundry tests."
+[balance-snapshot.env]
+RUST_BACKTRACE = "1"
 
 [diamond-foundry]
 repo = "https://github.com/FydeTreasury/Diamond-Foundry"
 description = "a reference implementation for EIP-2535 Diamonds."
+[diamond-foundry.env]
+RUST_BACKTRACE = "1"
 
 [fixed-term-loan]
 repo = "https://github.com/maple-labs/fixed-term-loan"
 description = "A set of contracts to facilitate on-chain loans."
 disabled = true
+[fixed-term-loan.env]
+RUST_BACKTRACE = "1"
 
 [tokenlon]
 repo = "https://github.com/consenlabs/tokenlon-contracts"
 description = "A decentralized exchange and payment settlement protocol."
+[tokenlon.env]
+RUST_BACKTRACE = "1"
 
 [uniswap-v4]
 repo = "https://github.com/Uniswap/v4-core"
 description = "A new automated market maker protocol."
+[uniswap-v4.env]
+RUST_BACKTRACE = "1"
 
 [beefy]
 repo = "https://github.com/beefyfinance/beefy-contracts"
 description = "Official repo for strategies and vaults from Beefy."
 requires_yarn = true
 [beefy.env]
+RUST_BACKTRACE = "1"
 EVM_DISABLE_MEMORY_SAFE_ASM_CHECK = "true"
 
 [gov-of-venice]
 repo = "https://github.com/pentagonxyz/gov-of-venice"
 description = "A new paradigm in DAO governance."
+[gov-of-venice.env]
+RUST_BACKTRACE = "1"
 
 [aave-v3]
 repo = "https://github.com/aave-dao/aave-v3-origin"
 description = "A non-custodial liquidity protocol on Ethereum."
 requires_yarn = true
+[aave-v3.env]
+RUST_BACKTRACE = "1"
 
 [seaport]
 repo = "https://github.com/ProjectOpenSea/seaport"
 description = "A marketplace protocol for safely and efficiently buying and selling NFTs."
 category = "huge"
 disabled = true # compilation hangs, required to disable fuzzing tests
+[seaport.env]
+RUST_BACKTRACE = "1"
 
 [lens]
 repo = "https://github.com/lens-protocol/core"
 description = "Lens protocol, non-custodial social graph."
 category = "huge"
 disabled = true # compilation is too long
+[lens.env]
+RUST_BACKTRACE = "1"

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -5,6 +5,13 @@
 # compile_only = true # optional, set to true if you only want to compile the project without running tests
 # requires_yarn = true # optional, set to true if the project requires yarn install before building
 # category = "huge" # optional, use huge to indicate a large project that may take longer to compile or run tests
+
+# Environment variables
+# You can set environment variables for the project.
+# They will be set during the compilation and testing phases.
+## [beefy.env]
+## TEST_ENV = "123"
+## ANOTHER_ENV = "321"
 ###
 
 [solady]

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -9,10 +9,9 @@
 # Environment variables
 # You can set environment variables for the project.
 # They will be set during the compilation and testing phases.
-## [beefy.env]
-## TEST_ENV = "123"
-## ANOTHER_ENV = "321"
-###
+# [beefy.env]
+# TEST_ENV = "123"
+# ANOTHER_ENV = "321"
 
 [solady]
 repo = "https://github.com/Vectorized/solady"
@@ -92,6 +91,8 @@ description = "A new automated market maker protocol."
 repo = "https://github.com/beefyfinance/beefy-contracts"
 description = "Official repo for strategies and vaults from Beefy."
 requires_yarn = true
+[beefy.env]
+EVM_DISABLE_MEMORY_SAFE_ASM_CHECK = "true"
 
 [gov-of-venice]
 repo = "https://github.com/pentagonxyz/gov-of-venice"

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -16,146 +16,101 @@
 [solady]
 repo = "https://github.com/Vectorized/solady"
 description = "Gas optimized Solidity snippets."
-[solady.env]
-RUST_BACKTRACE = "1"
 
 [openzeppelin]
 repo = "https://github.com/OpenZeppelin/openzeppelin-contracts"
 description = "A library for secure smart contract development."
-[openzeppelin.env]
-RUST_BACKTRACE = "1"
 
 [forge-std]
 repo = "https://github.com/foundry-rs/forge-std"
 description = "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry."
-[forge-std.env]
-RUST_BACKTRACE = "1"
 
 [lil-web3]
 repo = "https://github.com/m1guelpf/lil-web3"
 description = "lil web3 aims to build really simple, intentionally-limited versions of web3 protocols & apps."
-[lil-web3.env]
-RUST_BACKTRACE = "1"
 
 [maple-erc20]
 repo = "https://github.com/maple-labs/erc20"
 description = "Basic ERC-20 contract designed to be inherited and extended."
-[maple-erc20.env]
-RUST_BACKTRACE = "1"
 
 [diamonds]
 repo = "https://github.com/Timidan/Foundry-Hardhat-Diamonds"
 description = "A minimal template for Diamonds EIP-2535."
-[diamonds.env]
-RUST_BACKTRACE = "1"
 
 [rollcall]
 repo = "https://github.com/withtally/rollcall"
 description = "A set of cross chain governance solutions."
-[rollcall.env]
-RUST_BACKTRACE = "1"
 
 [playpen]
 repo = "https://github.com/ZeframLou/playpen"
 description = "A set of modern, gas optimized staking pool contracts."
-[playpen.env]
-RUST_BACKTRACE = "1"
 
 [solmate]
 repo = "https://github.com/transmissions11/solmate"
 description = "Modern, opinionated, and gas optimized building blocks for smart contract development."
-[solmate.env]
-RUST_BACKTRACE = "1"
 
 [prb-math]
 repo = "https://github.com/paulrberg/prb-math"
 description = "Solidity library for advanced fixed-point math operations."
 requires_yarn = true
-[prb-math.env]
-RUST_BACKTRACE = "1"
 
 [unix]
 repo = "https://github.com/refcell/unix"
 description = "A lightweight, extensible foundry library for shell scripting."
-[unix.env]
-RUST_BACKTRACE = "1"
 
 [foundry-upgrades]
 repo = "https://github.com/odyslam/foundry-upgrades"
 description = "Helper smart contracts to deploy and manage upgradeable contracts."
-[foundry-upgrades.env]
-RUST_BACKTRACE = "1"
 
 [art-gobblers]
 repo = "https://github.com/artgobblers/art-gobblers"
 description = "A decentralized art factory and marketplace."
-[art-gobblers.env]
-RUST_BACKTRACE = "1"
 
 [balance-snapshot]
 repo = "https://github.com/pilagod/balance-snapshot"
 description = "A Solidity library to improve balance change check in Foundry tests."
-[balance-snapshot.env]
-RUST_BACKTRACE = "1"
 
 [diamond-foundry]
 repo = "https://github.com/FydeTreasury/Diamond-Foundry"
 description = "a reference implementation for EIP-2535 Diamonds."
-[diamond-foundry.env]
-RUST_BACKTRACE = "1"
 
 [fixed-term-loan]
 repo = "https://github.com/maple-labs/fixed-term-loan"
 description = "A set of contracts to facilitate on-chain loans."
 disabled = true
-[fixed-term-loan.env]
-RUST_BACKTRACE = "1"
 
 [tokenlon]
 repo = "https://github.com/consenlabs/tokenlon-contracts"
 description = "A decentralized exchange and payment settlement protocol."
-[tokenlon.env]
-RUST_BACKTRACE = "1"
 
 [uniswap-v4]
 repo = "https://github.com/Uniswap/v4-core"
 description = "A new automated market maker protocol."
-[uniswap-v4.env]
-RUST_BACKTRACE = "1"
 
 [beefy]
 repo = "https://github.com/beefyfinance/beefy-contracts"
 description = "Official repo for strategies and vaults from Beefy."
 requires_yarn = true
 [beefy.env]
-RUST_BACKTRACE = "1"
 EVM_DISABLE_MEMORY_SAFE_ASM_CHECK = "true"
 
 [gov-of-venice]
 repo = "https://github.com/pentagonxyz/gov-of-venice"
 description = "A new paradigm in DAO governance."
-[gov-of-venice.env]
-RUST_BACKTRACE = "1"
 
 [aave-v3]
 repo = "https://github.com/aave-dao/aave-v3-origin"
 description = "A non-custodial liquidity protocol on Ethereum."
 requires_yarn = true
-[aave-v3.env]
-RUST_BACKTRACE = "1"
 
 [seaport]
 repo = "https://github.com/ProjectOpenSea/seaport"
 description = "A marketplace protocol for safely and efficiently buying and selling NFTs."
 category = "huge"
 disabled = true # compilation hangs, required to disable fuzzing tests
-[seaport.env]
-RUST_BACKTRACE = "1"
 
 [lens]
 repo = "https://github.com/lens-protocol/core"
 description = "Lens protocol, non-custodial social graph."
 category = "huge"
 disabled = true # compilation is too long
-[lens.env]
-RUST_BACKTRACE = "1"

--- a/.github/workflows/foundry-benchmarks.yaml
+++ b/.github/workflows/foundry-benchmarks.yaml
@@ -193,6 +193,16 @@ jobs:
               echo "Skipping ${PROJECT} as it is disabled"
               continue
             fi
+            # Set env variables for a project if any
+            while IFS='=' read -r key value; do
+              if [[ -n "${key}" ]]; then
+                export "${key}=${value}"
+                echo "Exported env variable: ${key}=${value} for ${PROJECT}."
+              fi
+            done < <(
+              yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" |
+                jq -r 'select(.key != null) | .key + "=" + (.value | tostring)'
+            )
             for COMPILER in solc solx; do
               for VIA_IR in true false; do
                 REPO=$(yq ".${PROJECT}.repo" "${TOML_CONFIG}")
@@ -210,17 +220,6 @@ jobs:
                   echo "Installing yarn dependencies for ${PROJECT}"
                   yarn install
                 fi
-          
-                # Set env variables for a project if any
-                while IFS='=' read -r key value; do
-                  if [[ -n "${key}" ]]; then
-                    export "${key}=${value}"
-                    echo "Exported env variable: ${key}=${value} for ${PROJECT}."
-                  fi
-                done < <(
-                  yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" |
-                    jq -r 'select(.key != null) | .key + "=" + (.value | tostring)'
-                )
           
                 # Replace solidity version in all .sol files
                 find . -name "*.sol" -type f -exec \
@@ -243,8 +242,15 @@ jobs:
                 end_ms=$(date +%s%3N)
                 elapsed_ms=$(( end_ms - start_ms ))
                 COMPILE_TIME=$(awk -v ms="${elapsed_ms}" 'BEGIN { printf "%.3f\n", ms / 1000 }')
-                jq --arg k "compile_time" --argjson v "${COMPILE_TIME}" '. + {($k): $v}' "${BUILD_JSON}" > tmp.json
-                mv tmp.json "${BUILD_JSON}"
+                
+                if jq empty "${BUILD_JSON}" > /dev/null 2>&1 && [ -s "${BUILD_JSON}" ]; then
+                  jq --arg k "compile_time" --argjson v "${COMPILE_TIME}" '. + {($k): $v}' "${BUILD_JSON}" > tmp.json
+                  mv tmp.json "${BUILD_JSON}"
+                else
+                  echo "Build failed for ${PROJECT} with ${COMPILER} via-ir=${VIA_IR}:"
+                  cat "${BUILD_JSON}"
+                  continue
+                fi
           
                 COMPILE_ONLY=$(yq ".${PROJECT}.compile_only" "${TOML_CONFIG}")
                 if [[ "${COMPILE_ONLY}" == "true" ]]; then
@@ -271,17 +277,16 @@ jobs:
                 mv tmp.json "${BUILD_JSON}"
           
                 forge test --gas-report ${VIA_IR_OPTION} --json ${USE_SOLX} ${DEFAULT_SKIP_TESTS} ${SKIP_TESTS} >"${GAS_JSON}" 2>/dev/null || true
-          
-                # Clean-up environment variables
-                while IFS= read -r key; do
-                  unset "${key}"
-                  echo "Unset environment variable ${key} for ${PROJECT}."
-                done < <(
-                  yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" | jq -r '.key'
-                )
 
               done
             done
+            # Clean-up environment variables for the project
+            while IFS= read -r key; do
+              unset "${key}"
+              echo "Unset environment variable ${key} for ${PROJECT}."
+            done < <(
+              yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" | jq -r '.key'
+            )
           done
 
       - name: Upload json

--- a/.github/workflows/foundry-benchmarks.yaml
+++ b/.github/workflows/foundry-benchmarks.yaml
@@ -185,15 +185,17 @@ jobs:
         run: |
           mkdir -p projects
           compilation_json='{}'
+          TOML_CONFIG="${GITHUB_WORKSPACE}/.github/forge-benchmarks.toml"
+          export PATH="${GITHUB_WORKSPACE}:${PATH}"
           for PROJECT in ${{ matrix.project }}; do
-            DISABLED=$(${GITHUB_WORKSPACE}/yq ".${PROJECT}.disabled" ${GITHUB_WORKSPACE}/.github/forge-benchmarks.toml)
+            DISABLED=$(yq ".${PROJECT}.disabled" "${TOML_CONFIG}")
             if [[ "${DISABLED}" == "true" ]]; then
               echo "Skipping ${PROJECT} as it is disabled"
               continue
             fi
             for COMPILER in solc solx; do
               for VIA_IR in true false; do
-                REPO=$(${GITHUB_WORKSPACE}/yq ".${PROJECT}.repo" ${GITHUB_WORKSPACE}/.github/forge-benchmarks.toml)
+                REPO=$(yq ".${PROJECT}.repo" "${TOML_CONFIG}")
                 if [ ! -d "${GITHUB_WORKSPACE}/projects/${PROJECT}" ]; then
                   git clone --depth 1 "${REPO}" "${GITHUB_WORKSPACE}/projects/${PROJECT}" --recurse-submodules
                 else
@@ -203,11 +205,22 @@ jobs:
                 cd "${GITHUB_WORKSPACE}/projects/${PROJECT}"
                 echo "Running tests for ${PROJECT} with ${COMPILER} via-ir=${VIA_IR}"
           
-                REQUIRES_YARN=$(${GITHUB_WORKSPACE}/yq ".${PROJECT}.requires_yarn" ${GITHUB_WORKSPACE}/.github/forge-benchmarks.toml)
+                REQUIRES_YARN=$(yq ".${PROJECT}.requires_yarn" "${TOML_CONFIG}")
                 if [[ "${REQUIRES_YARN}" == "true" ]]; then
                   echo "Installing yarn dependencies for ${PROJECT}"
                   yarn install
                 fi
+          
+                # Set env variables for a project if any
+                while IFS='=' read -r key value; do
+                  if [[ -n "${key}" ]]; then
+                    export "${key}=${value}"
+                    echo "Exported env variable: ${key}=${value} for ${PROJECT}."
+                  fi
+                done < <(
+                  yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" |
+                    jq -r 'select(.key != null) | .key + "=" + (.value | tostring)'
+                )
           
                 # Replace solidity version in all .sol files
                 find . -name "*.sol" -type f -exec \
@@ -233,7 +246,7 @@ jobs:
                 jq --arg k "compile_time" --argjson v "${COMPILE_TIME}" '. + {($k): $v}' "${BUILD_JSON}" > tmp.json
                 mv tmp.json "${BUILD_JSON}"
           
-                COMPILE_ONLY=$(${GITHUB_WORKSPACE}/yq ".${PROJECT}.compile_only" ${GITHUB_WORKSPACE}/.github/forge-benchmarks.toml)
+                COMPILE_ONLY=$(yq ".${PROJECT}.compile_only" "${TOML_CONFIG}")
                 if [[ "${COMPILE_ONLY}" == "true" ]]; then
                   echo "Skipping tests for ${PROJECT} as compile_only is set to true"
                   continue
@@ -241,7 +254,7 @@ jobs:
           
                 FAILED_TESTS_TO_SKIP=$(jq -r '.errors[] | select(.type == "Error") | .sourceLocation.file' ${BUILD_JSON} | sed -E 's/:([^ ]+)//g')
                 # Run tests
-                DEFAULT_SKIP=$(${GITHUB_WORKSPACE}/yq '.profile.default.skip[]' foundry.toml)
+                DEFAULT_SKIP=$(yq '.profile.default.skip[]' foundry.toml)
                 if [[ -n "${DEFAULT_SKIP}" ]] || [[ -n "${FAILED_TESTS_TO_SKIP}" ]]; then
                   SKIP_TESTS="--skip ${DEFAULT_SKIP} ${FAILED_TESTS_TO_SKIP}"
                 else
@@ -258,6 +271,15 @@ jobs:
                 mv tmp.json "${BUILD_JSON}"
           
                 forge test --gas-report ${VIA_IR_OPTION} --json ${USE_SOLX} ${DEFAULT_SKIP_TESTS} ${SKIP_TESTS} >"${GAS_JSON}" 2>/dev/null || true
+          
+                # Clean-up environment variables
+                while IFS= read -r key; do
+                  unset "${key}"
+                  echo "Unset environment variable ${key} for ${PROJECT}."
+                done < <(
+                  yq -oj ".${PROJECT}.env // {} | to_entries[]" "${TOML_CONFIG}" | jq -r '.key'
+                )
+
               done
             done
           done

--- a/.github/workflows/foundry-benchmarks.yaml
+++ b/.github/workflows/foundry-benchmarks.yaml
@@ -423,6 +423,11 @@ jobs:
                 continue
               fi
           
+              if ! (jq empty "${JSON}" > /dev/null 2>&1 && [ -s "${JSON}" ]); then
+                echo "Invalid JSON for ${PROJECT} [${MODE}]: ${JSON}"
+                continue
+              fi
+          
               # Bytecode size exceeds limit
               BYTECODE_WARN_SOLX=$(jq '[.errors[] | select(.errorCode == "5574" or .errorCode == "3860")] | length' "${JSON}")
               BYTECODE_WARN_SOLC=$(jq '[.errors[] | select(.errorCode == "5574" or .errorCode == "3860")] | length' "${REF_JSON}")

--- a/.github/workflows/foundry-benchmarks.yaml
+++ b/.github/workflows/foundry-benchmarks.yaml
@@ -252,6 +252,19 @@ jobs:
                   continue
                 fi
           
+                if jq -e 'has("errors") and (.errors | type == "array") and (.errors | length > 0)' ${BUILD_JSON} > /dev/null; then
+                  echo "Errors found in ${BUILD_JSON} for ${PROJECT} with ${COMPILER} via-ir=${VIA_IR}:"
+                  jq -r '
+                    .errors[] |
+                    "🔍 File: \(.sourceLocation.file // "N/A")\n" +
+                    "   🔹 Type: \(.type)\n" +
+                    "   🔹 Severity: \(.severity)\n" +
+                    "   🔹 Error Code: \(.errorCode)\n" +
+                    "   🔹 Message:\n     \(.message | gsub("\n"; "\n     "))\n" +
+                    "------------------------------------------------------------"
+                    ' "${BUILD_JSON}"
+                fi
+          
                 COMPILE_ONLY=$(yq ".${PROJECT}.compile_only" "${TOML_CONFIG}")
                 if [[ "${COMPILE_ONLY}" == "true" ]]; then
                   echo "Skipping tests for ${PROJECT} as compile_only is set to true"

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 [submodule "era-solidity"]
 	path = era-solidity
 	url = https://github.com/matter-labs/era-solidity
-	branch = app-unsafe-asm
+	branch = 0.8.30
 	update = none

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 [submodule "era-solidity"]
 	path = era-solidity
 	url = https://github.com/matter-labs/era-solidity
-	branch = 0.8.30
+	branch = app-unsafe-asm
 	update = none

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.28"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "shlex",
 ]
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "solx"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "solx-evm-assembly"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "solx-solc"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "solx-standard-json"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "solx-yul"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ authors = [
     "The Matter Labs Team <hello@matterlabs.dev>",
 ]
 edition = "2021"
-version = "0.1.0-alpha.4"
+version = "0.1.0"

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -456,7 +456,7 @@ Sets the optimization level of the LLVM optimizer. Available values are:
 
 | Level | Meaning                      | Hints                                            |
 |:------|:-----------------------------|:-------------------------------------------------|
-| 0     | No optimization              | For fast compilation during development
+| 0     | No optimization              | For fast compilation during development (unsupported, but coming soon)
 | 1     | Performance: basic           | For optimization research
 | 2     | Performance: default         | For optimization research
 | 3     | Performance: aggressive      | Best performance for production
@@ -496,6 +496,7 @@ Usage:
 ```bash
 solx 'Simple.sol' --bin -O3 --optimization-size-fallback
 ```
+
 This option can also be set with an environment variable `SOLX_OPTIMIZATION_SIZE_FALLBACK`, which is useful for toolkits
 where arbitrary solx-specific options are not supported:
 

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -484,7 +484,10 @@ SOLX_OPTIMIZATION='3' solx 'Simple.sol' --bin
 
 ### `--optimization-size-fallback`
 
-Sets the optimization level to `z` for contracts that failed to compile due to overrunning the bytecode size constraints. This mode is enabled by default, but it is only activated when the `--optimization` option is set to `3`, which is the default optimization level.
+Sets the optimization level to `z` for contracts that failed to compile due to overrunning the bytecode size constraints.
+
+> This option can cause stack-too-deep errors that solx cannot resolve yet. It will be fixed soon.
+> If you encounter such errors in your project, please temporarily refrain from using this option.
 
 Under the hood, this option automatically triggers recompilation of contracts with level `z`. Contracts that were successfully compiled with [the original `--optimization` setting](#--optimization---o) are not recompiled.
 

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -467,16 +467,41 @@ For most cases, it is fine to keep the default value of `3`. You should only use
 
 > Large contracts may hit the EVM bytecode size limit. In this case, it is recommended using the [`--optimization-size-fallback`](#--optimization-size-fallback) option rather than setting the level to `z`.
 
+Usage:
+
+```bash
+solx 'Simple.sol' --bin -O3
+```
+
+This option can also be set with an environment variable `SOLX_OPTIMIZATION`, which is useful for toolkits
+where arbitrary solx-specific options are not supported:
+
+```bash
+SOLX_OPTIMIZATION='3' solx 'Simple.sol' --bin
+```
+
 
 
 ### `--optimization-size-fallback`
 
-Sets the optimization level to `z` for contracts that failed to compile due to overrunning the bytecode size constraints.
+Sets the optimization level to `z` for contracts that failed to compile due to overrunning the bytecode size constraints. This mode is enabled by default, but it is only activated when the `--optimization` option is set to `3`, which is the default optimization level.
 
 Under the hood, this option automatically triggers recompilation of contracts with level `z`. Contracts that were successfully compiled with [the original `--optimization` setting](#--optimization---o) are not recompiled.
 
-> For deployment, it is recommended to have this option always enabled to reduce issues with bytecode size constraints.
-> If your environment does not have bytecode size limitations, it is better to keep this option disabled to prevent unnecessary recompilations.
+> For deployment, it is recommended not to disable this option in order to mitigate potential issues with EVM bytecode size constraints.
+> If your environment does not have bytecode size limitations, it is better to disable it to prevent unnecessary recompilations.
+
+Usage:
+
+```bash
+solx 'Simple.sol' --bin -O3 --optimization-size-fallback
+```
+This option can also be set with an environment variable `SOLX_OPTIMIZATION_SIZE_FALLBACK`, which is useful for toolkits
+where arbitrary solx-specific options are not supported:
+
+```bash
+SOLX_OPTIMIZATION_SIZE_FALLBACK= solx 'Simple.sol' --bin -O3
+```
 
 
 
@@ -698,17 +723,25 @@ The directory is created if it does not exist. If artifacts are already present 
 
 The intermediate build artifacts can be:
 
-| Name          | Via IR | Extension   |
-|:--------------|:-------|:------------|
-| EVM Assembly  | no     | *evmla*     |
-| EthIR         | no     | *ethir*     |  
-| Yul           | yes    | *yul*       |
-| LLVM IR       | any    | *ll*        |
+| Name          | Extension   |
+|:--------------|:------------|
+| EVM Assembly  | *evmla*     |
+| EthIR         | *ethir*     |  
+| Yul           | *yul*       |
+| LLVM IR       | *ll*        |
 
 Usage:
 
 ```bash
 solx 'Simple.sol' --bin --debug-output-dir './debug/'
+ls './debug/'
+```
+
+This option can also be set with an environment variable `SOLX_DEBUG_OUTPUT_DIR`, which is useful for toolkits
+where arbitrary solx-specific options are not supported:
+
+```bash
+SOLX_DEBUG_OUTPUT_DIR='./debug/' solx 'Simple.sol' --bin
 ls './debug/'
 ```
 

--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -70,8 +70,9 @@ On the other hand, parameters that are not mentioned here but are parts of **sol
       "mode": "3",
       // Optional, solx-only: Re-run the compilation with "mode": "z" if the initial compilation exceeds the EVM bytecode size limit.
       // Used on a per-contract basis and applied automatically, so some contracts will end up compiled in the initial mode, and others with "mode": "z".
-      // Default: false.
-      "sizeFallback": false
+      // Only activated if "mode" is set to "3", which is the default optimization mode.
+      // Default: true.
+      "sizeFallback": true
     },
 
     // Optional: Sorted list of remappings.

--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -71,8 +71,8 @@ On the other hand, parameters that are not mentioned here but are parts of **sol
       // Optional, solx-only: Re-run the compilation with "mode": "z" if the initial compilation exceeds the EVM bytecode size limit.
       // Used on a per-contract basis and applied automatically, so some contracts will end up compiled in the initial mode, and others with "mode": "z".
       // Only activated if "mode" is set to "3", which is the default optimization mode.
-      // Default: true.
-      "sizeFallback": true
+      // Default: false.
+      "sizeFallback": false
     },
 
     // Optional: Sorted list of remappings.

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -176,6 +176,17 @@ impl Compiler {
                 }
                 None => true,
             });
+        solc_output.errors = solc_output
+            .errors
+            .into_iter()
+            .map(|error| {
+                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok() {
+                    error.into_warning()
+                } else {
+                    error
+                }
+            })
+            .collect();
         solc_output.errors.append(messages);
 
         Ok(solc_output)

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -180,7 +180,13 @@ impl Compiler {
             .errors
             .into_iter()
             .map(|error| {
-                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok() {
+                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
+                    && error.error_code
+                        == Some(
+                            solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
+                                .to_string(),
+                        )
+                {
                     error.into_warning()
                 } else {
                     error

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -176,23 +176,23 @@ impl Compiler {
                 }
                 None => true,
             });
-        solc_output.errors = solc_output
-            .errors
-            .into_iter()
-            .map(|error| {
-                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
-                    && error.error_code
-                        == Some(
-                            solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
-                                .to_string(),
-                        )
-                {
-                    error.into_warning()
-                } else {
-                    error
-                }
-            })
-            .collect();
+        // solc_output.errors = solc_output
+        //     .errors
+        //     .into_iter()
+        //     .map(|error| {
+        //         if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
+        //             && error.error_code
+        //                 == Some(
+        //                     solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
+        //                         .to_string(),
+        //                 )
+        //         {
+        //             error.into_warning()
+        //         } else {
+        //             error
+        //         }
+        //     })
+        //     .collect();
         solc_output.errors.append(messages);
 
         Ok(solc_output)

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -176,23 +176,23 @@ impl Compiler {
                 }
                 None => true,
             });
-        // solc_output.errors = solc_output
-        //     .errors
-        //     .into_iter()
-        //     .map(|error| {
-        //         if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
-        //             && error.error_code
-        //                 == Some(
-        //                     solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
-        //                         .to_string(),
-        //                 )
-        //         {
-        //             error.into_warning()
-        //         } else {
-        //             error
-        //         }
-        //     })
-        //     .collect();
+        solc_output.errors = solc_output
+            .errors
+            .into_iter()
+            .map(|error| {
+                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
+                    && error.error_code
+                        == Some(
+                            solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
+                                .to_string(),
+                        )
+                {
+                    error.into_warning()
+                } else {
+                    error
+                }
+            })
+            .collect();
         solc_output.errors.append(messages);
 
         Ok(solc_output)

--- a/solx-solc/src/lib.rs
+++ b/solx-solc/src/lib.rs
@@ -176,23 +176,6 @@ impl Compiler {
                 }
                 None => true,
             });
-        solc_output.errors = solc_output
-            .errors
-            .into_iter()
-            .map(|error| {
-                if std::env::var("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK").is_ok()
-                    && error.error_code
-                        == Some(
-                            solx_standard_json::OutputError::MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE
-                                .to_string(),
-                        )
-                {
-                    error.into_warning()
-                } else {
-                    error
-                }
-            })
-            .collect();
         solc_output.errors.append(messages);
 
         Ok(solc_output)

--- a/solx-standard-json/src/input/settings/optimizer/mod.rs
+++ b/solx-standard-json/src/input/settings/optimizer/mod.rs
@@ -86,7 +86,7 @@ impl Optimizer {
     /// The default flag to enable the size fallback.
     ///
     pub fn default_size_fallback() -> Option<bool> {
-        Some(true)
+        Some(false)
     }
 
     ///

--- a/solx-standard-json/src/input/settings/optimizer/mod.rs
+++ b/solx-standard-json/src/input/settings/optimizer/mod.rs
@@ -86,7 +86,7 @@ impl Optimizer {
     /// The default flag to enable the size fallback.
     ///
     pub fn default_size_fallback() -> Option<bool> {
-        Some(false)
+        Some(true)
     }
 
     ///

--- a/solx-standard-json/src/output/error/mod.rs
+++ b/solx-standard-json/src/output/error/mod.rs
@@ -41,9 +41,6 @@ impl Error {
     /// The list of ignored `solc` warnings that are strictly EVM-related.
     pub const IGNORED_WARNING_CODES: [&'static str; 5] = ["1699", "3860", "5159", "5574", "6417"];
 
-    /// The memory-unsafe assembly check error code.
-    pub const MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE: isize = 5726;
-
     ///
     /// A shortcut constructor.
     ///

--- a/solx-standard-json/src/output/error/mod.rs
+++ b/solx-standard-json/src/output/error/mod.rs
@@ -41,6 +41,9 @@ impl Error {
     /// The list of ignored `solc` warnings that are strictly EVM-related.
     pub const IGNORED_WARNING_CODES: [&'static str; 5] = ["1699", "3860", "5159", "5574", "6417"];
 
+    /// The memory-unsafe assembly check error code.
+    pub const MEMORY_UNSAFE_ASSEMBLY_ERROR_CODE: isize = 5726;
+
     ///
     /// A shortcut constructor.
     ///
@@ -114,6 +117,17 @@ impl Error {
         S: std::fmt::Display,
     {
         Self::new("Warning", error_code, message, source_location, sources)
+    }
+
+    ///
+    /// Changes this message to a warning.
+    ///
+    /// It is useful when the user is confident that the error is not critical and can be ignored.
+    ///
+    pub fn into_warning(mut self) -> Self {
+        self.severity = "warning".to_owned();
+        self.r#type = "Warning".to_owned();
+        self
     }
 }
 

--- a/solx/src/build/contract/mod.rs
+++ b/solx/src/build/contract/mod.rs
@@ -718,7 +718,7 @@ impl Contract {
                         )
                     })
             } else {
-                panic!()
+                None
             },
             self.runtime_object_result
                 .as_mut()

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -289,8 +289,8 @@ impl Build {
                     .map(|object| object.warnings_standard_json(contract.name.full_path.as_str()))
                     .unwrap_or_default(),
             );
-            if let Err(ref error) = contract.deploy_object_result {
-                errors.push(error.to_owned().unwrap_standard_json());
+            if let Err(Error::StandardJson(ref error)) = contract.deploy_object_result {
+                errors.push(error.to_owned());
             }
             errors.extend(
                 contract
@@ -299,8 +299,8 @@ impl Build {
                     .map(|object| object.warnings_standard_json(contract.name.full_path.as_str()))
                     .unwrap_or_default(),
             );
-            if let Err(ref error) = contract.runtime_object_result {
-                errors.push(error.to_owned().unwrap_standard_json());
+            if let Err(Error::StandardJson(ref error)) = contract.runtime_object_result {
+                errors.push(error.to_owned());
             }
             if contract.deploy_object_result.is_err() || contract.runtime_object_result.is_err() {
                 continue;

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -366,13 +366,10 @@ impl Build {
                 stack_too_deep_errors.push(error);
             }
         }
-        // TODO: replace with `extract_if` when stabilized
         self.contracts.retain(|_, contract| {
             !matches!(contract.deploy_object_result, Err(Error::StackTooDeep(_)))
-        });
-        self.contracts.retain(|_, contract| {
-            !matches!(contract.runtime_object_result, Err(Error::StackTooDeep(_)))
-        });
+                && !matches!(contract.runtime_object_result, Err(Error::StackTooDeep(_)))
+        }); // TODO: replace with `extract_if` when stabilized
         stack_too_deep_errors
     }
 }

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -366,10 +366,13 @@ impl Build {
                 stack_too_deep_errors.push(error);
             }
         }
+        // TODO: replace with `extract_if` when stabilized
         self.contracts.retain(|_, contract| {
             !matches!(contract.deploy_object_result, Err(Error::StackTooDeep(_)))
-                && !matches!(contract.runtime_object_result, Err(Error::StackTooDeep(_)))
-        }); // TODO: replace with `extract_if` when stabilized
+        });
+        self.contracts.retain(|_, contract| {
+            !matches!(contract.runtime_object_result, Err(Error::StackTooDeep(_)))
+        });
         stack_too_deep_errors
     }
 }

--- a/solx/src/error/mod.rs
+++ b/solx/src/error/mod.rs
@@ -35,21 +35,6 @@ impl Error {
     }
 
     ///
-    /// Unwraps the error as a `StandardJson` error.
-    ///
-    pub fn unwrap_standard_json(self) -> solx_standard_json::OutputError {
-        match self {
-            Error::StandardJson(error) => error,
-            Error::Generic(error) => {
-                panic!("Expected a StandardJson error, but got a Generic error: {error}")
-            }
-            Error::StackTooDeep(error) => {
-                panic!("Expected a StandardJson error, but got a StackTooDeep error: {error}")
-            }
-        }
-    }
-
-    ///
     /// Unwraps the error as a `StandardJson` error reference.
     ///
     pub fn unwrap_standard_json_ref(&self) -> &solx_standard_json::OutputError {

--- a/solx/src/error/stack_too_deep.rs
+++ b/solx/src/error/stack_too_deep.rs
@@ -6,7 +6,7 @@
 /// Stack-too-deep compilation error.
 ///
 #[derive(Debug, Clone, thiserror::Error, serde::Serialize, serde::Deserialize)]
-#[error("Stack-too-deep error detected. Required spill area: {spill_area_size:?} bytes")]
+#[error("Stack-too-deep error detected in {code_segment:?} code of {contract_name:?}. Required spill area: {spill_area_size:?} bytes")]
 pub struct StackTooDeep {
     /// Spill area size in bytes.
     pub spill_area_size: u64,

--- a/solx/tests/cli/debug_output_dir.rs
+++ b/solx/tests/cli/debug_output_dir.rs
@@ -24,6 +24,29 @@ fn default() -> anyhow::Result<()> {
 }
 
 #[test]
+fn with_env_var() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let tmp_dir_debug = TempDir::with_prefix("debug_output")?;
+
+    let args = &[
+        "--bin",
+        crate::common::TEST_SOLIDITY_CONTRACT_PATH,
+        "--debug-output-dir",
+        tmp_dir_debug.path().to_str().unwrap(),
+    ];
+    let env_vars = vec![(
+        "SOLX_DEBUG_OUTPUT_DIR",
+        tmp_dir_debug.path().to_string_lossy().to_string(),
+    )];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result.success();
+
+    Ok(())
+}
+
+#[test]
 fn yul() -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/solx/tests/cli/mod.rs
+++ b/solx/tests/cli/mod.rs
@@ -55,6 +55,20 @@ pub fn execute_solx(args: &[&str]) -> anyhow::Result<assert_cmd::assert::Assert>
 }
 
 ///
+/// Execute `solx` with the given arguments and environment variables, and assert the result.
+///
+pub fn execute_solx_with_env_vars(
+    args: &[&str],
+    env_vars: Vec<(&str, String)>,
+) -> anyhow::Result<assert_cmd::assert::Assert> {
+    let mut command = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+    for (key, value) in env_vars.into_iter() {
+        command.env(key, value);
+    }
+    Ok(command.args(args).assert())
+}
+
+///
 /// Execute `solx` with the given arguments and stdin input, and assert the result.
 ///
 pub fn execute_solx_with_stdin(

--- a/solx/tests/cli/optimization.rs
+++ b/solx/tests/cli/optimization.rs
@@ -26,6 +26,24 @@ fn all(level: char) -> anyhow::Result<()> {
     Ok(())
 }
 
+// TODO: #[test_case('0')] when -O0 is supported
+#[test_case('1')]
+#[test_case('2')]
+#[test_case('3')]
+#[test_case('s')]
+#[test_case('z')]
+fn all_with_env_var(level: char) -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[crate::common::TEST_SOLIDITY_CONTRACT_PATH, "--bin"];
+    let env_vars = vec![("SOLX_OPTIMIZATION", level.to_string())];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result.success().stdout(predicate::str::contains("Binary"));
+
+    Ok(())
+}
+
 #[test]
 fn invalid() -> anyhow::Result<()> {
     crate::common::setup()?;

--- a/solx/tests/cli/optimization.rs
+++ b/solx/tests/cli/optimization.rs
@@ -60,6 +60,21 @@ fn invalid() -> anyhow::Result<()> {
 }
 
 #[test]
+fn invalid_with_env_var() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[crate::common::TEST_SOLIDITY_CONTRACT_PATH];
+    let env_vars = vec![("SOLX_OPTIMIZATION", "99".to_string())];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result.failure().stderr(
+        predicate::str::contains("Error: Invalid value \'99\' for environment variable \'SOLX_OPTIMIZATION\': values 1, 2, 3, s, z are supported.")
+    );
+
+    Ok(())
+}
+
+#[test]
 fn standard_json() -> anyhow::Result<()> {
     crate::common::setup()?;
 
@@ -74,6 +89,24 @@ fn standard_json() -> anyhow::Result<()> {
     result.success().stdout(predicate::str::contains(
         "LLVM optimizations must be specified in standard JSON input settings.",
     ));
+
+    Ok(())
+}
+
+#[test]
+fn standard_json_invalid_env_var() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::TEST_SOLIDITY_STANDARD_JSON_PATH,
+    ];
+    let env_vars = vec![("SOLX_OPTIMIZATION", "99".to_string())];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result.success().stdout(
+    predicate::str::contains("Error: Invalid value \'99\' for environment variable \'SOLX_OPTIMIZATION\': values 1, 2, 3, s, z are supported.")
+    );
 
     Ok(())
 }

--- a/solx/tests/cli/optimization_size_fallback.rs
+++ b/solx/tests/cli/optimization_size_fallback.rs
@@ -23,6 +23,21 @@ fn default() -> anyhow::Result<()> {
 }
 
 #[test]
+fn with_env_var() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[crate::common::TEST_SOLIDITY_CONTRACT_PATH, "--bin"];
+    let env_vars = vec![("SOLX_OPTIMIZATION_SIZE_FALLBACK", "true".to_owned())];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("Binary:\n"));
+
+    Ok(())
+}
+
+#[test]
 fn standard_json() -> anyhow::Result<()> {
     crate::common::setup()?;
 


### PR DESCRIPTION
# What ❔

Adds environment variables for solx-specific CLI and standard JSON parameters:

1. `SOLX_DEBUG_OUTPUT_DIR`: allows dumping LLVM IR and other IRs while using toolkits such as Foundry or Hardhat.
2. `EVM_DISABLE_MEMORY_SAFE_ASM_CHECK`: disables the stack-too-deep/unsafe-assembly showstopper when the user knows what they are doing. 
3. `SOLX_OPTIMIZATION`: allows setting the optimization level while using toolkits such as Foundry or Hardhat.
4. `SOLX_OPTIMIZATION_SIZE_FALLBACK`: allows enabling the size optimization fallback while using toolkits such as Foundry or Hardhat.

## Why ❔

solx will be mostly used from upstream Foundry and Hardhat. They cannot pass arbitrary parameters to solx, so this solution will temporarily unlock the full power that we can provide at the moment.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
