### PR TITLE
feat: add a metadata size hint for LLVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#78ecfae4cef4ebc0d42aab71c349f316a1f6ee88"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-add-metadata-size-hint#6049fbe58dc99f754f270f962912c28281ae84f7"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/solx-evm-assembly/Cargo.toml
+++ b/solx-evm-assembly/Cargo.toml
@@ -22,7 +22,7 @@ num = "0.4"
 
 solx-yul = { path = "../solx-yul" }
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-add-metadata-size-hint" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -29,7 +29,7 @@ semver = { version = "1.0", features = [ "serde" ] }
 hex = "0.4"
 num = "0.4"
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-add-metadata-size-hint" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 solx-solc = { path = "../solx-solc" }

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -101,12 +101,16 @@ impl Contract {
         output_selection: solx_standard_json::InputSelection,
         immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
         metadata_bytes: Option<Vec<u8>>,
-        optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        mut optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Result<EVMContractObject, Error> {
         use era_compiler_llvm_context::EVMWriteLLVM;
         let mut profiler = era_compiler_llvm_context::EVMProfiler::default();
+
+        if let Some(ref metadata_bytes) = metadata_bytes {
+            optimizer_settings.set_metadata_size(metadata_bytes.len() as u64);
+        }
 
         let solc_version = solx_solc::Compiler::default().version;
         let solidity_data = era_compiler_llvm_context::EVMContextSolidityData::new(immutables);


### PR DESCRIPTION
# What ❔

Passes the metadata size to LLVM.

## Why ❔

It can be used for the estimation of final bytecode size.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
