### PR TITLE
chore: unhardcode remaining file extensions that mimic solc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -519,7 +519,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "era-compiler-common"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#59e8048671cf86341d3f330d8fa57354ad33db81"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#c7c7cb3d92f1c185daa52f7868594763385085e9"
 dependencies = [
  "anyhow",
  "base58",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#1dd5c4406071615fdc62ac924751b92e43906b4c"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#b3561785768dd56f41008dd3ff8242398c4e0dea"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1992,9 +1992,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -491,7 +491,7 @@ Sets the optimization level to `z` for contracts that failed to compile due to o
 
 Under the hood, this option automatically triggers recompilation of contracts with level `z`. Contracts that were successfully compiled with [the original `--optimization` setting](#--optimization---o) are not recompiled.
 
-> For deployment, it is recommended not to disable this option in order to mitigate potential issues with EVM bytecode size constraints.
+> For deployment, it is recommended to have this option enabled in order to mitigate potential issues with EVM bytecode size constraints on a per-contract basis.
 > If your environment does not have bytecode size limitations, it is better to disable it to prevent unnecessary recompilations.
 
 Usage:
@@ -758,10 +758,12 @@ Simple.sol_Test.evmla
 Simple.sol_Test.ethir
 Simple.sol_Test.unoptimized.ll
 Simple.sol_Test.optimized.ll
+Simple.sol_Test.asm
 Simple.sol_Test.runtime.evmla
 Simple.sol_Test.runtime.ethir
 Simple.sol_Test.runtime.unoptimized.ll
 Simple.sol_Test.runtime.optimized.ll
+Simple.sol_Test.runtime.asm
 ```
 
 The output file name is constructed as follows: `<ContractPath>_<ContractName>.<Modifiers>.<Extension>`.

--- a/solx/src/build/contract/mod.rs
+++ b/solx/src/build/contract/mod.rs
@@ -388,8 +388,9 @@ impl Contract {
             solx_standard_json::InputSelector::ABI,
         ) {
             let output_name = format!(
-                "{contract_path}_{}.abi",
+                "{contract_path}_{}.{}",
                 self.name.name.as_deref().unwrap_or(contract_name),
+                era_compiler_common::EXTENSION_SOLIDITY_ABI,
             );
             let mut output_path = output_directory.to_owned();
             output_path.push(output_name.as_str());
@@ -404,8 +405,9 @@ impl Contract {
             solx_standard_json::InputSelector::MethodIdentifiers,
         ) {
             let output_name = format!(
-                "{contract_path}_{}.signatures",
+                "{contract_path}_{}.{}",
                 self.name.name.as_deref().unwrap_or(contract_name),
+                era_compiler_common::EXTENSION_SOLIDITY_SIGNATURES,
             );
             let mut output_path = output_directory.to_owned();
             output_path.push(output_name.as_str());
@@ -462,8 +464,9 @@ impl Contract {
             solx_standard_json::InputSelector::DeveloperDocumentation,
         ) {
             let output_name = format!(
-                "{contract_path}_{}.docdev",
+                "{contract_path}_{}.{}",
                 self.name.name.as_deref().unwrap_or(contract_name),
+                era_compiler_common::EXTENSION_SOLIDITY_DOCDEV,
             );
             let mut output_path = output_directory.to_owned();
             output_path.push(output_name.as_str());
@@ -477,8 +480,9 @@ impl Contract {
             solx_standard_json::InputSelector::UserDocumentation,
         ) {
             let output_name = format!(
-                "{contract_path}_{}.docuser",
+                "{contract_path}_{}.{}",
                 self.name.name.as_deref().unwrap_or(contract_name),
+                era_compiler_common::EXTENSION_SOLIDITY_DOCUSER,
             );
             let mut output_path = output_directory.to_owned();
             output_path.push(output_name.as_str());

--- a/solx/src/build/mod.rs
+++ b/solx/src/build/mod.rs
@@ -237,7 +237,11 @@ impl Build {
                 .to_string_lossy()
                 .replace(['\\', '/'], "_");
 
-                let output_name = format!("{path}_{}.ast", era_compiler_common::EXTENSION_JSON);
+                let output_name = format!(
+                    "{path}_{}.{}",
+                    era_compiler_common::EXTENSION_JSON,
+                    era_compiler_common::EXTENSION_SOLIDITY_AST
+                );
                 let mut output_path = output_directory.to_owned();
                 output_path.push(output_name.as_str());
 


### PR DESCRIPTION
Unhardcodes some `--output-directory` file extensions.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
