### PR TITLE
fix: make EVMLA block predecessors ordered again

### DIFF
--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -4,7 +4,7 @@
 
 pub mod element;
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use num::Zero;
 
@@ -26,7 +26,7 @@ pub struct Block {
     /// The block elements relevant to the stack consistency.
     pub elements: Vec<Element>,
     /// The block predecessors.
-    pub predecessors: HashSet<(era_compiler_llvm_context::BlockKey, usize)>,
+    pub predecessors: BTreeSet<(era_compiler_llvm_context::BlockKey, usize)>,
     /// The initial stack state.
     pub initial_stack: ElementStack,
     /// The stack.
@@ -38,8 +38,6 @@ pub struct Block {
 impl Block {
     /// The elements vector initial capacity.
     pub const ELEMENTS_VECTOR_DEFAULT_CAPACITY: usize = 64;
-    /// The predecessors hashset initial capacity.
-    pub const PREDECESSORS_HASHSET_DEFAULT_CAPACITY: usize = 4;
 
     ///
     /// Assembles a block from the sequence of instructions.
@@ -69,7 +67,7 @@ impl Block {
             key: era_compiler_llvm_context::BlockKey::new(code_segment, tag),
             instance: None,
             elements: Vec::with_capacity(Self::ELEMENTS_VECTOR_DEFAULT_CAPACITY),
-            predecessors: HashSet::with_capacity(Self::PREDECESSORS_HASHSET_DEFAULT_CAPACITY),
+            predecessors: BTreeSet::new(),
             initial_stack: ElementStack::new(),
             stack: ElementStack::new(),
             extra_hashes: vec![],


### PR DESCRIPTION
# What ❔

Uses an ordered `BTreeSet` for EVM assembly block predecessors.

## Why ❔

`HashSet` causes indeterministic output in debug mode.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
