### PR TITLE
ci: add more Foundry projects for benchmarking

### DIFF
--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -135,3 +135,4 @@ run_iterations = 5 # the project is large
 repo = "https://github.com/lidofinance/core"
 description = "Lido DAO smart contracts"
 run_iterations = 5 # the project is large
+disabled = true # written in Solidity v0.4

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -116,7 +116,8 @@ description = "A private on-chain voting protocol based on homomorphic time-lock
 [seaport]
 repo = "https://github.com/ProjectOpenSea/seaport"
 description = "A marketplace protocol for safely and efficiently buying and selling NFTs."
-run_iterations = 1 # the project is large
+category = "huge"
+disabled = true # compilation hangs, required to disable fuzzing tests
 
 [lens]
 repo = "https://github.com/lens-protocol/core"

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -107,7 +107,7 @@ description = "A new paradigm in DAO governance."
 repo = "https://github.com/aave-dao/aave-v3-origin"
 description = "A non-custodial liquidity protocol on Ethereum."
 requires_yarn = true
-run_iterations = 5 # Aave v3 is a large project
+run_iterations = 5 # the project is large
 
 [cicada]
 repo = "https://github.com/a16z/cicada"
@@ -124,3 +124,15 @@ repo = "https://github.com/lens-protocol/core"
 description = "Lens protocol, non-custodial social graph."
 category = "huge"
 disabled = true # compilation is too long
+
+[morpho-blue]
+repo = "https://github.com/morpho-org/morpho-blue"
+description = "Morpho Blue Protocol"
+requires_yarn = true
+run_iterations = 5 # the project is large
+
+[lido-core]
+repo = "https://github.com/lidofinance/core"
+description = "Lido DAO smart contracts"
+requires_yarn = true
+run_iterations = 5 # the project is large

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -116,8 +116,7 @@ description = "A private on-chain voting protocol based on homomorphic time-lock
 [seaport]
 repo = "https://github.com/ProjectOpenSea/seaport"
 description = "A marketplace protocol for safely and efficiently buying and selling NFTs."
-category = "huge"
-disabled = true # compilation hangs, required to disable fuzzing tests
+run_iterations = 1 # the project is large
 
 [lens]
 repo = "https://github.com/lens-protocol/core"

--- a/.github/forge-benchmarks.toml
+++ b/.github/forge-benchmarks.toml
@@ -134,5 +134,4 @@ run_iterations = 5 # the project is large
 [lido-core]
 repo = "https://github.com/lidofinance/core"
 description = "Lido DAO smart contracts"
-requires_yarn = true
 run_iterations = 5 # the project is large


### PR DESCRIPTION
# What ❔

Adds more projects for benchmarking:
1. morpho-blue
2. lido-core (turned off because written in solc v0.4)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
