### PR TITLE
ci: reduce number of run iterations for benchmarks to 20

### DIFF
--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -17,6 +17,7 @@
 [openzeppelin]
 repo = "https://github.com/OpenZeppelin/openzeppelin-contracts"
 description = "A library for secure smart contract development."
+run_iterations = 5 # OpenZeppelin is a large project, so we run fewer iterations
 
 [lil-web3]
 repo = "https://github.com/m1guelpf/lil-web3"

--- a/.github/workflows/foundry-benchmarks.yaml
+++ b/.github/workflows/foundry-benchmarks.yaml
@@ -109,7 +109,7 @@ jobs:
       (needs.build-solx.result == 'skipped' || needs.build-solx.result == 'success')
     runs-on: matterlabs-ci-runner-high-performance
     env:
-      DEFAULT_ITERATIONS: 50
+      DEFAULT_ITERATIONS: 20
     outputs:
       solx-version: ${{ steps.solx.outputs.solx-version }}
       solx-llvm-version: ${{ steps.solx.outputs.solx-llvm-version }}


### PR DESCRIPTION
# What ❔

* [x] Reduce number of run iterations for benchmarks to 20
* [x] Use 5 iterations for openzeppelin as it takes 50 minutes to run one config for it

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To optimize benchmarks runtime.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
