### PR TITLE
feat: add an env var to dump input JSON

### DIFF
--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -773,6 +773,13 @@ SOLX_DEBUG_OUTPUT_DIR='./debug/' solx 'Simple.sol' --bin
 ls './debug/'
 ```
 
+Additionally, it is possible to dump the standard JSON input file with the `SOLX_STANDARD_JSON_DEBUG` environment variable:
+
+```bash
+SOLX_STANDARD_JSON_DEBUG='./debug/input.json' solx 'Simple.sol' --bin
+cat './debug/input.json' | jq .
+```
+
 Output:
 
 ```text

--- a/solx-standard-json/src/input/mod.rs
+++ b/solx-standard-json/src/input/mod.rs
@@ -49,6 +49,12 @@ impl Input {
             None => std::io::read_to_string(std::io::stdin())
                 .map_err(|error| anyhow::anyhow!("Standard JSON reading from stdin: {error}")),
         }?;
+        // TODO: write docs
+        if let Ok(output_path) = std::env::var("SOLX_STANDARD_JSON_DEBUG") {
+            std::fs::write(output_path.as_str(), input_json.as_str()).map_err(|error| {
+                anyhow::anyhow!("Standard JSON input debug file `{output_path}` writing: {error}")
+            })?;
+        }
         era_compiler_common::deserialize_from_str::<Self>(input_json.as_str())
             .map_err(|error| anyhow::anyhow!("Standard JSON parsing: {error}"))
     }

--- a/solx-standard-json/src/input/mod.rs
+++ b/solx-standard-json/src/input/mod.rs
@@ -49,7 +49,6 @@ impl Input {
             None => std::io::read_to_string(std::io::stdin())
                 .map_err(|error| anyhow::anyhow!("Standard JSON reading from stdin: {error}")),
         }?;
-        // TODO: write docs
         if let Ok(output_path) = std::env::var("SOLX_STANDARD_JSON_DEBUG") {
             std::fs::write(output_path.as_str(), input_json.as_str()).map_err(|error| {
                 anyhow::anyhow!("Standard JSON input debug file `{output_path}` writing: {error}")

--- a/solx/tests/cli/debug_output_dir.rs
+++ b/solx/tests/cli/debug_output_dir.rs
@@ -2,6 +2,8 @@
 //! CLI tests for the eponymous option.
 //!
 
+use std::path::PathBuf;
+
 use tempfile::TempDir;
 
 #[test]
@@ -101,6 +103,33 @@ fn standard_json() -> anyhow::Result<()> {
 
     let result = crate::cli::execute_solx(args)?;
     result.success();
+
+    Ok(())
+}
+
+#[test]
+fn standard_json_debug() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let output_directory = TempDir::with_prefix("solx_output")?;
+
+    let mut input_json_output_path = output_directory.path().to_path_buf();
+    input_json_output_path.push("input.json");
+
+    let args = &[
+        "--standard-json",
+        crate::common::TEST_SOLIDITY_STANDARD_JSON_PATH,
+    ];
+    let env_vars = vec![(
+        "SOLX_STANDARD_JSON_DEBUG",
+        input_json_output_path.to_string_lossy().to_string(),
+    )];
+
+    let result = crate::cli::execute_solx_with_env_vars(args, env_vars)?;
+    result.success();
+
+    assert!(output_directory.path().exists());
+    assert!(PathBuf::from(input_json_output_path).exists());
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

Introduces an env var for dumping of standard JSON input.

## Why ❔

It is useful for debugging and benchmarking of large projects.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
