### PR TITLE
chore: migrate era-compiler-llvm-context as solx-codegen-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,12 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,22 +108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
@@ -138,34 +120,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -176,7 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -217,22 +178,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -334,32 +283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,18 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,17 +365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,9 +386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -498,44 +396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "equivalent"
@@ -561,23 +425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "era-compiler-llvm-context"
-version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#f4c7a283d9dc9e16652edbfb8a11de82d7774098"
-dependencies = [
- "anyhow",
- "era-compiler-common",
- "indexmap",
- "inkwell",
- "itertools",
- "num",
- "semver",
- "serde",
- "thiserror 2.0.16",
- "zkevm_opcode_defs",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,47 +435,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "filetime"
@@ -643,18 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,12 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,18 +469,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -700,18 +480,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
+ "wasi",
 ]
 
 [[package]]
@@ -741,53 +510,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "indexmap"
@@ -844,7 +566,7 @@ dependencies = [
  "filetime",
  "multihash",
  "quick-protobuf",
- "sha2 0.9.9",
+ "sha2",
 ]
 
 [[package]]
@@ -867,20 +589,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2 0.10.8",
- "signature",
-]
 
 [[package]]
 name = "keccak"
@@ -960,7 +668,7 @@ dependencies = [
  "blake2s_simd",
  "digest 0.9.0",
  "sha-1",
- "sha2 0.9.9",
+ "sha2",
  "sha3 0.9.1",
  "unsigned-varint 0.5.1",
 ]
@@ -1072,69 +780,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
-dependencies = [
- "arrayvec 0.7.6",
- "bitvec",
- "byte-slice-cast",
- "const_format",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "rustversion",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1173,37 +822,6 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -1249,40 +867,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1292,16 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1310,7 +892,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1378,32 +960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
-name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,30 +973,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "semver"
@@ -1529,17 +1065,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,25 +1093,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "solx"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "ciborium",
  "clap",
  "era-compiler-common",
- "era-compiler-llvm-context",
  "hex",
  "inkwell",
  "normpath",
@@ -1597,6 +1111,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "solx-codegen-evm",
  "solx-evm-assembly",
  "solx-solc",
  "solx-standard-json",
@@ -1607,26 +1122,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "solx-codegen-evm"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "era-compiler-common",
+ "indexmap",
+ "inkwell",
+ "itertools",
+ "num",
+ "semver",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "solx-evm-assembly"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ciborium",
  "era-compiler-common",
- "era-compiler-llvm-context",
  "hex",
  "inkwell",
  "num",
  "rayon",
  "semver",
  "serde",
+ "solx-codegen-evm",
  "solx-yul",
  "twox-hash",
 ]
 
 [[package]]
 name = "solx-solc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1639,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "solx-standard-json"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1653,22 +1183,12 @@ dependencies = [
 
 [[package]]
 name = "solx-yul"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
  "serde",
  "thiserror 2.0.16",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -1685,22 +1205,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1714,19 +1222,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -1812,38 +1314,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "twox-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 dependencies = [
- "rand 0.9.2",
+ "rand",
 ]
 
 [[package]]
@@ -1853,28 +1329,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsigned-varint"
@@ -1908,12 +1366,6 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2078,28 +1530,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "winnow"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "zerocopy"
@@ -2119,27 +1553,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "0.150.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762b5f1c1b283c5388995a85d40a05aef1c14f50eb904998b7e9364739f5b899"
-dependencies = [
- "bitflags",
- "blake2",
- "ethereum-types",
- "k256",
- "lazy_static",
- "p256",
- "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
 members = [
     "solx",
+    "solx-solc",
+    "solx-standard-json",
     "solx-evm-assembly",
     "solx-yul",
-    "solx-standard-json",
-    "solx-solc",
+    "solx-codegen-evm",
 ]
 resolver = "2"
 
@@ -13,4 +14,4 @@ authors = [
     "The Matter Labs Team <hello@matterlabs.dev>",
 ]
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For reference, see [llvm-sys](https://crates.io/crates/llvm-sys) and [Local LLVM
 ## License
 
 - Crates **solx** and **solx-solc** are licensed under [GNU General Public License v3.0](./solx/LICENSE.txt)
-- Crates **solx-standard-json**, **solx-evm-assembly**, **solx-yul** are licensed under the terms of either
+- Crates **solx-standard-json**, **solx-evm-assembly**, **solx-yul**, **solx-codegen-evm** are licensed under the terms of either
   - Apache License, Version 2.0 ([LICENSE-APACHE](./solx-standard-json/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
   - MIT license ([LICENSE-MIT](./solx-standard-json/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 - [`era-solidity`](https://github.com/matter-labs/era-solidity/) is licensed under [GNU General Public License v3.0](https://github.com/matter-labs/era-solidity/blob/0.8.30/LICENSE.txt)

--- a/solx-codegen-evm/Cargo.toml
+++ b/solx-codegen-evm/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solx-codegen-evm"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+description = "EVM codegen for solx"
+license = "MIT OR Apache-2.0"
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = "1.0"
+thiserror = "2.0"
+semver = "1.0"
+serde = { version = "1.0", features = [ "derive" ] }
+num = "0.4"
+itertools = "0.14"
+indexmap = { version = "2.11", features = ["serde"] }
+
+era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
+
+[dependencies.inkwell]
+git = "https://github.com/matter-labs-forks/inkwell"
+branch = "llvm-19"
+default-features = false
+features = ["llvm19-1", "serde", "no-libffi-linking", "target-evm"]

--- a/solx-codegen-evm/LICENSE-APACHE
+++ b/solx-codegen-evm/LICENSE-APACHE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/solx-codegen-evm/LICENSE-MIT
+++ b/solx-codegen-evm/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Matter Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/solx-codegen-evm/src/codegen/attribute.rs
+++ b/solx-codegen-evm/src/codegen/attribute.rs
@@ -1,0 +1,33 @@
+//!
+//! The EVM string attribute.
+//!
+
+///
+/// The EVM string attribute.
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum Attribute {
+    /// The corresponding value.
+    EVMEntryFunction,
+}
+
+impl std::str::FromStr for Attribute {
+    type Err = anyhow::Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        match string {
+            "evm-entry-function" => Ok(Attribute::EVMEntryFunction),
+            _ => anyhow::bail!("Unknown attribute: {string}"),
+        }
+    }
+}
+
+impl std::fmt::Display for Attribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Attribute::EVMEntryFunction => write!(f, "evm-entry-function"),
+        }
+    }
+}

--- a/solx-codegen-evm/src/codegen/build.rs
+++ b/solx-codegen-evm/src/codegen/build.rs
@@ -1,0 +1,46 @@
+//!
+//! The LLVM module build.
+//!
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use crate::codegen::warning::Warning;
+
+///
+/// The LLVM module build.
+///
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Build {
+    /// Bytecode.
+    pub bytecode: Option<Vec<u8>>,
+    /// Text assembly.
+    pub assembly: Option<String>,
+    /// Mapping with immutables.
+    pub immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
+    /// Whether the size fallback has been activated.
+    pub is_size_fallback: bool,
+    /// Warnings produced during compilation.
+    pub warnings: Vec<Warning>,
+}
+
+impl Build {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        bytecode: Option<Vec<u8>>,
+        assembly: Option<String>,
+        immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
+        is_size_fallback: bool,
+        warnings: Vec<Warning>,
+    ) -> Self {
+        Self {
+            bytecode,
+            assembly,
+            immutables,
+            is_size_fallback,
+            warnings,
+        }
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/address_space.rs
+++ b/solx-codegen-evm/src/codegen/context/address_space.rs
@@ -1,0 +1,46 @@
+//!
+//! The address space aliases.
+//!
+
+use crate::context::traits::address_space::IAddressSpace;
+
+///
+/// The address space aliases.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AddressSpace {
+    /// The stack memory.
+    Stack,
+    /// The heap memory.
+    Heap,
+    /// The calldata memory.
+    Calldata,
+    /// The return data memory.
+    ReturnData,
+    /// The code memory.
+    Code,
+    /// The storage.
+    Storage,
+    /// The transient storage.
+    TransientStorage,
+}
+
+impl IAddressSpace for AddressSpace {
+    fn stack() -> Self {
+        Self::Stack
+    }
+}
+
+impl From<AddressSpace> for inkwell::AddressSpace {
+    fn from(value: AddressSpace) -> Self {
+        match value {
+            AddressSpace::Stack => Self::from(0),
+            AddressSpace::Heap => Self::from(1),
+            AddressSpace::Calldata => Self::from(2),
+            AddressSpace::ReturnData => Self::from(3),
+            AddressSpace::Code => Self::from(4),
+            AddressSpace::Storage => Self::from(5),
+            AddressSpace::TransientStorage => Self::from(6),
+        }
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/evmla_data.rs
+++ b/solx-codegen-evm/src/codegen/context/evmla_data.rs
@@ -1,0 +1,49 @@
+//!
+//! The LLVM IR generator EVM legacy assembly data.
+//!
+
+use crate::context::traits::evmla_data::IEVMLAData;
+use crate::context::value::Value;
+
+///
+/// The LLVM IR generator EVM legacy assembly data.
+///
+/// Describes some data that is only relevant to the EVM legacy assembly.
+///
+#[derive(Debug, Clone)]
+pub struct EVMLAData<'ctx> {
+    /// The Solidity compiler version.
+    /// Some instruction behave differenly depending on the version.
+    pub version: semver::Version,
+    /// The static stack allocated for the current function.
+    pub stack: Vec<Value<'ctx>>,
+}
+
+impl EVMLAData<'_> {
+    /// The default stack size.
+    pub const DEFAULT_STACK_SIZE: usize = 64;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(version: semver::Version) -> Self {
+        Self {
+            version,
+            stack: Vec::with_capacity(Self::DEFAULT_STACK_SIZE),
+        }
+    }
+}
+
+impl<'ctx> IEVMLAData<'ctx> for EVMLAData<'ctx> {
+    fn get_element(&self, position: usize) -> &Value<'ctx> {
+        &self.stack[position]
+    }
+
+    fn set_element(&mut self, position: usize, value: Value<'ctx>) {
+        self.stack[position] = value;
+    }
+
+    fn set_original(&mut self, position: usize, original: String) {
+        self.stack[position].original = Some(original);
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/function/intrinsics.rs
+++ b/solx-codegen-evm/src/codegen/context/function/intrinsics.rs
@@ -1,0 +1,974 @@
+//!
+//! The LLVM intrinsic functions.
+//!
+
+use inkwell::types::BasicType;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::context::function::declaration::Declaration as FunctionDeclaration;
+
+///
+/// The LLVM intrinsic functions, implemented in the LLVM back-end.
+///
+/// Most of them are translated directly into bytecode instructions.
+///
+#[derive(Debug)]
+pub struct Intrinsics<'ctx> {
+    /// The corresponding intrinsic function name.
+    pub exp: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub signextend: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub sha3: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub addmod: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub mulmod: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub byte: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub mstore8: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub msize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub calldatasize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub returndatasize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub codesize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub extcodesize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub extcodecopy: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub extcodehash: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub datasize: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub dataoffset: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub linkersymbol: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub loadimmutable: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub pushdeployaddress: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub log0: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub log1: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub log2: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub log3: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub log4: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub call: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub staticcall: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub delegatecall: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub callcode: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub create: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub create2: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub address: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub caller: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub balance: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub selfbalance: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub callvalue: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub gas: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub gasprice: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub gaslimit: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub blockhash: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub coinbase: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub basefee: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub timestamp: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub number: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub chainid: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub origin: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub difficulty: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub r#return: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub revert: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub stop: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub invalid: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub selfdestruct: FunctionDeclaration<'ctx>,
+
+    /// The corresponding intrinsic function name.
+    pub memory_move_heap: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub memory_copy_from_calldata: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub memory_copy_from_return_data: FunctionDeclaration<'ctx>,
+    /// The corresponding intrinsic function name.
+    pub memory_copy_from_code: FunctionDeclaration<'ctx>,
+}
+
+impl<'ctx> Intrinsics<'ctx> {
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_EXP: &'static str = "llvm.evm.exp";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_SIGNEXTEND: &'static str = "llvm.evm.signextend";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_SHA3: &'static str = "llvm.evm.sha3";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_ADDMOD: &'static str = "llvm.evm.addmod";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MULMOD: &'static str = "llvm.evm.mulmod";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_BYTE: &'static str = "llvm.evm.byte";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MSTORE8: &'static str = "llvm.evm.mstore8";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MSIZE: &'static str = "llvm.evm.msize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CALLDATASIZE: &'static str = "llvm.evm.calldatasize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_RETURNDATASIZE: &'static str = "llvm.evm.returndatasize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CODESIZE: &'static str = "llvm.evm.codesize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_EXTCODESIZE: &'static str = "llvm.evm.extcodesize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_EXTCODECOPY: &'static str = "llvm.evm.extcodecopy";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_EXTCODEHASH: &'static str = "llvm.evm.extcodehash";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_DATASIZE: &'static str = "llvm.evm.datasize";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_DATAOFFSET: &'static str = "llvm.evm.dataoffset";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LINKER_SYMBOL: &'static str = "llvm.evm.linkersymbol";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOAD_IMMUTABLE: &'static str = "llvm.evm.loadimmutable";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_PUSH_DEPLOY_ADDRESS: &'static str = "llvm.evm.pushdeployaddress";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOG0: &'static str = "llvm.evm.log0";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOG1: &'static str = "llvm.evm.log1";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOG2: &'static str = "llvm.evm.log2";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOG3: &'static str = "llvm.evm.log3";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_LOG4: &'static str = "llvm.evm.log4";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CALL: &'static str = "llvm.evm.call";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_STATICCALL: &'static str = "llvm.evm.staticcall";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_DELEGATECALL: &'static str = "llvm.evm.delegatecall";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CODECALL: &'static str = "llvm.evm.callcode";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CREATE: &'static str = "llvm.evm.create";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CREATE2: &'static str = "llvm.evm.create2";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_ADDRESS: &'static str = "llvm.evm.address";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CALLER: &'static str = "llvm.evm.caller";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_BALANCE: &'static str = "llvm.evm.balance";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_SELFBALANCE: &'static str = "llvm.evm.selfbalance";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CALLVALUE: &'static str = "llvm.evm.callvalue";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_GAS: &'static str = "llvm.evm.gas";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_GASPRICE: &'static str = "llvm.evm.gasprice";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_GASLIMIT: &'static str = "llvm.evm.gaslimit";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_BLOCKHASH: &'static str = "llvm.evm.blockhash";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_COINBASE: &'static str = "llvm.evm.coinbase";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_BASEFEE: &'static str = "llvm.evm.basefee";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_TIMESTAMP: &'static str = "llvm.evm.timestamp";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_NUMBER: &'static str = "llvm.evm.number";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_CHAINID: &'static str = "llvm.evm.chainid";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_ORIGIN: &'static str = "llvm.evm.origin";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_DIFFICULTY: &'static str = "llvm.evm.difficulty";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_RETURN: &'static str = "llvm.evm.return";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_REVERT: &'static str = "llvm.evm.revert";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_STOP: &'static str = "llvm.evm.stop";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_INVALID: &'static str = "llvm.evm.invalid";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_SELFDESTRUCT: &'static str = "llvm.evm.selfdestruct";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MEMORY_MOVE_HEAP: &'static str = "llvm.memmove.p1.p1.i256";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MEMORY_COPY_FROM_CALLDATA: &'static str = "llvm.memcpy.p1.p2.i256";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MEMORY_COPY_FROM_RETURN_DATA: &'static str = "llvm.memcpy.p1.p3.i256";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_MEMORY_COPY_FROM_CODE: &'static str = "llvm.memcpy.p1.p4.i256";
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        llvm: &'ctx inkwell::context::Context,
+        module: &inkwell::module::Module<'ctx>,
+    ) -> Self {
+        let void_type = llvm.void_type();
+        let bool_type = llvm.bool_type();
+        let field_type = llvm.custom_width_int_type(era_compiler_common::BIT_LENGTH_FIELD as u32);
+
+        let heap_byte_pointer_type = llvm.ptr_type(AddressSpace::Heap.into());
+        let calldata_byte_pointer_type = llvm.ptr_type(AddressSpace::Calldata.into());
+        let return_data_byte_pointer_type = llvm.ptr_type(AddressSpace::ReturnData.into());
+        let code_byte_pointer_type = llvm.ptr_type(AddressSpace::Code.into());
+
+        let exp = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_EXP,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let signextend = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_SIGNEXTEND,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let sha3 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_SHA3,
+            field_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let addmod = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_ADDMOD,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let mulmod = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MULMOD,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let byte = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_BYTE,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+
+        let mstore8 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MSTORE8,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let msize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MSIZE,
+            field_type.fn_type(&[], false),
+        );
+        let calldatasize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CALLDATASIZE,
+            field_type.fn_type(&[], false),
+        );
+        let returndatasize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_RETURNDATASIZE,
+            field_type.fn_type(&[], false),
+        );
+        let codesize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CODESIZE,
+            field_type.fn_type(&[], false),
+        );
+        let extcodesize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_EXTCODESIZE,
+            field_type.fn_type(&[field_type.as_basic_type_enum().into()], false),
+        );
+        let extcodecopy = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_EXTCODECOPY,
+            void_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    code_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let extcodehash = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_EXTCODEHASH,
+            field_type.fn_type(&[field_type.as_basic_type_enum().into()], false),
+        );
+        let datasize = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_DATASIZE,
+            field_type.fn_type(&[llvm.metadata_type().into()], false),
+        );
+        let dataoffset = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_DATAOFFSET,
+            field_type.fn_type(&[llvm.metadata_type().into()], false),
+        );
+        let linkersymbol = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LINKER_SYMBOL,
+            field_type.fn_type(&[llvm.metadata_type().into()], false),
+        );
+        let loadimmutable = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOAD_IMMUTABLE,
+            field_type.fn_type(&[llvm.metadata_type().into()], false),
+        );
+        let pushdeployaddress = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_PUSH_DEPLOY_ADDRESS,
+            field_type.fn_type(&[], false),
+        );
+
+        let log0 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOG0,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let log1 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOG1,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let log2 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOG2,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let log3 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOG3,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let log4 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_LOG4,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let call = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CALL,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let staticcall = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_STATICCALL,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let delegatecall = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_DELEGATECALL,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let callcode = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CODECALL,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let create = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CREATE,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let create2 = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CREATE2,
+            field_type.fn_type(
+                &[
+                    field_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let address = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_ADDRESS,
+            field_type.fn_type(&[], false),
+        );
+        let caller = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CALLER,
+            field_type.fn_type(&[], false),
+        );
+        let balance = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_BALANCE,
+            field_type.fn_type(&[field_type.as_basic_type_enum().into()], false),
+        );
+        let selfbalance = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_SELFBALANCE,
+            field_type.fn_type(&[], false),
+        );
+        let callvalue = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CALLVALUE,
+            field_type.fn_type(&[], false),
+        );
+        let gas = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_GAS,
+            field_type.fn_type(&[], false),
+        );
+        let gasprice = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_GASPRICE,
+            field_type.fn_type(&[], false),
+        );
+        let gaslimit = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_GASLIMIT,
+            field_type.fn_type(&[], false),
+        );
+        let blockhash = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_BLOCKHASH,
+            field_type.fn_type(&[field_type.as_basic_type_enum().into()], false),
+        );
+        let coinbase = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_COINBASE,
+            field_type.fn_type(&[], false),
+        );
+        let basefee = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_BASEFEE,
+            field_type.fn_type(&[], false),
+        );
+        let timestamp = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_TIMESTAMP,
+            field_type.fn_type(&[], false),
+        );
+        let number = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_NUMBER,
+            field_type.fn_type(&[], false),
+        );
+        let chainid = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_CHAINID,
+            field_type.fn_type(&[], false),
+        );
+        let origin = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_ORIGIN,
+            field_type.fn_type(&[], false),
+        );
+        let difficulty = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_DIFFICULTY,
+            field_type.fn_type(&[], false),
+        );
+
+        let r#return = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_RETURN,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let revert = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_REVERT,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let stop = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_STOP,
+            void_type.fn_type(&[], false),
+        );
+        let invalid = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_INVALID,
+            void_type.fn_type(&[], false),
+        );
+
+        let selfdestruct = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_SELFDESTRUCT,
+            void_type.fn_type(&[field_type.as_basic_type_enum().into()], false),
+        );
+
+        let memory_move_heap = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MEMORY_MOVE_HEAP,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    bool_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let memory_copy_from_calldata = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MEMORY_COPY_FROM_CALLDATA,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    calldata_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    bool_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let memory_copy_from_return_data = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MEMORY_COPY_FROM_RETURN_DATA,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    return_data_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    bool_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+        let memory_copy_from_code = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_MEMORY_COPY_FROM_CODE,
+            void_type.fn_type(
+                &[
+                    heap_byte_pointer_type.as_basic_type_enum().into(),
+                    code_byte_pointer_type.as_basic_type_enum().into(),
+                    field_type.as_basic_type_enum().into(),
+                    bool_type.as_basic_type_enum().into(),
+                ],
+                false,
+            ),
+        );
+
+        Self {
+            exp,
+            signextend,
+            sha3,
+            addmod,
+            mulmod,
+            byte,
+
+            mstore8,
+            msize,
+            calldatasize,
+            returndatasize,
+            codesize,
+            extcodesize,
+            extcodecopy,
+            extcodehash,
+            datasize,
+            dataoffset,
+            linkersymbol,
+            loadimmutable,
+            pushdeployaddress,
+
+            log0,
+            log1,
+            log2,
+            log3,
+            log4,
+
+            call,
+            staticcall,
+            delegatecall,
+            callcode,
+
+            create,
+            create2,
+
+            address,
+            caller,
+            balance,
+            selfbalance,
+            callvalue,
+            gas,
+            gasprice,
+            gaslimit,
+            blockhash,
+            coinbase,
+            basefee,
+            timestamp,
+            number,
+            chainid,
+            origin,
+            difficulty,
+
+            r#return,
+            revert,
+            stop,
+            invalid,
+
+            selfdestruct,
+
+            memory_move_heap,
+            memory_copy_from_calldata,
+            memory_copy_from_return_data,
+            memory_copy_from_code,
+        }
+    }
+
+    ///
+    /// Finds the specified LLVM intrinsic function in the target and returns its declaration.
+    ///
+    pub fn declare(
+        llvm: &'ctx inkwell::context::Context,
+        module: &inkwell::module::Module<'ctx>,
+        name: &str,
+        r#type: inkwell::types::FunctionType<'ctx>,
+    ) -> FunctionDeclaration<'ctx> {
+        let intrinsic = inkwell::intrinsics::Intrinsic::find(name)
+            .unwrap_or_else(|| panic!("Intrinsic function `{name}` does not exist"));
+        let argument_types = Self::argument_types(llvm, name);
+        let value = intrinsic
+            .get_declaration(module, argument_types.as_slice())
+            .unwrap_or_else(|| panic!("Intrinsic function `{name}` declaration error"));
+        FunctionDeclaration::new(r#type, value)
+    }
+
+    ///
+    /// Returns the LLVM types for selecting via the signature.
+    ///
+    pub fn argument_types(
+        llvm: &'ctx inkwell::context::Context,
+        name: &str,
+    ) -> Vec<inkwell::types::BasicTypeEnum<'ctx>> {
+        let field_type = llvm.custom_width_int_type(era_compiler_common::BIT_LENGTH_FIELD as u32);
+
+        match name {
+            name if name == Self::FUNCTION_MEMORY_MOVE_HEAP => vec![
+                llvm.ptr_type(AddressSpace::Heap.into())
+                    .as_basic_type_enum(),
+                llvm.ptr_type(AddressSpace::Heap.into())
+                    .as_basic_type_enum(),
+                field_type.as_basic_type_enum(),
+            ],
+            name if name == Self::FUNCTION_MEMORY_COPY_FROM_CALLDATA => vec![
+                llvm.ptr_type(AddressSpace::Heap.into())
+                    .as_basic_type_enum(),
+                llvm.ptr_type(AddressSpace::Calldata.into())
+                    .as_basic_type_enum(),
+                field_type.as_basic_type_enum(),
+            ],
+            name if name == Self::FUNCTION_MEMORY_COPY_FROM_RETURN_DATA => vec![
+                llvm.ptr_type(AddressSpace::Heap.into())
+                    .as_basic_type_enum(),
+                llvm.ptr_type(AddressSpace::ReturnData.into())
+                    .as_basic_type_enum(),
+                field_type.as_basic_type_enum(),
+            ],
+            name if name == Self::FUNCTION_MEMORY_COPY_FROM_CODE => vec![
+                llvm.ptr_type(AddressSpace::Heap.into())
+                    .as_basic_type_enum(),
+                llvm.ptr_type(AddressSpace::Code.into())
+                    .as_basic_type_enum(),
+                field_type.as_basic_type_enum(),
+            ],
+            _ => vec![],
+        }
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/function/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/function/mod.rs
@@ -1,0 +1,362 @@
+//!
+//! The LLVM IR generator function.
+//!
+
+pub mod intrinsics;
+pub mod runtime;
+pub mod vyper_data;
+
+use std::collections::HashMap;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::context::attribute::Attribute;
+use crate::context::function::block::key::Key as BlockKey;
+use crate::context::function::block::Block;
+use crate::context::function::declaration::Declaration as FunctionDeclaration;
+use crate::context::function::evmla_data::EVMLAData as FunctionEVMLAData;
+use crate::context::function::r#return::Return as FunctionReturn;
+use crate::context::pointer::Pointer;
+use crate::context::traits::evmla_function::IEVMLAFunction;
+use crate::optimizer::settings::size_level::SizeLevel;
+use crate::optimizer::Optimizer;
+
+use self::vyper_data::VyperData;
+
+///
+/// The LLVM IR generator function.
+///
+#[derive(Debug)]
+pub struct Function<'ctx> {
+    /// The high-level source code name.
+    name: String,
+    /// The LLVM function declaration.
+    declaration: FunctionDeclaration<'ctx>,
+    /// The stack representation.
+    stack: HashMap<String, Pointer<'ctx, AddressSpace>>,
+    /// The return value entity.
+    r#return: FunctionReturn<'ctx, AddressSpace>,
+
+    /// The entry block. Each LLVM IR functions must have an entry block.
+    entry_block: inkwell::basic_block::BasicBlock<'ctx>,
+    /// The return/leave block. LLVM IR functions may have multiple returning blocks, but it is
+    /// more reasonable to have a single returning block and other high-level language returns
+    /// jumping to it. This way it is easier to implement some additional checks and clean-ups
+    /// before the returning.
+    return_block: inkwell::basic_block::BasicBlock<'ctx>,
+
+    /// The EVM legacy assembly compiler data.
+    evmla_data: Option<FunctionEVMLAData<'ctx>>,
+    /// The Vyper data.
+    vyper_data: Option<VyperData>,
+}
+
+impl<'ctx> Function<'ctx> {
+    /// The near call ABI function prefix.
+    pub const ZKSYNC_NEAR_CALL_ABI_PREFIX: &'static str = "ZKSYNC_NEAR_CALL";
+
+    /// The near call ABI exception handler name.
+    pub const ZKSYNC_NEAR_CALL_ABI_EXCEPTION_HANDLER: &'static str = "ZKSYNC_CATCH_NEAR_CALL";
+
+    /// The stack hashmap default capacity.
+    const STACK_HASHMAP_INITIAL_CAPACITY: usize = 64;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        name: String,
+        declaration: FunctionDeclaration<'ctx>,
+        r#return: FunctionReturn<'ctx, AddressSpace>,
+
+        entry_block: inkwell::basic_block::BasicBlock<'ctx>,
+        return_block: inkwell::basic_block::BasicBlock<'ctx>,
+    ) -> Self {
+        Self {
+            name,
+            declaration,
+            stack: HashMap::with_capacity(Self::STACK_HASHMAP_INITIAL_CAPACITY),
+            r#return,
+
+            entry_block,
+            return_block,
+
+            evmla_data: None,
+            vyper_data: None,
+        }
+    }
+
+    ///
+    /// Returns the function name reference.
+    ///
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    ///
+    /// Checks whether the function is defined outside of the front-end.
+    ///
+    pub fn is_name_external(name: &str) -> bool {
+        name.starts_with("llvm.")
+            || (name.starts_with("__") && name != crate::r#const::ENTRY_FUNCTION_NAME)
+    }
+
+    ///
+    /// Returns the LLVM function declaration.
+    ///
+    pub fn declaration(&self) -> FunctionDeclaration<'ctx> {
+        self.declaration
+    }
+
+    ///
+    /// Returns the N-th parameter of the function.
+    ///
+    pub fn get_nth_param(&self, index: usize) -> inkwell::values::BasicValueEnum<'ctx> {
+        self.declaration()
+            .value
+            .get_nth_param(index as u32)
+            .expect("Always exists")
+    }
+
+    ///
+    /// Sets the default attributes.
+    ///
+    /// The attributes only affect the LLVM optimizations.
+    ///
+    pub fn set_default_attributes(
+        llvm: &'ctx inkwell::context::Context,
+        declaration: FunctionDeclaration<'ctx>,
+        optimizer: &Optimizer,
+    ) {
+        if optimizer.settings().level_middle_end_size == SizeLevel::Z {
+            declaration.value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                llvm.create_enum_attribute(Attribute::OptimizeForSize as u32, 0),
+            );
+            declaration.value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                llvm.create_enum_attribute(Attribute::MinSize as u32, 0),
+            );
+        }
+
+        declaration.value.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::NoFree as u32, 0),
+        );
+        declaration.value.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::NullPointerIsValid as u32, 0),
+        );
+    }
+
+    ///
+    /// Sets the front-end runtime attributes.
+    ///
+    pub fn set_frontend_runtime_attributes(
+        llvm: &'ctx inkwell::context::Context,
+        declaration: FunctionDeclaration<'ctx>,
+        optimizer: &Optimizer,
+    ) {
+        if optimizer.settings().level_middle_end_size == SizeLevel::Z {
+            declaration.value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                llvm.create_enum_attribute(Attribute::NoInline as u32, 0),
+            );
+        }
+    }
+
+    ///
+    /// Sets the exception handler attributes.
+    ///
+    pub fn set_exception_handler_attributes(
+        llvm: &'ctx inkwell::context::Context,
+        declaration: FunctionDeclaration<'ctx>,
+    ) {
+        declaration.value.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::NoInline as u32, 0),
+        );
+    }
+
+    ///
+    /// Sets the size optimization attributes.
+    ///
+    pub fn set_size_attributes(
+        llvm: &'ctx inkwell::context::Context,
+        function: inkwell::values::FunctionValue<'ctx>,
+    ) {
+        function.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::OptimizeForSize as u32, 0),
+        );
+        function.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::MinSize as u32, 0),
+        );
+    }
+
+    ///
+    /// Saves the pointer to a stack variable, returning the pointer to the shadowed variable,
+    /// if it exists.
+    ///
+    pub fn insert_stack_pointer(
+        &mut self,
+        name: String,
+        pointer: Pointer<'ctx, AddressSpace>,
+    ) -> Option<Pointer<'ctx, AddressSpace>> {
+        self.stack.insert(name, pointer)
+    }
+
+    ///
+    /// Gets the pointer to a stack variable.
+    ///
+    pub fn get_stack_pointer(&self, name: &str) -> Option<Pointer<'ctx, AddressSpace>> {
+        self.stack.get(name).copied()
+    }
+
+    ///
+    /// Removes the pointer to a stack variable.
+    ///
+    pub fn remove_stack_pointer(&mut self, name: &str) {
+        self.stack.remove(name);
+    }
+
+    ///
+    /// Returns the return entity representation.
+    ///
+    pub fn r#return(&self) -> FunctionReturn<'ctx, AddressSpace> {
+        self.r#return
+    }
+
+    ///
+    /// Returns the pointer to the function return value.
+    ///
+    /// # Panics
+    /// If the pointer has not been set yet.
+    ///
+    pub fn return_pointer(&self) -> Option<Pointer<'ctx, AddressSpace>> {
+        self.r#return.return_pointer()
+    }
+
+    ///
+    /// Returns the return data size in bytes, based on the default stack alignment.
+    ///
+    /// # Panics
+    /// If the pointer has not been set yet.
+    ///
+    pub fn return_data_size(&self) -> usize {
+        self.r#return.return_data_size()
+    }
+
+    ///
+    /// Returns the function entry block.
+    ///
+    pub fn entry_block(&self) -> inkwell::basic_block::BasicBlock<'ctx> {
+        self.entry_block
+    }
+
+    ///
+    /// Returns the function return block.
+    ///
+    pub fn return_block(&self) -> inkwell::basic_block::BasicBlock<'ctx> {
+        self.return_block
+    }
+
+    ///
+    /// Sets the EVM legacy assembly data.
+    ///
+    pub fn set_evmla_data(&mut self, data: FunctionEVMLAData<'ctx>) {
+        self.evmla_data = Some(data);
+    }
+
+    ///
+    /// Returns the EVM legacy assembly data reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    pub fn evmla(&self) -> &FunctionEVMLAData<'ctx> {
+        self.evmla_data
+            .as_ref()
+            .expect("The EVM data must have been initialized")
+    }
+
+    ///
+    /// Returns the EVM legacy assembly data mutable reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    pub fn evmla_mut(&mut self) -> &mut FunctionEVMLAData<'ctx> {
+        self.evmla_data
+            .as_mut()
+            .expect("The EVM data must have been initialized")
+    }
+
+    ///
+    /// Sets the Vyper data.
+    ///
+    pub fn set_vyper_data(&mut self, data: VyperData) {
+        self.vyper_data = Some(data);
+    }
+
+    ///
+    /// Returns the Vyper data reference.
+    ///
+    /// # Panics
+    /// If the Vyper data has not been initialized.
+    ///
+    pub fn vyper(&self) -> &VyperData {
+        self.vyper_data
+            .as_ref()
+            .expect("The Vyper data must have been initialized")
+    }
+
+    ///
+    /// Returns the Vyper data mutable reference.
+    ///
+    /// # Panics
+    /// If the Vyper data has not been initialized.
+    ///
+    pub fn vyper_mut(&mut self) -> &mut VyperData {
+        self.vyper_data
+            .as_mut()
+            .expect("The Vyper data must have been initialized")
+    }
+}
+
+impl<'ctx> IEVMLAFunction<'ctx> for Function<'ctx> {
+    fn find_block(&self, key: &BlockKey, stack_hash: &u64) -> anyhow::Result<Block<'ctx>> {
+        let evmla_data = self.evmla();
+
+        if evmla_data
+            .blocks
+            .get(key)
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+            .len()
+            == 1
+        {
+            return evmla_data
+                .blocks
+                .get(key)
+                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key));
+        }
+
+        evmla_data
+            .blocks
+            .get(key)
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+            .iter()
+            .find(|block| {
+                block
+                    .evm()
+                    .stack_hashes
+                    .iter()
+                    .any(|hash| hash == stack_hash)
+            })
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/function/runtime/entry.rs
+++ b/solx-codegen-evm/src/codegen/context/function/runtime/entry.rs
@@ -1,0 +1,79 @@
+//!
+//! The entry function.
+//!
+
+use crate::codegen::attribute::Attribute;
+use crate::codegen::context::Context;
+use crate::codegen::WriteLLVM;
+use crate::context::IContext;
+
+///
+/// The entry function.
+///
+/// Is a special runtime function that is only used by the front-end generated code.
+///
+#[derive(Debug)]
+pub struct Entry<B>
+where
+    B: WriteLLVM,
+{
+    /// The runtime code AST representation.
+    inner: B,
+}
+
+impl<B> Entry<B>
+where
+    B: WriteLLVM,
+{
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(inner: B) -> Self {
+        Self { inner }
+    }
+}
+
+impl<B> WriteLLVM for Entry<B>
+where
+    B: WriteLLVM,
+{
+    fn declare(&mut self, context: &mut Context) -> anyhow::Result<()> {
+        let function_type = context.function_type::<inkwell::types::BasicTypeEnum>(vec![], 0);
+        let function = context.add_function(
+            crate::r#const::ENTRY_FUNCTION_NAME,
+            function_type,
+            0,
+            Some(inkwell::module::Linkage::External),
+        )?;
+        function.borrow().declaration().value.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            context
+                .llvm()
+                .create_string_attribute(Attribute::EVMEntryFunction.to_string().as_str(), ""),
+        );
+
+        self.inner.declare(context)
+    }
+
+    fn into_llvm(self, context: &mut Context) -> anyhow::Result<()> {
+        context.set_current_function(crate::r#const::ENTRY_FUNCTION_NAME)?;
+
+        context.set_basic_block(context.current_function().borrow().entry_block());
+        self.inner.into_llvm(context)?;
+        match context
+            .basic_block()
+            .get_last_instruction()
+            .map(|instruction| instruction.get_opcode())
+        {
+            Some(inkwell::values::InstructionOpcode::Br) => {}
+            Some(inkwell::values::InstructionOpcode::Switch) => {}
+            _ => context
+                .build_unconditional_branch(context.current_function().borrow().return_block())?,
+        }
+
+        context.set_basic_block(context.current_function().borrow().return_block());
+        crate::codegen::instructions::r#return::stop(context)?;
+
+        Ok(())
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/function/runtime/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/function/runtime/mod.rs
@@ -1,0 +1,5 @@
+//!
+//! The front-end runtime functions.
+//!
+
+pub mod entry;

--- a/solx-codegen-evm/src/codegen/context/function/vyper_data.rs
+++ b/solx-codegen-evm/src/codegen/context/function/vyper_data.rs
@@ -1,0 +1,52 @@
+//!
+//! The LLVM function Vyper data.
+//!
+
+use std::collections::HashMap;
+
+///
+/// The LLVM function Vyper data.
+///
+/// Describes some data that is only relevant to Vyper.
+///
+#[derive(Debug)]
+pub struct VyperData {
+    /// The block-local variables. They are still allocated at the beginning of the function,
+    /// but their parent block must be known in order to pass the implicit arguments thereto.
+    /// Is only used by the Vyper LLL IR compiler.
+    label_arguments: HashMap<String, Vec<String>>,
+}
+
+impl Default for VyperData {
+    fn default() -> Self {
+        Self {
+            label_arguments: HashMap::with_capacity(Self::LABEL_ARGUMENTS_HASHMAP_INITIAL_CAPACITY),
+        }
+    }
+}
+
+impl VyperData {
+    /// The label arguments hashmap default capacity.
+    const LABEL_ARGUMENTS_HASHMAP_INITIAL_CAPACITY: usize = 16;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    ///
+    /// Returns the list of a Vyper label arguments.
+    ///
+    pub fn label_arguments(&self, label_name: &str) -> Option<Vec<String>> {
+        self.label_arguments.get(label_name).cloned()
+    }
+
+    ///
+    /// Inserts arguments for the specified label.
+    ///
+    pub fn insert_label_arguments(&mut self, label_name: String, arguments: Vec<String>) {
+        self.label_arguments.insert(label_name, arguments);
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -1,0 +1,673 @@
+//!
+//! The LLVM IR generator context.
+//!
+
+pub mod address_space;
+pub mod evmla_data;
+pub mod function;
+pub mod solidity_data;
+pub mod yul_data;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use inkwell::types::BasicType;
+
+use crate::codegen::build::Build as EVMBuild;
+use crate::codegen::profiler::Profiler;
+use crate::codegen::warning::Warning;
+use crate::context::attribute::Attribute;
+use crate::context::function::declaration::Declaration as FunctionDeclaration;
+use crate::context::function::r#return::Return as FunctionReturn;
+use crate::context::r#loop::Loop;
+use crate::context::IContext;
+use crate::debug_config::DebugConfig;
+use crate::optimizer::settings::Settings as OptimizerSettings;
+use crate::optimizer::Optimizer;
+use crate::target_machine::TargetMachine;
+
+use self::address_space::AddressSpace;
+use self::evmla_data::EVMLAData;
+use self::function::intrinsics::Intrinsics;
+use self::function::Function;
+use self::solidity_data::SolidityData;
+use self::yul_data::YulData;
+
+///
+/// The LLVM IR generator context.
+///
+/// It is a not-so-big god-like object glueing all the compilers' complexity and act as an adapter
+/// and a superstructure over the inner `inkwell` LLVM context.
+///
+pub struct Context<'ctx> {
+    /// The inner LLVM context.
+    llvm: &'ctx inkwell::context::Context,
+    /// The inner LLVM context builder.
+    builder: inkwell::builder::Builder<'ctx>,
+    /// The optimization tools.
+    optimizer: Optimizer,
+    /// The current module.
+    module: inkwell::module::Module<'ctx>,
+    /// The extra LLVM options.
+    llvm_options: Vec<String>,
+    /// The current contract code type, which can be deploy or runtime.
+    code_segment: era_compiler_common::CodeSegment,
+    /// The LLVM intrinsic functions, defined on the LLVM side.
+    intrinsics: Intrinsics<'ctx>,
+    /// The declared functions.
+    functions: HashMap<String, Rc<RefCell<Function<'ctx>>>>,
+    /// The current active function.
+    current_function: Option<Rc<RefCell<Function<'ctx>>>>,
+    /// The loop context stack.
+    loop_stack: Vec<Loop<'ctx>>,
+
+    /// The debug configuration telling whether to dump the needed IRs.
+    debug_config: Option<DebugConfig>,
+
+    /// The Solidity data.
+    solidity_data: Option<SolidityData>,
+    /// The Yul data.
+    yul_data: Option<YulData>,
+    /// The EVM legacy assembly data.
+    evmla_data: Option<EVMLAData<'ctx>>,
+}
+
+impl<'ctx> Context<'ctx> {
+    /// The functions hashmap default capacity.
+    const FUNCTIONS_HASHMAP_INITIAL_CAPACITY: usize = 64;
+
+    /// The loop stack default capacity.
+    const LOOP_STACK_INITIAL_CAPACITY: usize = 16;
+
+    ///
+    /// Initializes a new LLVM context.
+    ///
+    pub fn new(
+        llvm: &'ctx inkwell::context::Context,
+        module: inkwell::module::Module<'ctx>,
+        llvm_options: Vec<String>,
+        code_segment: era_compiler_common::CodeSegment,
+        optimizer: Optimizer,
+        debug_config: Option<DebugConfig>,
+    ) -> Self {
+        let builder = llvm.create_builder();
+        let intrinsics = Intrinsics::new(llvm, &module);
+
+        Self {
+            llvm,
+            builder,
+            llvm_options,
+            optimizer,
+            module,
+            code_segment,
+            intrinsics,
+            functions: HashMap::with_capacity(Self::FUNCTIONS_HASHMAP_INITIAL_CAPACITY),
+            current_function: None,
+            loop_stack: Vec::with_capacity(Self::LOOP_STACK_INITIAL_CAPACITY),
+
+            debug_config,
+
+            solidity_data: None,
+            yul_data: None,
+            evmla_data: None,
+        }
+    }
+
+    ///
+    /// Builds the LLVM IR module, returning the build artifacts.
+    ///
+    pub fn build(
+        &mut self,
+        output_assembly: bool,
+        output_bytecode: bool,
+        is_size_fallback: bool,
+        profiler: &mut Profiler,
+    ) -> anyhow::Result<EVMBuild> {
+        let module_clone = self.module.clone();
+        let contract_path = self.module.get_name().to_str().expect("Always valid");
+
+        let run_init_verify = profiler.start_evm_translation_unit(
+            contract_path,
+            self.code_segment,
+            "InitVerify",
+            self.optimizer.settings(),
+        );
+        let target_machine =
+            TargetMachine::new(self.optimizer.settings(), self.llvm_options.as_slice())?;
+        target_machine.set_target_data(self.module());
+        target_machine.set_asm_verbosity(true);
+
+        let spill_area = self
+            .optimizer
+            .settings()
+            .spill_area_size()
+            .map(|spill_area_size| (crate::r#const::SOLC_GENERAL_MEMORY_OFFSET, spill_area_size));
+
+        if let Some(ref debug_config) = self.debug_config {
+            debug_config.dump_llvm_ir_unoptimized(
+                contract_path,
+                self.module(),
+                is_size_fallback,
+                spill_area,
+            )?;
+        }
+        self.verify().map_err(|error| {
+            anyhow::anyhow!(
+                "{} code unoptimized LLVM IR verification: {error}",
+                self.code_segment,
+            )
+        })?;
+        run_init_verify.borrow_mut().finish();
+
+        let run_optimize_verify = profiler.start_evm_translation_unit(
+            contract_path,
+            self.code_segment,
+            "OptimizeVerify",
+            self.optimizer.settings(),
+        );
+        self.optimizer
+            .run(&target_machine, self.module())
+            .map_err(|error| anyhow::anyhow!("{} code optimizing: {error}", self.code_segment))?;
+        if let Some(ref debug_config) = self.debug_config {
+            debug_config.dump_llvm_ir_optimized(
+                contract_path,
+                self.module(),
+                is_size_fallback,
+                spill_area,
+            )?;
+        }
+        self.verify().map_err(|error| {
+            anyhow::anyhow!(
+                "{} code optimized LLVM IR verification: {error}",
+                self.code_segment,
+            )
+        })?;
+        run_optimize_verify.borrow_mut().finish();
+
+        let assembly_buffer = if output_assembly || self.debug_config.is_some() {
+            let run_emit_llvm_assembly = profiler.start_evm_translation_unit(
+                contract_path,
+                self.code_segment,
+                "EmitLLVMAssembly",
+                self.optimizer.settings(),
+            );
+            let assembly_buffer = target_machine
+                .write_to_memory_buffer(self.module(), inkwell::targets::FileType::Assembly)
+                .map_err(|error| anyhow::anyhow!("assembly emitting: {error}"))?;
+
+            if let Some(ref debug_config) = self.debug_config {
+                let assembly_text = String::from_utf8_lossy(assembly_buffer.as_slice());
+                debug_config.dump_assembly(
+                    contract_path,
+                    era_compiler_common::Target::EVM,
+                    assembly_text.as_ref(),
+                    is_size_fallback,
+                    spill_area,
+                )?;
+            }
+
+            run_emit_llvm_assembly.borrow_mut().finish();
+            Some(assembly_buffer)
+        } else {
+            None
+        };
+        let assembly = assembly_buffer
+            .map(|assembly_buffer| String::from_utf8_lossy(assembly_buffer.as_slice()).to_string());
+
+        if output_bytecode {
+            let run_emit_bytecode = profiler.start_evm_translation_unit(
+                contract_path,
+                self.code_segment,
+                "EmitBytecode",
+                self.optimizer.settings(),
+            );
+            let bytecode_buffer = target_machine
+                .write_to_memory_buffer(self.module(), inkwell::targets::FileType::Object)
+                .map_err(|error| {
+                    anyhow::anyhow!("{} bytecode emitting: {error}", self.code_segment)
+                })?;
+            run_emit_bytecode.borrow_mut().finish();
+
+            let immutables = match self.code_segment {
+                era_compiler_common::CodeSegment::Deploy => None,
+                era_compiler_common::CodeSegment::Runtime => {
+                    Some(bytecode_buffer.get_immutables_evm())
+                }
+            };
+
+            let bytecode_size_limit = match self.code_segment {
+                era_compiler_common::CodeSegment::Deploy => crate::r#const::DEPLOY_CODE_SIZE_LIMIT,
+                era_compiler_common::CodeSegment::Runtime => {
+                    crate::r#const::RUNTIME_CODE_SIZE_LIMIT
+                }
+            };
+
+            let mut warnings = Vec::with_capacity(1);
+            let bytecode_size = bytecode_buffer.as_slice().len();
+            if bytecode_size > bytecode_size_limit {
+                if self.optimizer.settings() == &OptimizerSettings::cycles()
+                    && self.optimizer.settings().is_fallback_to_size_enabled()
+                {
+                    crate::codegen::IS_SIZE_FALLBACK
+                        .compare_exchange(
+                            false,
+                            true,
+                            std::sync::atomic::Ordering::Relaxed,
+                            std::sync::atomic::Ordering::Relaxed,
+                        )
+                        .expect("Failed to set the global size fallback flag");
+                    self.optimizer = Optimizer::new(OptimizerSettings::size());
+                    self.module = module_clone;
+                    for function in self.module.get_functions() {
+                        Function::set_size_attributes(self.llvm, function);
+                    }
+                    return self.build(output_assembly, output_bytecode, true, profiler);
+                } else {
+                    warnings.push(match self.code_segment {
+                        era_compiler_common::CodeSegment::Deploy => Warning::DeployCodeSize {
+                            found: bytecode_size,
+                        },
+                        era_compiler_common::CodeSegment::Runtime => Warning::RuntimeCodeSize {
+                            found: bytecode_size,
+                        },
+                    })
+                };
+            }
+            Ok(EVMBuild::new(
+                Some(bytecode_buffer.as_slice().to_vec()),
+                assembly,
+                immutables,
+                is_size_fallback,
+                warnings,
+            ))
+        } else {
+            Ok(EVMBuild::new(
+                None,
+                assembly,
+                None,
+                is_size_fallback,
+                vec![],
+            ))
+        }
+    }
+
+    ///
+    /// Verifies the current LLVM IR module.
+    ///
+    pub fn verify(&self) -> anyhow::Result<()> {
+        self.module()
+            .verify()
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    ///
+    /// Returns the LLVM intrinsics collection reference.
+    ///
+    pub fn intrinsics(&self) -> &Intrinsics<'ctx> {
+        &self.intrinsics
+    }
+
+    ///
+    /// Returns a Yul function type with the specified arguments and number of return values.
+    ///
+    pub fn function_type<T>(
+        &self,
+        argument_types: Vec<T>,
+        return_values_size: usize,
+    ) -> inkwell::types::FunctionType<'ctx>
+    where
+        T: BasicType<'ctx>,
+    {
+        let argument_types: Vec<inkwell::types::BasicMetadataTypeEnum> = argument_types
+            .as_slice()
+            .iter()
+            .map(T::as_basic_type_enum)
+            .map(inkwell::types::BasicMetadataTypeEnum::from)
+            .collect();
+        match return_values_size {
+            0 => self
+                .llvm
+                .void_type()
+                .fn_type(argument_types.as_slice(), false),
+            1 => self.field_type().fn_type(argument_types.as_slice(), false),
+            size => self
+                .structure_type(vec![self.field_type().as_basic_type_enum(); size].as_slice())
+                .fn_type(argument_types.as_slice(), false),
+        }
+    }
+
+    ///
+    /// Modifies the call site value, setting the default attributes.
+    ///
+    /// The attributes only affect the LLVM optimizations.
+    ///
+    pub fn modify_call_site_value(
+        &self,
+        arguments: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
+        call_site_value: inkwell::values::CallSiteValue<'ctx>,
+        function: FunctionDeclaration<'ctx>,
+    ) {
+        for (index, argument) in arguments.iter().enumerate() {
+            if argument.is_pointer_value() {
+                call_site_value.set_alignment_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    era_compiler_common::BYTE_LENGTH_FIELD as u32,
+                );
+                call_site_value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    self.llvm
+                        .create_enum_attribute(Attribute::NoAlias as u32, 0),
+                );
+                call_site_value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    self.llvm
+                        .create_enum_attribute(Attribute::NoCapture as u32, 0),
+                );
+                call_site_value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    self.llvm.create_enum_attribute(Attribute::NoFree as u32, 0),
+                );
+                if (*argument)
+                    .try_into()
+                    .map(|argument: inkwell::values::BasicValueEnum<'ctx>| argument.get_type())
+                    .ok()
+                    == function.r#type.get_return_type()
+                {
+                    if function
+                        .r#type
+                        .get_return_type()
+                        .map(|r#type| {
+                            r#type.into_pointer_type().get_address_space()
+                                == AddressSpace::Stack.into()
+                        })
+                        .unwrap_or_default()
+                    {
+                        call_site_value.add_attribute(
+                            inkwell::attributes::AttributeLoc::Param(index as u32),
+                            self.llvm
+                                .create_enum_attribute(Attribute::Returned as u32, 0),
+                        );
+                    }
+                    call_site_value.add_attribute(
+                        inkwell::attributes::AttributeLoc::Param(index as u32),
+                        self.llvm.create_enum_attribute(
+                            Attribute::Dereferenceable as u32,
+                            (era_compiler_common::BIT_LENGTH_FIELD * 2) as u64,
+                        ),
+                    );
+                    call_site_value.add_attribute(
+                        inkwell::attributes::AttributeLoc::Return,
+                        self.llvm.create_enum_attribute(
+                            Attribute::Dereferenceable as u32,
+                            (era_compiler_common::BIT_LENGTH_FIELD * 2) as u64,
+                        ),
+                    );
+                }
+                call_site_value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    self.llvm
+                        .create_enum_attribute(Attribute::NonNull as u32, 0),
+                );
+                call_site_value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Param(index as u32),
+                    self.llvm
+                        .create_enum_attribute(Attribute::NoUndef as u32, 0),
+                );
+            }
+        }
+
+        if function
+            .r#type
+            .get_return_type()
+            .map(|r#type| r#type.is_pointer_type())
+            .unwrap_or_default()
+        {
+            call_site_value.set_alignment_attribute(
+                inkwell::attributes::AttributeLoc::Return,
+                era_compiler_common::BYTE_LENGTH_FIELD as u32,
+            );
+            call_site_value.add_attribute(
+                inkwell::attributes::AttributeLoc::Return,
+                self.llvm
+                    .create_enum_attribute(Attribute::NoAlias as u32, 0),
+            );
+            call_site_value.add_attribute(
+                inkwell::attributes::AttributeLoc::Return,
+                self.llvm
+                    .create_enum_attribute(Attribute::NonNull as u32, 0),
+            );
+            call_site_value.add_attribute(
+                inkwell::attributes::AttributeLoc::Return,
+                self.llvm
+                    .create_enum_attribute(Attribute::NoUndef as u32, 0),
+            );
+        }
+    }
+}
+
+impl<'ctx> IContext<'ctx> for Context<'ctx> {
+    type Function = Function<'ctx>;
+
+    type AddressSpace = AddressSpace;
+
+    type SolidityData = SolidityData;
+
+    type YulData = YulData;
+
+    type EVMLAData = EVMLAData<'ctx>;
+
+    type VyperData = ();
+
+    fn llvm(&self) -> &'ctx inkwell::context::Context {
+        self.llvm
+    }
+
+    fn builder(&self) -> &inkwell::builder::Builder<'ctx> {
+        &self.builder
+    }
+
+    fn module(&self) -> &inkwell::module::Module<'ctx> {
+        &self.module
+    }
+
+    fn optimizer(&self) -> &Optimizer {
+        &self.optimizer
+    }
+
+    fn debug_config(&self) -> Option<&DebugConfig> {
+        self.debug_config.as_ref()
+    }
+
+    fn set_code_segment(&mut self, code_segment: era_compiler_common::CodeSegment) {
+        self.code_segment = code_segment;
+    }
+
+    fn code_segment(&self) -> Option<era_compiler_common::CodeSegment> {
+        Some(self.code_segment.to_owned())
+    }
+
+    fn append_basic_block(&self, name: &str) -> inkwell::basic_block::BasicBlock<'ctx> {
+        self.llvm()
+            .append_basic_block(self.current_function().borrow().declaration().value, name)
+    }
+
+    fn set_basic_block(&self, block: inkwell::basic_block::BasicBlock<'ctx>) {
+        self.builder().position_at_end(block);
+    }
+
+    fn basic_block(&self) -> inkwell::basic_block::BasicBlock<'ctx> {
+        self.builder().get_insert_block().expect("Always exists")
+    }
+
+    fn push_loop(
+        &mut self,
+        body_block: inkwell::basic_block::BasicBlock<'ctx>,
+        continue_block: inkwell::basic_block::BasicBlock<'ctx>,
+        join_block: inkwell::basic_block::BasicBlock<'ctx>,
+    ) {
+        self.loop_stack
+            .push(Loop::new(body_block, continue_block, join_block));
+    }
+
+    fn pop_loop(&mut self) {
+        self.loop_stack.pop();
+    }
+
+    fn r#loop(&self) -> &Loop<'ctx> {
+        self.loop_stack
+            .last()
+            .expect("The current context is not in a loop")
+    }
+
+    fn add_function(
+        &mut self,
+        name: &str,
+        r#type: inkwell::types::FunctionType<'ctx>,
+        return_values_length: usize,
+        linkage: Option<inkwell::module::Linkage>,
+    ) -> anyhow::Result<Rc<RefCell<Self::Function>>> {
+        let value = self.module().add_function(name, r#type, linkage);
+
+        let entry_block = self.llvm.append_basic_block(value, "entry");
+        let return_block = self.llvm.append_basic_block(value, "return");
+
+        let r#return = match return_values_length {
+            0 => FunctionReturn::none(),
+            1 => {
+                self.set_basic_block(entry_block);
+                let pointer = self.build_alloca(self.field_type(), "return_pointer")?;
+                FunctionReturn::primitive(pointer)
+            }
+            size => {
+                self.set_basic_block(entry_block);
+                let pointer = self.build_alloca(
+                    self.structure_type(
+                        vec![self.field_type().as_basic_type_enum(); size].as_slice(),
+                    ),
+                    "return_pointer",
+                )?;
+                FunctionReturn::compound(pointer, size)
+            }
+        };
+
+        let function = Function::new(
+            name.to_owned(),
+            FunctionDeclaration::new(r#type, value),
+            r#return,
+            entry_block,
+            return_block,
+        );
+        Function::set_default_attributes(self.llvm, function.declaration(), &self.optimizer);
+
+        let function = Rc::new(RefCell::new(function));
+        self.functions.insert(name.to_string(), function.clone());
+
+        Ok(function)
+    }
+
+    fn get_function(&self, name: &str) -> Option<Rc<RefCell<Self::Function>>> {
+        self.functions.get(name).cloned()
+    }
+
+    fn current_function(&self) -> Rc<RefCell<Self::Function>> {
+        self.current_function
+            .clone()
+            .expect("Must be declared before use")
+    }
+
+    fn set_current_function(&mut self, name: &str) -> anyhow::Result<()> {
+        let function = self.functions.get(name).cloned().ok_or_else(|| {
+            anyhow::anyhow!("Failed to activate an undeclared function `{}`", name)
+        })?;
+        self.current_function = Some(function);
+        Ok(())
+    }
+
+    fn build_call(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
+        let arguments: Vec<inkwell::values::BasicMetadataValueEnum> = arguments
+            .iter()
+            .copied()
+            .map(inkwell::values::BasicMetadataValueEnum::from)
+            .collect();
+        self.build_call_metadata(function, arguments.as_slice(), name)
+    }
+
+    fn build_call_metadata(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
+        let call_site_value = self.builder.build_indirect_call(
+            function.r#type,
+            function.value.as_global_value().as_pointer_value(),
+            arguments,
+            name,
+        )?;
+        self.modify_call_site_value(arguments, call_site_value, function);
+        Ok(call_site_value.try_as_basic_value().left())
+    }
+
+    fn build_invoke(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
+        Self::build_call(self, function, arguments, name)
+    }
+
+    fn set_solidity_data(&mut self, data: Self::SolidityData) {
+        self.solidity_data = Some(data);
+    }
+
+    fn solidity(&self) -> Option<&Self::SolidityData> {
+        self.solidity_data.as_ref()
+    }
+
+    fn solidity_mut(&mut self) -> Option<&mut Self::SolidityData> {
+        self.solidity_data.as_mut()
+    }
+
+    fn set_yul_data(&mut self, data: Self::YulData) {
+        self.yul_data = Some(data);
+    }
+
+    fn yul(&self) -> Option<&Self::YulData> {
+        self.yul_data.as_ref()
+    }
+
+    fn yul_mut(&mut self) -> Option<&mut Self::YulData> {
+        self.yul_data.as_mut()
+    }
+
+    fn set_evmla_data(&mut self, data: Self::EVMLAData) {
+        self.evmla_data = Some(data);
+    }
+
+    fn evmla(&self) -> Option<&Self::EVMLAData> {
+        self.evmla_data.as_ref()
+    }
+
+    fn evmla_mut(&mut self) -> Option<&mut Self::EVMLAData> {
+        self.evmla_data.as_mut()
+    }
+
+    fn set_vyper_data(&mut self, _data: Self::VyperData) {
+        panic!("Unused with the EVM target");
+    }
+
+    fn vyper(&self) -> Option<&Self::VyperData> {
+        panic!("Unused with the EVM target");
+    }
+
+    fn vyper_mut(&mut self) -> Option<&mut Self::VyperData> {
+        panic!("Unused with the EVM target");
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/solidity_data.rs
+++ b/solx-codegen-evm/src/codegen/context/solidity_data.rs
@@ -1,0 +1,86 @@
+//!
+//! The LLVM IR generator Solidity data.
+//!
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use crate::context::traits::solidity_data::ISolidityData;
+
+///
+/// The LLVM IR generator Solidity data.
+///
+/// Describes some data that is only relevant to Solidity.
+///
+#[derive(Debug, Default)]
+pub struct SolidityData {
+    /// The immutables identifier-to-offset mapping.
+    /// If the runtime code is available and this field is set, `offsets` method below can return `None`
+    /// for immutables that are never referenced in the runtime code,
+    /// However, if it is unset and `immutables_dummy` is used, then `offsets` method will always return
+    /// a set with a single offset to avoid stack-too-deep false negatives caused by missing immutable writing operations.
+    immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
+    /// The dummy mapping that is used in dummy compiler runs.
+    /// For instance, when the runtime code with actual immutables is not available due to errors such as stack-too-deep,
+    /// but we still want to try compiling the deploy code to check for other errors including stack-too-deep.
+    /// In this case, `immutables` is `None`, and `immutables_dummy` is used to allocated the offsets of the immutables.
+    immutables_dummy: BTreeMap<String, u64>,
+}
+
+impl ISolidityData for SolidityData {
+    fn offsets(&mut self, id: &str) -> Option<BTreeSet<u64>> {
+        match self.immutables.as_ref() {
+            Some(immutables) => immutables.get(id).cloned(),
+            None => {
+                let mut offsets = BTreeSet::new();
+                offsets.insert(self.get_or_allocate_dummy_immutable(id));
+                Some(offsets)
+            }
+        }
+    }
+}
+
+impl SolidityData {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(immutables: Option<BTreeMap<String, BTreeSet<u64>>>) -> Self {
+        Self {
+            immutables,
+            immutables_dummy: BTreeMap::new(),
+        }
+    }
+
+    ///
+    /// Returns the current number of immutables values in the contract.
+    ///
+    pub fn immutables_dummy_size(&self) -> usize {
+        self.immutables_dummy.len() * era_compiler_common::BYTE_LENGTH_FIELD
+    }
+
+    ///
+    /// Allocates memory for an immutable value in the auxiliary heap.
+    ///
+    /// If the identifier is already known, just returns its offset.
+    ///
+    pub fn allocate_dummy_immutable(&mut self, identifier: &str) -> u64 {
+        let number_of_elements = self.immutables_dummy.len();
+        let new_offset = number_of_elements * era_compiler_common::BYTE_LENGTH_FIELD;
+        *self
+            .immutables_dummy
+            .entry(identifier.to_owned())
+            .or_insert(new_offset as u64)
+    }
+
+    ///
+    /// Gets the offset of the immutable value.
+    ///
+    /// If the value is not yet allocated, then it is done forcibly.
+    ///
+    pub fn get_or_allocate_dummy_immutable(&mut self, identifier: &str) -> u64 {
+        match self.immutables_dummy.get(identifier).copied() {
+            Some(offset) => offset,
+            None => self.allocate_dummy_immutable(identifier),
+        }
+    }
+}

--- a/solx-codegen-evm/src/codegen/context/yul_data.rs
+++ b/solx-codegen-evm/src/codegen/context/yul_data.rs
@@ -1,0 +1,35 @@
+//!
+//! The LLVM IR generator Yul data.
+//!
+
+use std::collections::BTreeMap;
+
+use crate::context::traits::yul_data::IYulData;
+
+///
+/// The LLVM IR generator Yul data.
+///
+/// Describes some data that is only relevant to Yul.
+///
+#[derive(Debug, Default)]
+pub struct YulData {
+    /// Mapping from Yul object identifiers to full contract paths.
+    identifier_paths: BTreeMap<String, String>,
+}
+
+impl YulData {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(identifier_paths: BTreeMap<String, String>) -> Self {
+        Self { identifier_paths }
+    }
+}
+
+impl IYulData for YulData {
+    fn resolve_path(&self, identifier: &str) -> Option<&str> {
+        self.identifier_paths
+            .get(identifier)
+            .map(|path| path.as_str())
+    }
+}

--- a/solx-codegen-evm/src/codegen/instructions/arithmetic.rs
+++ b/solx-codegen-evm/src/codegen/instructions/arithmetic.rs
@@ -1,0 +1,255 @@
+//!
+//! Translates the arithmetic operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::Context;
+use crate::context::IContext;
+
+///
+/// Translates the arithmetic addition.
+///
+/// There is not difference between the EVM and LLVM IR behaviors.
+///
+pub fn addition<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_int_add(operand_1, operand_2, "addition_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the arithmetic subtraction.
+///
+/// There is not difference between the EVM and LLVM IR behaviors.
+///
+pub fn subtraction<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_int_sub(operand_1, operand_2, "subtraction_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the arithmetic multiplication.
+///
+/// There is not difference between the EVM and LLVM IR behaviors.
+///
+pub fn multiplication<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_int_mul(operand_1, operand_2, "multiplication_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the arithmetic division.
+///
+/// The only difference between the EVM and LLVM IR is that 0 must be returned in case of
+/// division by zero.
+///
+pub fn division<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let zero_block = context.append_basic_block("division_zero");
+    let non_zero_block = context.append_basic_block("division_non_zero");
+    let join_block = context.append_basic_block("division_join");
+
+    let result_pointer = context.build_alloca(context.field_type(), "division_result_pointer")?;
+    let condition = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_2,
+        context.field_const(0),
+        "division_is_divider_zero",
+    )?;
+    context.build_conditional_branch(condition, zero_block, non_zero_block)?;
+
+    context.set_basic_block(non_zero_block);
+    let result = context.builder().build_int_unsigned_div(
+        operand_1,
+        operand_2,
+        "division_result_non_zero",
+    )?;
+    context.build_store(result_pointer, result)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(zero_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "division_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the arithmetic remainder.
+///
+/// The only difference between the EVM and LLVM IR is that 0 must be returned in case of
+/// division by zero.
+///
+pub fn remainder<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let zero_block = context.append_basic_block("remainder_zero");
+    let non_zero_block = context.append_basic_block("remainder_non_zero");
+    let join_block = context.append_basic_block("remainder_join");
+
+    let result_pointer = context.build_alloca(context.field_type(), "remainder_result_pointer")?;
+    let condition = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_2,
+        context.field_const(0),
+        "remainder_is_modulo_zero",
+    )?;
+    context.build_conditional_branch(condition, zero_block, non_zero_block)?;
+
+    context.set_basic_block(non_zero_block);
+    let result = context.builder().build_int_unsigned_rem(
+        operand_1,
+        operand_2,
+        "remainder_result_non_zero",
+    )?;
+    context.build_store(result_pointer, result)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(zero_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "remainder_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the signed arithmetic division.
+///
+/// Two differences between the EVM and LLVM IR:
+/// 1. In case of division by zero, 0 is returned.
+/// 2. In case of overflow, the first argument is returned.
+///
+pub fn division_signed<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let zero_block = context.append_basic_block("division_signed_zero");
+    let non_zero_block = context.append_basic_block("division_signed_non_zero");
+    let overflow_block = context.append_basic_block("division_signed_overflow");
+    let non_overflow_block = context.append_basic_block("division_signed_non_overflow");
+    let join_block = context.append_basic_block("division_signed_join");
+
+    let result_pointer =
+        context.build_alloca(context.field_type(), "division_signed_result_pointer")?;
+    let condition_is_divider_zero = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_2,
+        context.field_const(0),
+        "division_signed_is_divider_zero",
+    )?;
+    context.build_conditional_branch(condition_is_divider_zero, zero_block, non_zero_block)?;
+
+    context.set_basic_block(non_zero_block);
+    let condition_is_divided_int_min = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_1,
+        context.field_const_str_hex(
+            "8000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        "division_signed_is_divided_int_min",
+    )?;
+    let condition_is_divider_minus_one = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_2,
+        context.field_type().const_all_ones(),
+        "division_signed_is_divider_minus_one",
+    )?;
+    let condition_is_overflow = context.builder().build_and(
+        condition_is_divided_int_min,
+        condition_is_divider_minus_one,
+        "division_signed_is_overflow",
+    )?;
+    context.build_conditional_branch(condition_is_overflow, overflow_block, non_overflow_block)?;
+
+    context.set_basic_block(overflow_block);
+    context.build_store(result_pointer, operand_1)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(non_overflow_block);
+    let result = context.builder().build_int_signed_div(
+        operand_1,
+        operand_2,
+        "division_signed_result_non_zero",
+    )?;
+    context.build_store(result_pointer, result)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(zero_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "division_signed_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the signed arithmetic remainder.
+///
+/// The only differences between the EVM and LLVM IR are that 0 must be returned in cases of
+/// division by zero or overflow.
+///
+pub fn remainder_signed<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let zero_block = context.append_basic_block("remainder_signed_zero");
+    let non_zero_block = context.append_basic_block("remainder_signed_non_zero");
+    let join_block = context.append_basic_block("remainder_signed_join");
+
+    let result_pointer =
+        context.build_alloca(context.field_type(), "remainder_signed_result_pointer")?;
+    let condition = context.builder().build_int_compare(
+        inkwell::IntPredicate::EQ,
+        operand_2,
+        context.field_const(0),
+        "remainder_signed_is_modulo_zero",
+    )?;
+    context.build_conditional_branch(condition, zero_block, non_zero_block)?;
+
+    context.set_basic_block(non_zero_block);
+    let result = context.builder().build_int_signed_rem(
+        operand_1,
+        operand_2,
+        "remainder_signed_result_non_zero",
+    )?;
+    context.build_store(result_pointer, result)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(zero_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "remainder_signed_result")?;
+    Ok(result)
+}

--- a/solx-codegen-evm/src/codegen/instructions/bitwise.rs
+++ b/solx-codegen-evm/src/codegen/instructions/bitwise.rs
@@ -1,0 +1,228 @@
+//!
+//! Translates the bitwise operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::Context;
+use crate::context::IContext;
+
+///
+/// Translates the bitwise OR.
+///
+pub fn or<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_or(operand_1, operand_2, "or_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the bitwise XOR.
+///
+pub fn xor<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_xor(operand_1, operand_2, "xor_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the bitwise AND.
+///
+pub fn and<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .builder()
+        .build_and(operand_1, operand_2, "and_result")?
+        .as_basic_value_enum())
+}
+
+///
+/// Translates the bitwise shift left.
+///
+/// Shifting by a word size or more is an UB in LLVM, so we must always check if the offset is
+/// between 0 and the word size (256 bits) and return 0 if so.
+///
+pub fn shift_left<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let overflow_block = context.append_basic_block("shift_left_overflow");
+    let non_overflow_block = context.append_basic_block("shift_left_non_overflow");
+    let join_block = context.append_basic_block("shift_left_join");
+
+    let result_pointer = context.build_alloca(context.field_type(), "shift_left_result_pointer")?;
+    let condition_is_overflow = context.builder().build_int_compare(
+        inkwell::IntPredicate::UGT,
+        operand_1,
+        context.field_const((era_compiler_common::BIT_LENGTH_FIELD - 1) as u64),
+        "shift_left_is_overflow",
+    )?;
+    context.build_conditional_branch(condition_is_overflow, overflow_block, non_overflow_block)?;
+
+    context.set_basic_block(overflow_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(non_overflow_block);
+    let value = context.builder().build_left_shift(
+        operand_2,
+        operand_1,
+        "shift_left_non_overflow_result",
+    )?;
+    context.build_store(result_pointer, value)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "shift_left_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the bitwise shift right.
+///
+/// Shifting by a word size or more is an UB in LLVM, so we must always check if the offset is
+/// between 0 and the word size (256 bits) and return 0 if so.
+///
+pub fn shift_right<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let overflow_block = context.append_basic_block("shift_right_overflow");
+    let non_overflow_block = context.append_basic_block("shift_right_non_overflow");
+    let join_block = context.append_basic_block("shift_right_join");
+
+    let result_pointer =
+        context.build_alloca(context.field_type(), "shift_right_result_pointer")?;
+    let condition_is_overflow = context.builder().build_int_compare(
+        inkwell::IntPredicate::UGT,
+        operand_1,
+        context.field_const((era_compiler_common::BIT_LENGTH_FIELD - 1) as u64),
+        "shift_right_is_overflow",
+    )?;
+    context.build_conditional_branch(condition_is_overflow, overflow_block, non_overflow_block)?;
+
+    context.set_basic_block(overflow_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(non_overflow_block);
+    let value = context.builder().build_right_shift(
+        operand_2,
+        operand_1,
+        false,
+        "shift_right_non_overflow_result",
+    )?;
+    context.build_store(result_pointer, value)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "shift_right_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the arithmetic bitwise shift right.
+///
+/// Shifting by a word size or more is an UB in LLVM, so we must always check if the offset is
+/// between 0 and the word size (256 bits) and return 0 or -1 if so.
+///
+pub fn shift_right_arithmetic<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let overflow_block = context.append_basic_block("shift_right_arithmetic_overflow");
+    let overflow_positive_block =
+        context.append_basic_block("shift_right_arithmetic_overflow_positive");
+    let overflow_negative_block =
+        context.append_basic_block("shift_right_arithmetic_overflow_negative");
+    let non_overflow_block = context.append_basic_block("shift_right_arithmetic_non_overflow");
+    let join_block = context.append_basic_block("shift_right_arithmetic_join");
+
+    let result_pointer = context.build_alloca(
+        context.field_type(),
+        "shift_right_arithmetic_result_pointer",
+    )?;
+    let condition_is_overflow = context.builder().build_int_compare(
+        inkwell::IntPredicate::UGT,
+        operand_1,
+        context.field_const((era_compiler_common::BIT_LENGTH_FIELD - 1) as u64),
+        "shift_right_arithmetic_is_overflow",
+    )?;
+    context.build_conditional_branch(condition_is_overflow, overflow_block, non_overflow_block)?;
+
+    context.set_basic_block(overflow_block);
+    let sign_bit = context.builder().build_right_shift(
+        operand_2,
+        context.field_const((era_compiler_common::BIT_LENGTH_FIELD - 1) as u64),
+        false,
+        "shift_right_arithmetic_sign_bit",
+    )?;
+    let condition_is_negative = context.builder().build_int_truncate_or_bit_cast(
+        sign_bit,
+        context.bool_type(),
+        "shift_right_arithmetic_sign_bit_truncated",
+    )?;
+    context.build_conditional_branch(
+        condition_is_negative,
+        overflow_negative_block,
+        overflow_positive_block,
+    )?;
+
+    context.set_basic_block(overflow_positive_block);
+    context.build_store(result_pointer, context.field_const(0))?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(overflow_negative_block);
+    context.build_store(result_pointer, context.field_type().const_all_ones())?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(non_overflow_block);
+    let value = context.builder().build_right_shift(
+        operand_2,
+        operand_1,
+        true,
+        "shift_right_arithmetic_non_overflow_result",
+    )?;
+    context.build_store(result_pointer, value)?;
+    context.build_unconditional_branch(join_block)?;
+
+    context.set_basic_block(join_block);
+    let result = context.build_load(result_pointer, "shift_right_arithmetic_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the `byte` instruction.
+///
+pub fn byte<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().byte,
+            &[
+                operand_1.as_basic_value_enum(),
+                operand_2.as_basic_value_enum(),
+            ],
+            "byte",
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/call.rs
+++ b/solx-codegen-evm/src/codegen/instructions/call.rs
@@ -1,0 +1,163 @@
+//!
+//! Translates a contract call.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates an external call.
+///
+#[allow(clippy::too_many_arguments)]
+pub fn call<'ctx>(
+    context: &mut Context<'ctx>,
+    gas: inkwell::values::IntValue<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+    output_offset: inkwell::values::IntValue<'ctx>,
+    output_length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "call_input_offset_pointer",
+    )?;
+    let output_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        output_offset,
+        "call_output_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().call,
+            &[
+                gas.as_basic_value_enum(),
+                address.as_basic_value_enum(),
+                value.as_basic_value_enum(),
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                output_offset_pointer.as_basic_value_enum(),
+                output_length.as_basic_value_enum(),
+            ],
+            "call",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates a static call.
+///
+#[allow(clippy::too_many_arguments)]
+pub fn static_call<'ctx>(
+    context: &mut Context<'ctx>,
+    gas: inkwell::values::IntValue<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+    output_offset: inkwell::values::IntValue<'ctx>,
+    output_length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "staticcall_input_offset_pointer",
+    )?;
+    let output_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        output_offset,
+        "staticcall_output_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().staticcall,
+            &[
+                gas.as_basic_value_enum(),
+                address.as_basic_value_enum(),
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                output_offset_pointer.as_basic_value_enum(),
+                output_length.as_basic_value_enum(),
+            ],
+            "static_call",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates a delegate call.
+///
+#[allow(clippy::too_many_arguments)]
+pub fn delegate_call<'ctx>(
+    context: &mut Context<'ctx>,
+    gas: inkwell::values::IntValue<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+    output_offset: inkwell::values::IntValue<'ctx>,
+    output_length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "delegatecall_input_offset_pointer",
+    )?;
+    let output_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        output_offset,
+        "delegatecall_output_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().delegatecall,
+            &[
+                gas.as_basic_value_enum(),
+                address.as_basic_value_enum(),
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                output_offset_pointer.as_basic_value_enum(),
+                output_length.as_basic_value_enum(),
+            ],
+            "delegate_call",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `linkersymbol` instruction.
+///
+pub fn linker_symbol<'ctx>(
+    context: &mut Context<'ctx>,
+    path: &str,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call_metadata(
+            context.intrinsics().linkersymbol,
+            &[context
+                .llvm()
+                .metadata_node(&[context.llvm().metadata_string(path).into()])
+                .into()],
+            format!("linker_symbol_{path}").as_str(),
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/calldata.rs
+++ b/solx-codegen-evm/src/codegen/instructions/calldata.rs
@@ -1,0 +1,72 @@
+//!
+//! Translates the calldata instructions.
+//!
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the calldata load.
+///
+pub fn load<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Calldata,
+        context.field_type(),
+        offset,
+        "calldataload_pointer",
+    )?;
+    let result = context.build_load(pointer, "calldata_load_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the calldata size.
+///
+pub fn size<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().calldatasize, &[], "calldatasize")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the calldata copy.
+///
+pub fn copy<'ctx>(
+    context: &mut Context<'ctx>,
+    destination_offset: inkwell::values::IntValue<'ctx>,
+    source_offset: inkwell::values::IntValue<'ctx>,
+    size: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let destination = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        destination_offset,
+        "calldatacopy_destination_pointer",
+    )?;
+
+    let source = Pointer::new_with_offset(
+        context,
+        AddressSpace::Calldata,
+        context.byte_type(),
+        source_offset,
+        "calldatacopy_source_pointer",
+    )?;
+
+    context.build_memcpy(
+        context.intrinsics().memory_copy_from_calldata,
+        destination,
+        source,
+        size,
+        "calldatacopy_memcpy",
+    )?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/code.rs
+++ b/solx-codegen-evm/src/codegen/instructions/code.rs
@@ -1,0 +1,167 @@
+//!
+//! Translates the external code operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the `codesize` instruction.
+///
+pub fn size<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().codesize, &[], "codesize")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `codecopy` instruction.
+///
+pub fn copy<'ctx>(
+    context: &mut Context<'ctx>,
+    destination_offset: inkwell::values::IntValue<'ctx>,
+    source_offset: inkwell::values::IntValue<'ctx>,
+    size: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let destination = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        destination_offset,
+        "codecopy_destination_pointer",
+    )?;
+
+    let source = Pointer::new_with_offset(
+        context,
+        AddressSpace::Code,
+        context.byte_type(),
+        source_offset,
+        "codecopy_source_pointer",
+    )?;
+
+    context.build_memcpy(
+        context.intrinsics().memory_copy_from_code,
+        destination,
+        source,
+        size,
+        "codecopy_memcpy",
+    )?;
+    Ok(())
+}
+
+///
+/// Translates the `dataoffset` instruction.
+///
+pub fn data_offset<'ctx>(
+    context: &mut Context<'ctx>,
+    object_name: &str,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let object_name = context
+        .llvm()
+        .metadata_node(&[context.llvm().metadata_string(object_name).into()]);
+
+    Ok(context
+        .build_call_metadata(
+            context.intrinsics().dataoffset,
+            &[object_name.into()],
+            "dataoffset",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `datasize` instruction.
+///
+pub fn data_size<'ctx>(
+    context: &mut Context<'ctx>,
+    object_name: &str,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let object_name = context
+        .llvm()
+        .metadata_node(&[context.llvm().metadata_string(object_name).into()]);
+
+    Ok(context
+        .build_call_metadata(
+            context.intrinsics().datasize,
+            &[object_name.into()],
+            "datasize",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `extcodesize` instruction.
+///
+pub fn ext_size<'ctx>(
+    context: &mut Context<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().extcodesize,
+            &[address.as_basic_value_enum()],
+            "extcodesize",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `extcodecopy` instruction.
+///
+pub fn ext_copy<'ctx>(
+    context: &mut Context<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+    destination_offset: inkwell::values::IntValue<'ctx>,
+    source_offset: inkwell::values::IntValue<'ctx>,
+    size: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let destination = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        destination_offset,
+        "extcodecopy_destination_pointer",
+    )?;
+
+    let source = Pointer::new_with_offset(
+        context,
+        AddressSpace::Code,
+        context.byte_type(),
+        source_offset,
+        "extcodecopy_source_pointer",
+    )?;
+
+    context.build_call(
+        context.intrinsics().extcodecopy,
+        &[
+            address.as_basic_value_enum(),
+            destination.as_basic_value_enum(),
+            source.as_basic_value_enum(),
+            size.as_basic_value_enum(),
+        ],
+        "extcodecopy",
+    )?;
+    Ok(())
+}
+
+///
+/// Translates the `extcodehash` instruction.
+///
+pub fn ext_hash<'ctx>(
+    context: &mut Context<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().extcodehash,
+            &[address.as_basic_value_enum()],
+            "extcodehash",
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/comparison.rs
+++ b/solx-codegen-evm/src/codegen/instructions/comparison.rs
@@ -1,0 +1,33 @@
+//!
+//! Translates the comparison operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::Context;
+use crate::context::IContext;
+
+///
+/// Translates the comparison operations.
+///
+/// There is not difference between the EVM and LLVM IR behaviors.
+///
+pub fn compare<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+    operation: inkwell::IntPredicate,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let result = context.builder().build_int_compare(
+        operation,
+        operand_1,
+        operand_2,
+        "comparison_result",
+    )?;
+    let result = context.builder().build_int_z_extend_or_bit_cast(
+        result,
+        context.field_type(),
+        "comparison_result_extended",
+    )?;
+    Ok(result.as_basic_value_enum())
+}

--- a/solx-codegen-evm/src/codegen/instructions/contract_context.rs
+++ b/solx-codegen-evm/src/codegen/instructions/contract_context.rs
@@ -1,0 +1,134 @@
+//!
+//! Translates the context getter instructions.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::Context;
+use crate::context::IContext;
+
+///
+/// Translates the `gas_limit` instruction.
+///
+pub fn gas_limit<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().gaslimit, &[], "gaslimit")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `gas_price` instruction.
+///
+pub fn gas_price<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().gasprice, &[], "gasprice")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `tx.origin` instruction.
+///
+pub fn origin<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().origin, &[], "origin")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `chain_id` instruction.
+///
+pub fn chain_id<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().chainid, &[], "chainid")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `block_number` instruction.
+///
+pub fn block_number<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().number, &[], "number")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `block_timestamp` instruction.
+///
+pub fn block_timestamp<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().timestamp, &[], "timestamp")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `block_hash` instruction.
+///
+pub fn block_hash<'ctx>(
+    context: &mut Context<'ctx>,
+    index: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().blockhash,
+            &[index.as_basic_value_enum()],
+            "blockhash",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `difficulty` instruction.
+///
+pub fn difficulty<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().difficulty, &[], "difficulty")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `coinbase` instruction.
+///
+pub fn coinbase<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().coinbase, &[], "coinbase")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `basefee` instruction.
+///
+pub fn basefee<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().basefee, &[], "basefee")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `msize` instruction.
+///
+pub fn msize<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().msize, &[], "msize")?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/create.rs
+++ b/solx-codegen-evm/src/codegen/instructions/create.rs
@@ -1,0 +1,72 @@
+//!
+//! Translates the contract creation instructions.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the contract `create` instruction.
+///
+pub fn create<'ctx>(
+    context: &mut Context<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "create_input_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().create,
+            &[
+                value.as_basic_value_enum(),
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+            ],
+            "create",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the contract `create2` instruction.
+///
+pub fn create2<'ctx>(
+    context: &mut Context<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+    salt: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "create2_input_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().create2,
+            &[
+                value.as_basic_value_enum(),
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                salt.as_basic_value_enum(),
+            ],
+            "create2",
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/ether_gas.rs
+++ b/solx-codegen-evm/src/codegen/instructions/ether_gas.rs
@@ -1,0 +1,73 @@
+//!
+//! Translates the value and balance operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::Context;
+use crate::context::IContext;
+
+///
+/// Translates the `gas` instruction.
+///
+pub fn gas<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().gas, &[], "gas")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `callvalue` instruction.
+///
+pub fn callvalue<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().callvalue, &[], "callvalue")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `balance` instructions.
+///
+pub fn balance<'ctx>(
+    context: &mut Context<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().balance,
+            &[address.as_basic_value_enum()],
+            "balance",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `selfbalance` instructions.
+///
+pub fn self_balance<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().selfbalance, &[], "selfbalance")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `selfdestruct` instructions.
+///
+pub fn self_destruct<'ctx>(
+    context: &mut Context<'ctx>,
+    address: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().selfdestruct,
+            &[address.as_basic_value_enum()],
+            "selfdestruct",
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/event.rs
+++ b/solx-codegen-evm/src/codegen/instructions/event.rs
@@ -1,0 +1,83 @@
+//!
+//! Translates a log or event call.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates an event log call.
+///
+pub fn log<'ctx>(
+    context: &mut Context<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+    topics: Vec<inkwell::values::IntValue<'ctx>>,
+) -> anyhow::Result<()> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        format!("log{}_input_offset_pointer", topics.len()).as_str(),
+    )?;
+
+    match topics.len() {
+        0 => context.build_call(
+            context.intrinsics().log0,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+            ],
+            "log0",
+        ),
+        1 => context.build_call(
+            context.intrinsics().log1,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
+            ],
+            "log1",
+        ),
+        2 => context.build_call(
+            context.intrinsics().log2,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
+                topics[1].as_basic_value_enum(),
+            ],
+            "log2",
+        ),
+        3 => context.build_call(
+            context.intrinsics().log3,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
+                topics[1].as_basic_value_enum(),
+                topics[2].as_basic_value_enum(),
+            ],
+            "log3",
+        ),
+        4 => context.build_call(
+            context.intrinsics().log4,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
+                topics[1].as_basic_value_enum(),
+                topics[2].as_basic_value_enum(),
+                topics[3].as_basic_value_enum(),
+            ],
+            "log4",
+        ),
+        length => panic!("The number of topics must be from 0 to 4, found {length}"),
+    }?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/immutable.rs
+++ b/solx-codegen-evm/src/codegen/instructions/immutable.rs
@@ -1,0 +1,71 @@
+//!
+//! Translates the contract immutable operations.
+//!
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::traits::solidity_data::ISolidityData;
+use crate::context::IContext;
+
+///
+/// Translates the `loadimmutable` instruction.
+///
+pub fn load<'ctx>(
+    context: &mut Context<'ctx>,
+    id: &str,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let id = context
+        .llvm()
+        .metadata_node(&[context.llvm().metadata_string(id).into()]);
+
+    Ok(context
+        .build_call_metadata(
+            context.intrinsics().loadimmutable,
+            &[id.into()],
+            "load_immutable",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `setimmutable` instruction.
+///
+pub fn store<'ctx>(
+    context: &mut Context<'ctx>,
+    id: &str,
+    base_offset: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    match context.code_segment() {
+        Some(era_compiler_common::CodeSegment::Deploy) => {}
+        Some(era_compiler_common::CodeSegment::Runtime) => {
+            anyhow::bail!("Setting immutables is only allowed in deploy code");
+        }
+        None => {
+            anyhow::bail!("Code segment is undefined");
+        }
+    }
+
+    let offsets = match context.solidity_mut().expect("Always exists").offsets(id) {
+        Some(offsets) => offsets,
+        None => return Ok(()),
+    };
+    for offset in offsets.into_iter() {
+        let immutable_offset = context.builder().build_int_add(
+            base_offset,
+            context.field_const(offset),
+            "setimmutable_offset",
+        )?;
+        let immutable_pointer = Pointer::new_with_offset(
+            context,
+            AddressSpace::Heap,
+            context.byte_type(),
+            immutable_offset,
+            "setimmutable_pointer",
+        )?;
+        context.build_store(immutable_pointer, value)?;
+    }
+
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/math.rs
+++ b/solx-codegen-evm/src/codegen/instructions/math.rs
@@ -1,0 +1,116 @@
+//!
+//! Translates the mathematics operation.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the `addmod` instruction.
+///
+pub fn add_mod<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+    modulo: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().addmod,
+            &[
+                operand_1.as_basic_value_enum(),
+                operand_2.as_basic_value_enum(),
+                modulo.as_basic_value_enum(),
+            ],
+            "addmod",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `mulmod` instruction.
+///
+pub fn mul_mod<'ctx>(
+    context: &mut Context<'ctx>,
+    operand_1: inkwell::values::IntValue<'ctx>,
+    operand_2: inkwell::values::IntValue<'ctx>,
+    modulo: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().mulmod,
+            &[
+                operand_1.as_basic_value_enum(),
+                operand_2.as_basic_value_enum(),
+                modulo.as_basic_value_enum(),
+            ],
+            "mulmod",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `exp` instruction.
+///
+pub fn exponent<'ctx>(
+    context: &mut Context<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+    exponent: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().exp,
+            &[value.as_basic_value_enum(), exponent.as_basic_value_enum()],
+            "mulmod",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `signextend` instruction.
+///
+pub fn sign_extend<'ctx>(
+    context: &mut Context<'ctx>,
+    bytes: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(
+            context.intrinsics().signextend,
+            &[bytes.as_basic_value_enum(), value.as_basic_value_enum()],
+            "signextend",
+        )?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the `keccak256` instruction.
+///
+pub fn keccak256<'ctx>(
+    context: &mut Context<'ctx>,
+    input_offset: inkwell::values::IntValue<'ctx>,
+    input_length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let input_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        input_offset,
+        "keccak256_input_offset_pointer",
+    )?;
+
+    Ok(context
+        .build_call(
+            context.intrinsics().sha3,
+            &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
+            ],
+            "keccak256",
+        )?
+        .expect("Always exists"))
+}

--- a/solx-codegen-evm/src/codegen/instructions/memory.rs
+++ b/solx-codegen-evm/src/codegen/instructions/memory.rs
@@ -1,0 +1,77 @@
+//!
+//! Translates the heap memory operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the `mload` instruction.
+///
+/// Uses the main heap.
+///
+pub fn load<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.field_type(),
+        offset,
+        "memory_load_pointer",
+    )?;
+    let result = context.build_load(pointer, "memory_load_result")?;
+    Ok(result)
+}
+
+///
+/// Translates the `mstore` instruction.
+///
+/// Uses the main heap.
+///
+pub fn store<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.field_type(),
+        offset,
+        "memory_store_pointer",
+    )?;
+    context.build_store(pointer, value)?;
+    Ok(())
+}
+
+///
+/// Translates the `mstore8` instruction.
+///
+/// Uses the main heap.
+///
+pub fn store_byte<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        offset,
+        "store_byte_pointer",
+    )?;
+
+    context.build_call(
+        context.intrinsics().mstore8,
+        &[pointer.as_basic_value_enum(), value.as_basic_value_enum()],
+        "mstore8",
+    )?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/mod.rs
+++ b/solx-codegen-evm/src/codegen/instructions/mod.rs
@@ -1,0 +1,20 @@
+//!
+//! The EVM instructions translation utils.
+//!
+
+pub mod arithmetic;
+pub mod bitwise;
+pub mod call;
+pub mod calldata;
+pub mod code;
+pub mod comparison;
+pub mod contract_context;
+pub mod create;
+pub mod ether_gas;
+pub mod event;
+pub mod immutable;
+pub mod math;
+pub mod memory;
+pub mod r#return;
+pub mod return_data;
+pub mod storage;

--- a/solx-codegen-evm/src/codegen/instructions/return.rs
+++ b/solx-codegen-evm/src/codegen/instructions/return.rs
@@ -1,0 +1,84 @@
+//!
+//! Translates the transaction return operations.
+//!
+
+use inkwell::values::BasicValue;
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the `return` instruction.
+///
+pub fn r#return<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+    length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        offset,
+        "revert_offset_pointer",
+    )?;
+
+    context.build_call(
+        context.intrinsics().r#return,
+        &[
+            offset_pointer.as_basic_value_enum(),
+            length.as_basic_value_enum(),
+        ],
+        "return",
+    )?;
+    context.build_unreachable()?;
+    Ok(())
+}
+
+///
+/// Translates the `revert` instruction.
+///
+pub fn revert<'ctx>(
+    context: &mut Context<'ctx>,
+    offset: inkwell::values::IntValue<'ctx>,
+    length: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        offset,
+        "revert_offset_pointer",
+    )?;
+
+    context.build_call(
+        context.intrinsics().revert,
+        &[
+            offset_pointer.as_basic_value_enum(),
+            length.as_basic_value_enum(),
+        ],
+        "revert",
+    )?;
+    context.build_unreachable()?;
+    Ok(())
+}
+
+///
+/// Translates the `stop` instruction.
+///
+pub fn stop(context: &mut Context) -> anyhow::Result<()> {
+    context.build_call(context.intrinsics().stop, &[], "stop")?;
+    context.build_unreachable()?;
+    Ok(())
+}
+
+///
+/// Translates the `invalid` instruction.
+///
+pub fn invalid(context: &mut Context) -> anyhow::Result<()> {
+    context.build_call(context.intrinsics().invalid, &[], "invalid")?;
+    context.build_unreachable()?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/return_data.rs
+++ b/solx-codegen-evm/src/codegen/instructions/return_data.rs
@@ -1,0 +1,54 @@
+//!
+//! Translates the return data instructions.
+//!
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the return data size.
+///
+pub fn size<'ctx>(
+    context: &mut Context<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    Ok(context
+        .build_call(context.intrinsics().returndatasize, &[], "returndatasize")?
+        .expect("Always exists"))
+}
+
+///
+/// Translates the return data copy.
+///
+pub fn copy<'ctx>(
+    context: &mut Context<'ctx>,
+    destination_offset: inkwell::values::IntValue<'ctx>,
+    source_offset: inkwell::values::IntValue<'ctx>,
+    size: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let destination = Pointer::new_with_offset(
+        context,
+        AddressSpace::Heap,
+        context.byte_type(),
+        destination_offset,
+        "returndatacopy_destination_pointer",
+    )?;
+
+    let source = Pointer::new_with_offset(
+        context,
+        AddressSpace::ReturnData,
+        context.byte_type(),
+        source_offset,
+        "returndatacopy_source_pointer",
+    )?;
+
+    context.build_memcpy(
+        context.intrinsics().memory_copy_from_return_data,
+        destination,
+        source,
+        size,
+        "returndatacopy_memcpy",
+    )?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/instructions/storage.rs
+++ b/solx-codegen-evm/src/codegen/instructions/storage.rs
@@ -1,0 +1,82 @@
+//!
+//! Translates the contract storage operations.
+//!
+
+use crate::codegen::context::address_space::AddressSpace;
+use crate::codegen::context::Context;
+use crate::context::pointer::Pointer;
+use crate::context::IContext;
+
+///
+/// Translates the contract storage load.
+///
+pub fn load<'ctx>(
+    context: &mut Context<'ctx>,
+    position: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let position_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Storage,
+        context.field_type(),
+        position,
+        "storage_load_position_pointer",
+    )?;
+    let value = context.build_load(position_pointer, "storage_load_value")?;
+    Ok(value)
+}
+
+///
+/// Translates the contract storage store.
+///
+pub fn store<'ctx>(
+    context: &mut Context<'ctx>,
+    position: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let position_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::Storage,
+        context.field_type(),
+        position,
+        "storage_store_position_pointer",
+    )?;
+    context.build_store(position_pointer, value)?;
+    Ok(())
+}
+
+///
+/// Translates the transient storage load.
+///
+pub fn transient_load<'ctx>(
+    context: &mut Context<'ctx>,
+    position: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+    let position_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::TransientStorage,
+        context.field_type(),
+        position,
+        "transient_storage_load_position_pointer",
+    )?;
+    let value = context.build_load(position_pointer, "transient_storage_load_value")?;
+    Ok(value)
+}
+
+///
+/// Translates the transient storage store.
+///
+pub fn transient_store<'ctx>(
+    context: &mut Context<'ctx>,
+    position: inkwell::values::IntValue<'ctx>,
+    value: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<()> {
+    let position_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::TransientStorage,
+        context.field_type(),
+        position,
+        "transient_storage_store_position_pointer",
+    )?;
+    context.build_store(position_pointer, value)?;
+    Ok(())
+}

--- a/solx-codegen-evm/src/codegen/mod.rs
+++ b/solx-codegen-evm/src/codegen/mod.rs
@@ -1,0 +1,154 @@
+//!
+//! The LLVM EVM context library.
+//!
+
+pub mod attribute;
+pub mod build;
+pub mod context;
+pub mod instructions;
+pub mod profiler;
+pub mod warning;
+
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicBool;
+
+use self::context::Context;
+
+///
+/// Initializes the EVM target machine.
+///
+pub fn initialize_target() {
+    inkwell::targets::Target::initialize_evm(&inkwell::targets::InitializationConfig::default());
+}
+
+///
+/// Appends metadata to runtime code.
+///
+pub fn append_metadata(
+    bytecode_buffer: inkwell::memory_buffer::MemoryBuffer,
+    metadata: &[u8],
+) -> anyhow::Result<inkwell::memory_buffer::MemoryBuffer> {
+    if metadata.is_empty() {
+        return Ok(bytecode_buffer);
+    }
+
+    bytecode_buffer
+        .append_metadata_evm(metadata)
+        .map_err(|error| anyhow::anyhow!("bytecode metadata appending error: {error}"))
+}
+
+/// Whether the size fallback is activated during the compilation.
+/// Only set once, as we're only compiling one traslation unit in a process.
+pub static IS_SIZE_FALLBACK: AtomicBool = AtomicBool::new(false);
+
+///
+/// Assembles the main buffer and its dependencies from `bytecode_buffers`.
+///
+pub fn assemble(
+    bytecode_buffers: &[&inkwell::memory_buffer::MemoryBuffer],
+    bytecode_buffer_ids: &[&str],
+    code_segment: era_compiler_common::CodeSegment,
+) -> anyhow::Result<inkwell::memory_buffer::MemoryBuffer> {
+    let code_segment = match code_segment {
+        era_compiler_common::CodeSegment::Deploy => inkwell::memory_buffer::CodeSegment::Deploy,
+        era_compiler_common::CodeSegment::Runtime => inkwell::memory_buffer::CodeSegment::Runtime,
+    };
+    inkwell::memory_buffer::MemoryBuffer::assemble_evm(
+        bytecode_buffers,
+        bytecode_buffer_ids,
+        code_segment,
+    )
+    .map_err(|error| anyhow::anyhow!("linking: {error}"))
+}
+
+///
+/// Links `bytecode_buffer` with `linker_symbols`.
+///
+pub fn link(
+    bytecode_buffer: inkwell::memory_buffer::MemoryBuffer,
+    linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
+) -> anyhow::Result<inkwell::memory_buffer::MemoryBuffer> {
+    if !bytecode_buffer.is_elf_evm() {
+        return Ok(bytecode_buffer);
+    }
+
+    let bytecode_buffer_linked = bytecode_buffer
+        .link_evm(linker_symbols)
+        .map_err(|error| anyhow::anyhow!("linking: {error}"))?;
+
+    Ok(bytecode_buffer_linked)
+}
+
+///
+/// Returns minimal deploy code patched with specified identifiers.
+///
+pub fn minimal_deploy_code(deploy_code_identifier: &str, runtime_code_identifier: &str) -> String {
+    format!(
+        r#"
+; ModuleID = '{deploy_code_identifier}'
+source_filename = "{deploy_code_identifier}"
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm-unknown-unknown"
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i256 @llvm.evm.datasize(metadata) #0
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i256 @llvm.evm.dataoffset(metadata) #0
+
+; Function Attrs: noreturn nounwind
+declare void @llvm.evm.return(ptr addrspace(1), i256) #1
+
+; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p1.p4.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(4) noalias nocapture readonly, i256, i1 immarg) #2
+
+; Function Attrs: nofree noreturn null_pointer_is_valid
+define void @__entry() local_unnamed_addr #3 {{
+entry:
+  %datasize = tail call i256 @llvm.evm.datasize(metadata !0)
+  %dataoffset = tail call i256 @llvm.evm.dataoffset(metadata !0)
+  %codecopy_source_pointer = inttoptr i256 %dataoffset to ptr addrspace(4)
+  tail call void @llvm.memcpy.p1.p4.i256(ptr addrspace(1) align 4294967296 null, ptr addrspace(4) align 1 %codecopy_source_pointer, i256 %datasize, i1 false)
+  tail call void @llvm.evm.return(ptr addrspace(1) noalias nocapture nofree noundef nonnull align 32 null, i256 %datasize)
+  unreachable
+}}
+
+attributes #0 = {{ mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none) }}
+attributes #1 = {{ noreturn nounwind }}
+attributes #2 = {{ mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }}
+attributes #3 = {{ nofree noreturn null_pointer_is_valid }}
+
+!0 = !{{!"{runtime_code_identifier}"}}
+"#
+    )
+}
+
+///
+/// Implemented by items which are translated into LLVM IR.
+///
+pub trait WriteLLVM {
+    ///
+    /// Declares the entity in the LLVM IR.
+    /// Is usually performed in order to use the item before defining it.
+    ///
+    fn declare(&mut self, _context: &mut Context) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    ///
+    /// Translates the entity into LLVM IR.
+    ///
+    fn into_llvm(self, context: &mut Context) -> anyhow::Result<()>;
+}
+
+///
+/// The dummy LLVM writable entity.
+///
+#[derive(Debug, Default, Clone)]
+pub struct DummyLLVMWritable {}
+
+impl WriteLLVM for DummyLLVMWritable {
+    fn into_llvm(self, _context: &mut Context) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/solx-codegen-evm/src/codegen/profiler/mod.rs
+++ b/solx-codegen-evm/src/codegen/profiler/mod.rs
@@ -1,0 +1,93 @@
+//!
+//! Compiler pipeline profiler.
+//!
+
+pub mod run;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use indexmap::IndexMap;
+
+use crate::optimizer::settings::Settings as OptimizerSettings;
+
+use self::run::Run;
+
+///
+/// Compiler pipeline profiler.
+///
+#[derive(Debug, Default)]
+pub struct Profiler {
+    /// Indexed map of timing entries.
+    pub timings: IndexMap<String, Rc<RefCell<Run>>>,
+}
+
+impl Profiler {
+    ///
+    /// Starts a new run for a generic part of the pipeline.
+    ///
+    pub fn start_pipeline_element(&mut self, description: &str) -> Rc<RefCell<Run>> {
+        let run_name = description.to_owned();
+        assert!(
+            !self.timings.contains_key(run_name.as_str()),
+            "Translation unit run `{run_name}` already exists"
+        );
+
+        self.start_run(run_name)
+    }
+
+    ///
+    /// Starts a new run for an EVM translation unit.
+    ///
+    pub fn start_evm_translation_unit(
+        &mut self,
+        full_path: &str,
+        code_segment: era_compiler_common::CodeSegment,
+        description: &str,
+        optimizer_settings: &OptimizerSettings,
+    ) -> Rc<RefCell<Run>> {
+        let spill_area_description = format!(
+            "SpillArea({})",
+            optimizer_settings.spill_area_size().unwrap_or_default()
+        );
+        let run_name = format!(
+            "{full_path}:{code_segment}/{description}/{optimizer_settings}/{spill_area_description}",
+        );
+        assert!(
+            !self.timings.contains_key(run_name.as_str()),
+            "Translation unit run `{run_name}` already exists"
+        );
+
+        self.start_run(run_name)
+    }
+
+    ///
+    /// Returns a serializeable vector of the profiler runs.
+    ///
+    pub fn to_vec(&self) -> Vec<(String, u64)> {
+        self.timings
+            .iter()
+            .map(|(name, run)| {
+                let run = run.borrow();
+                (
+                    name.clone(),
+                    run.duration.expect("Always exists").as_millis() as u64,
+                )
+            })
+            .collect()
+    }
+
+    ///
+    /// Starts a new run with the given name.
+    ///
+    fn start_run(&mut self, name: String) -> Rc<RefCell<Run>> {
+        assert!(
+            !self.timings.contains_key(name.as_str()),
+            "Run `{name}` already exists"
+        );
+
+        let run = Rc::new(RefCell::new(Run::default()));
+        self.timings.insert(name, run.clone());
+        run
+    }
+}

--- a/solx-codegen-evm/src/codegen/profiler/run.rs
+++ b/solx-codegen-evm/src/codegen/profiler/run.rs
@@ -1,0 +1,52 @@
+//!
+//! Compiler pipeline profiler run.
+//!
+
+use std::time::Duration;
+use std::time::Instant;
+
+///
+/// Compiler pipeline profiler run.
+///
+#[derive(Debug)]
+pub struct Run {
+    /// Start time.
+    pub start_time: Instant,
+    /// Recorded duration.
+    pub duration: Option<Duration>,
+}
+
+impl Default for Run {
+    fn default() -> Self {
+        Run {
+            start_time: Instant::now(),
+            duration: None,
+        }
+    }
+}
+
+impl Run {
+    ///
+    /// Records the duration of the run.
+    ///
+    pub fn finish(&mut self) {
+        assert!(
+            self.duration.is_none(),
+            "Duration has already been recorded"
+        );
+
+        self.duration = Some(self.start_time.elapsed());
+    }
+}
+
+impl std::fmt::Display for Run {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let duration = self
+            .duration
+            .as_ref()
+            .expect("Duration has not been recorded yet");
+
+        write!(f, "{duration:?}")?;
+        Ok(())
+    }
+}

--- a/solx-codegen-evm/src/codegen/warning.rs
+++ b/solx-codegen-evm/src/codegen/warning.rs
@@ -1,0 +1,45 @@
+//!
+//! EVM target warning.
+//!
+
+///
+/// EVM target warning.
+///
+#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Warning {
+    /// Deploy code size warning.
+    #[error(
+        "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
+        era_compiler_common::CodeSegment::Deploy,
+        crate::r#const::DEPLOY_CODE_SIZE_LIMIT
+    )]
+    DeployCodeSize {
+        /// Bytecode size.
+        found: usize,
+    },
+
+    /// Runtime code size warning.
+    #[error(
+        "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
+        era_compiler_common::CodeSegment::Runtime,
+        crate::r#const::RUNTIME_CODE_SIZE_LIMIT
+    )]
+    RuntimeCodeSize {
+        /// Bytecode size.
+        found: usize,
+    },
+}
+
+impl Warning {
+    ///
+    /// Warning code.
+    ///
+    /// Mimic `solc` warning codes where possible for compatibility.
+    ///
+    pub fn code(&self) -> Option<isize> {
+        match self {
+            Self::DeployCodeSize { .. } => Some(3860),
+            Self::RuntimeCodeSize { .. } => Some(5574),
+        }
+    }
+}

--- a/solx-codegen-evm/src/const.rs
+++ b/solx-codegen-evm/src/const.rs
@@ -1,0 +1,24 @@
+//!
+//! EVM codegen constants.
+//!
+
+/// The LLVM framework version.
+pub const LLVM_VERSION: semver::Version = semver::Version::new(19, 1, 0);
+
+/// The entry function name.
+pub const ENTRY_FUNCTION_NAME: &str = "__entry";
+
+/// The deployed Yul object identifier suffix.
+pub static YUL_OBJECT_DEPLOYED_SUFFIX: &str = "_deployed";
+
+/// Library deploy address Yul identifier.
+pub static LIBRARY_DEPLOY_ADDRESS_TAG: &str = "library_deploy_address";
+
+/// The deploy bytecode size limit.
+pub const DEPLOY_CODE_SIZE_LIMIT: usize = 49152;
+
+/// The runtime bytecode size limit.
+pub const RUNTIME_CODE_SIZE_LIMIT: usize = 24576;
+
+/// The `solc` general memory offset.
+pub const SOLC_GENERAL_MEMORY_OFFSET: u64 = 128;

--- a/solx-codegen-evm/src/context/attribute/memory.rs
+++ b/solx-codegen-evm/src/context/attribute/memory.rs
@@ -1,0 +1,36 @@
+//!
+//! The LLVM memory attribute.
+//!
+
+///
+/// The LLVM memory attribute.
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum Memory {
+    /// The corresponding value.
+    None = 0,
+    /// The corresponding value.
+    Read = 1,
+    /// The corresponding value.
+    Write = 2,
+    /// The corresponding value.
+    ArgMemOnly = 3,
+    /// The corresponding value.
+    ArgMemReadOnly = 4,
+    /// The corresponding value.
+    ArgMemWriteOnly = 5,
+    /// The corresponding value.
+    InaccessibleMemOnly = 6,
+    /// The corresponding value.
+    InaccessibleMemReadOnly = 7,
+    /// The corresponding value.
+    InaccessibleMemWriteOnly = 8,
+    /// The corresponding value.
+    InaccessibleOrArgMemOnly = 9,
+    /// The corresponding value.
+    InaccessibleOrArgMemReadOnly = 10,
+    /// The corresponding value.
+    InaccessibleOrArgMemWriteOnly = 11,
+}

--- a/solx-codegen-evm/src/context/attribute/mod.rs
+++ b/solx-codegen-evm/src/context/attribute/mod.rs
@@ -1,0 +1,222 @@
+//!
+//! The LLVM attribute.
+//!
+
+pub mod memory;
+
+///
+/// The LLVM attribute.
+///
+/// In order to check the real order in a new major version of LLVM, find the `Attributes.inc` file
+/// inside of the LLVM build directory. This order is actually generated during the building.
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum Attribute {
+    /// Unused.
+    Unused = 0,
+    /// The eponymous LLVM attribute.
+    AllocAlign,
+    /// The eponymous LLVM attribute.
+    AllocatedPointer,
+    /// The eponymous LLVM attribute.
+    AlwaysInline,
+    /// The eponymous LLVM attribute.
+    Builtin,
+    /// The eponymous LLVM attribute.
+    Cold = 5,
+    /// The eponymous LLVM attribute.
+    Convergent,
+    /// The eponymous LLVM attribute.
+    CoroDestroyOnlyWhenComplete,
+    /// The eponymous LLVM attribute.
+    DeadOnUnwind,
+    /// The eponymous LLVM attribute.
+    DisableSanitizerInstrumentation,
+    /// The eponymous LLVM attribute.
+    FnRetThunkExtern = 10,
+    /// The eponymous LLVM attribute.
+    Hot,
+    /// The eponymous LLVM attribute.
+    HybridPatchable,
+    /// The eponymous LLVM attribute.
+    ImmArg,
+    /// The eponymous LLVM attribute.
+    InReg,
+    /// The eponymous LLVM attribute.
+    InlineHint = 15,
+    /// The eponymous LLVM attribute.
+    JumpTable,
+    /// The eponymous LLVM attribute.
+    MinSize,
+    /// The eponymous LLVM attribute.
+    MustProgress,
+    /// The eponymous LLVM attribute.
+    Naked,
+    /// The eponymous LLVM attribute.
+    Nest = 20,
+    /// The eponymous LLVM attribute.
+    NoAlias,
+    /// The eponymous LLVM attribute.
+    NoBuiltin,
+    /// The eponymous LLVM attribute.
+    NoCallback,
+    /// The eponymous LLVM attribute.
+    NoCapture,
+    /// The eponymous LLVM attribute.
+    NoCfCheck = 25,
+    /// The eponymous LLVM attribute.
+    NoDuplicate,
+    /// The eponymous LLVM attribute.
+    NoFree,
+    /// The eponymous LLVM attribute.
+    NoImplicitFloat,
+    /// The eponymous LLVM attribute.
+    NoInline,
+    /// The eponymous LLVM attribute.
+    NoMerge = 30,
+    /// The eponymous LLVM attribute.
+    NoProfile,
+    /// The eponymous LLVM attribute.
+    NoRecurse,
+    /// The eponymous LLVM attribute.
+    NoRedZone,
+    /// The eponymous LLVM attribute.
+    NoReturn,
+    /// The eponymous LLVM attribute.
+    NoSanitizeBounds = 35,
+    /// The eponymous LLVM attribute.
+    NoSanitizeCoverage,
+    /// The eponymous LLVM attribute.
+    NoSync,
+    /// The eponymous LLVM attribute.
+    NoUndef,
+    /// The eponymous LLVM attribute.
+    NoUnwind,
+    /// The eponymous LLVM attribute.
+    NonLazyBind = 40,
+    /// The eponymous LLVM attribute.
+    NonNull,
+    /// The eponymous LLVM attribute.
+    NullPointerIsValid,
+    /// The eponymous LLVM attribute.
+    OptForFuzzing,
+    /// The eponymous LLVM attribute.
+    OptimizeForDebugging,
+    /// The eponymous LLVM attribute.
+    OptimizeForSize = 45,
+    /// The eponymous LLVM attribute.
+    OptimizeNone,
+    /// The eponymous LLVM attribute.
+    PresplitCoroutine,
+    /// The eponymous LLVM attribute.
+    ReadNone,
+    /// The eponymous LLVM attribute.
+    ReadOnly,
+    /// The eponymous LLVM attribute.
+    Returned = 50,
+    /// The eponymous LLVM attribute.
+    ReturnsTwice,
+    /// The eponymous LLVM attribute.
+    SExt,
+    /// The eponymous LLVM attribute.
+    SafeStack,
+    /// The eponymous LLVM attribute.
+    SanitizeAddress,
+    /// The eponymous LLVM attribute.
+    SanitizeHWAddress = 55,
+    /// The eponymous LLVM attribute.
+    SanitizeMemTag,
+    /// The eponymous LLVM attribute.
+    SanitizeMemory,
+    /// The eponymous LLVM attribute.
+    SanitizeNumericalStability,
+    /// The eponymous LLVM attribute.
+    SanitizeThread,
+    /// The eponymous LLVM attribute.
+    ShadowCallStack = 60,
+    /// The eponymous LLVM attribute.
+    SkipProfile,
+    /// The eponymous LLVM attribute.
+    Speculatable,
+    /// The eponymous LLVM attribute.
+    SpeculativeLoadHardening,
+    /// The eponymous LLVM attribute.
+    StackProtect,
+    /// The eponymous LLVM attribute.
+    StackProtectReq = 65,
+    /// The eponymous LLVM attribute.
+    StackProtectStrong,
+    /// The eponymous LLVM attribute.
+    StrictFP,
+    /// The eponymous LLVM attribute.
+    SwiftAsync,
+    /// The eponymous LLVM attribute.
+    SwiftError,
+    /// The eponymous LLVM attribute.
+    SwiftSelf = 70,
+    /// The eponymous LLVM attribute.
+    WillReturn,
+    /// The eponymous LLVM attribute.
+    Writable,
+    /// The eponymous LLVM attribute.
+    WriteOnly,
+    /// The eponymous LLVM attribute.
+    ZExt,
+    /// The eponymous LLVM attribute.
+    ByRef = 75,
+    /// The eponymous LLVM attribute.
+    ByVal,
+    /// The eponymous LLVM attribute.
+    ElementType,
+    /// The eponymous LLVM attribute.
+    InAlloca,
+    /// The eponymous LLVM attribute.
+    Preallocated,
+    /// The eponymous LLVM attribute.
+    StructRet = 80,
+    /// The eponymous LLVM attribute.
+    Alignment,
+    /// The eponymous LLVM attribute.
+    AllocKind,
+    /// The eponymous LLVM attribute.
+    AllocSize,
+    /// The eponymous LLVM attribute.
+    Dereferenceable,
+    /// The eponymous LLVM attribute.
+    DereferenceableOrNull = 85,
+    /// The eponymous LLVM attribute.
+    Memory,
+    /// The eponymous LLVM attribute.
+    NoFPClass,
+    /// The eponymous LLVM attribute.
+    StackAlignment,
+    /// The eponymous LLVM attribute.
+    UWTable,
+    /// The eponymous LLVM attribute.
+    VScaleRange = 90,
+    /// The eponymous LLVM attribute.
+    Range,
+    /// The eponymous LLVM attribute.
+    Initializes,
+}
+
+impl TryFrom<&str> for Attribute {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "AlwaysInline" => Ok(Attribute::AlwaysInline),
+            "Cold" => Ok(Attribute::Cold),
+            "Hot" => Ok(Attribute::Hot),
+            "MinSize" => Ok(Attribute::MinSize),
+            "OptimizeForSize" => Ok(Attribute::OptimizeForSize),
+            "NoInline" => Ok(Attribute::NoInline),
+            "WillReturn" => Ok(Attribute::WillReturn),
+            "NoReturn" => Ok(Attribute::NoReturn),
+            "MustProgress" => Ok(Attribute::MustProgress),
+            _ => Err(value.to_owned()),
+        }
+    }
+}

--- a/solx-codegen-evm/src/context/function/block/evmla_data.rs
+++ b/solx-codegen-evm/src/context/function/block/evmla_data.rs
@@ -1,0 +1,23 @@
+//!
+//! The LLVM function block EVM legacy assembly data.
+//!
+
+///
+/// The LLVM function block EVM legacy assembly data.
+///
+/// Describes some data that is only relevant to the EVM legacy assembly.
+///
+#[derive(Debug, Clone)]
+pub struct EVMLAData {
+    /// The initial hashes of the allowed stack states.
+    pub stack_hashes: Vec<u64>,
+}
+
+impl EVMLAData {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(stack_hashes: Vec<u64>) -> Self {
+        Self { stack_hashes }
+    }
+}

--- a/solx-codegen-evm/src/context/function/block/key.rs
+++ b/solx-codegen-evm/src/context/function/block/key.rs
@@ -1,0 +1,39 @@
+//!
+//! The LLVM IR generator function block key.
+//!
+
+///
+/// The LLVM IR generator function block key.
+///
+/// Is only relevant to the EVM legacy assembly.
+///
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Key {
+    /// The block code type.
+    pub code_segment: era_compiler_common::CodeSegment,
+    /// The block tag.
+    pub tag: num::BigUint,
+}
+
+impl Key {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(code_segment: era_compiler_common::CodeSegment, tag: num::BigUint) -> Self {
+        Self { code_segment, tag }
+    }
+}
+
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}_{}",
+            match self.code_segment {
+                era_compiler_common::CodeSegment::Deploy => "dt",
+                era_compiler_common::CodeSegment::Runtime => "rt",
+            },
+            self.tag
+        )
+    }
+}

--- a/solx-codegen-evm/src/context/function/block/mod.rs
+++ b/solx-codegen-evm/src/context/function/block/mod.rs
@@ -1,0 +1,69 @@
+//!
+//! The LLVM IR generator function block.
+//!
+
+pub mod evmla_data;
+pub mod key;
+
+use self::evmla_data::EVMLAData;
+
+///
+/// The LLVM IR generator function block.
+///
+#[derive(Debug, Clone)]
+pub struct Block<'ctx> {
+    /// The inner block.
+    inner: inkwell::basic_block::BasicBlock<'ctx>,
+    /// The EVM legacy assembly compiler data.
+    evmla_data: Option<EVMLAData>,
+}
+
+impl<'ctx> Block<'ctx> {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(inner: inkwell::basic_block::BasicBlock<'ctx>) -> Self {
+        Self {
+            inner,
+            evmla_data: None,
+        }
+    }
+
+    ///
+    /// Sets the EVM legacy assembly data.
+    ///
+    pub fn set_evmla_data(&mut self, data: EVMLAData) {
+        self.evmla_data = Some(data);
+    }
+
+    ///
+    /// The LLVM object reference.
+    ///
+    pub fn inner(&self) -> inkwell::basic_block::BasicBlock<'ctx> {
+        self.inner
+    }
+
+    ///
+    /// Returns the EVM data reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    pub fn evm(&self) -> &EVMLAData {
+        self.evmla_data
+            .as_ref()
+            .expect("The EVM data must have been initialized")
+    }
+
+    ///
+    /// Returns the EVM data mutable reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    pub fn evm_mut(&mut self) -> &mut EVMLAData {
+        self.evmla_data
+            .as_mut()
+            .expect("The EVM data must have been initialized")
+    }
+}

--- a/solx-codegen-evm/src/context/function/declaration.rs
+++ b/solx-codegen-evm/src/context/function/declaration.rs
@@ -1,0 +1,26 @@
+//!
+//! The LLVM function declaration.
+//!
+
+///
+/// The LLVM function declaration.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Declaration<'ctx> {
+    /// The function type.
+    pub r#type: inkwell::types::FunctionType<'ctx>,
+    /// The function value.
+    pub value: inkwell::values::FunctionValue<'ctx>,
+}
+
+impl<'ctx> Declaration<'ctx> {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        r#type: inkwell::types::FunctionType<'ctx>,
+        value: inkwell::values::FunctionValue<'ctx>,
+    ) -> Self {
+        Self { r#type, value }
+    }
+}

--- a/solx-codegen-evm/src/context/function/evmla_data.rs
+++ b/solx-codegen-evm/src/context/function/evmla_data.rs
@@ -1,0 +1,45 @@
+//!
+//! The LLVM function EVM legacy assembly data.
+//!
+
+use std::collections::BTreeMap;
+
+use crate::context::function::block::key::Key as BlockKey;
+use crate::context::function::block::Block;
+
+///
+/// The LLVM function EVM legacy assembly data.
+///
+/// Describes some data that is only relevant to the EVM legacy assembly.
+///
+#[derive(Debug)]
+pub struct EVMLAData<'ctx> {
+    /// The ordinary blocks with numeric tags.
+    /// Is only used by the Solidity EVM compiler.
+    pub blocks: BTreeMap<BlockKey, Vec<Block<'ctx>>>,
+    /// The function stack size.
+    pub stack_size: usize,
+}
+
+impl<'ctx> EVMLAData<'ctx> {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(stack_size: usize) -> Self {
+        Self {
+            blocks: BTreeMap::new(),
+            stack_size,
+        }
+    }
+
+    ///
+    /// Inserts a function block.
+    ///
+    pub fn insert_block(&mut self, key: BlockKey, block: Block<'ctx>) {
+        if let Some(blocks) = self.blocks.get_mut(&key) {
+            blocks.push(block);
+        } else {
+            self.blocks.insert(key, vec![block]);
+        }
+    }
+}

--- a/solx-codegen-evm/src/context/function/mod.rs
+++ b/solx-codegen-evm/src/context/function/mod.rs
@@ -1,0 +1,8 @@
+//!
+//! The common LLVM function entities.
+//!
+
+pub mod block;
+pub mod declaration;
+pub mod evmla_data;
+pub mod r#return;

--- a/solx-codegen-evm/src/context/function/return.rs
+++ b/solx-codegen-evm/src/context/function/return.rs
@@ -1,0 +1,92 @@
+//!
+//! The LLVM IR generator function return entity.
+//!
+
+use crate::context::pointer::Pointer;
+use crate::context::traits::address_space::IAddressSpace;
+
+///
+/// The LLVM IR generator function return entity.
+///
+#[derive(Debug, Clone, Copy)]
+pub enum Return<'ctx, AS>
+where
+    AS: IAddressSpace
+        + Clone
+        + Copy
+        + PartialEq
+        + Eq
+        + Into<inkwell::AddressSpace>
+        + std::fmt::Debug,
+{
+    /// The function does not return a value.
+    None,
+    /// The function returns a primitive value.
+    Primitive {
+        /// The primitive value pointer allocated at the function entry.
+        pointer: Pointer<'ctx, AS>,
+    },
+    /// The function returns a compound value.
+    /// In this case, the return pointer is allocated on the stack by the callee.
+    Compound {
+        /// The structure pointer allocated at the function entry.
+        pointer: Pointer<'ctx, AS>,
+        /// The function return type size.
+        size: usize,
+    },
+}
+
+impl<'ctx, AS> Return<'ctx, AS>
+where
+    AS: IAddressSpace
+        + Clone
+        + Copy
+        + PartialEq
+        + Eq
+        + Into<inkwell::AddressSpace>
+        + std::fmt::Debug,
+{
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn none() -> Self {
+        Self::None
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn primitive(pointer: Pointer<'ctx, AS>) -> Self {
+        Self::Primitive { pointer }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn compound(pointer: Pointer<'ctx, AS>, size: usize) -> Self {
+        Self::Compound { pointer, size }
+    }
+
+    ///
+    /// Returns the pointer to the function return value.
+    ///
+    pub fn return_pointer(&self) -> Option<Pointer<'ctx, AS>> {
+        match self {
+            Return::None => None,
+            Return::Primitive { pointer } => Some(pointer.to_owned()),
+            Return::Compound { pointer, .. } => Some(pointer.to_owned()),
+        }
+    }
+
+    ///
+    /// Returns the return data size in bytes, based on the default stack alignment.
+    ///
+    pub fn return_data_size(&self) -> usize {
+        era_compiler_common::BYTE_LENGTH_FIELD
+            * match self {
+                Self::None => 0,
+                Self::Primitive { .. } => 1,
+                Self::Compound { size, .. } => *size,
+            }
+    }
+}

--- a/solx-codegen-evm/src/context/loop.rs
+++ b/solx-codegen-evm/src/context/loop.rs
@@ -1,0 +1,33 @@
+//!
+//! The LLVM IR generator loop.
+//!
+
+///
+/// The LLVM IR generator loop.
+///
+#[derive(Debug, Clone)]
+pub struct Loop<'ctx> {
+    /// The loop current block.
+    pub body_block: inkwell::basic_block::BasicBlock<'ctx>,
+    /// The increment block before the body.
+    pub continue_block: inkwell::basic_block::BasicBlock<'ctx>,
+    /// The join block after the body.
+    pub join_block: inkwell::basic_block::BasicBlock<'ctx>,
+}
+
+impl<'ctx> Loop<'ctx> {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        body_block: inkwell::basic_block::BasicBlock<'ctx>,
+        continue_block: inkwell::basic_block::BasicBlock<'ctx>,
+        join_block: inkwell::basic_block::BasicBlock<'ctx>,
+    ) -> Self {
+        Self {
+            body_block,
+            continue_block,
+            join_block,
+        }
+    }
+}

--- a/solx-codegen-evm/src/context/mod.rs
+++ b/solx-codegen-evm/src/context/mod.rs
@@ -1,0 +1,587 @@
+//!
+//! The LLVM module context trait.
+//!
+
+pub mod attribute;
+pub mod function;
+pub mod r#loop;
+pub mod pointer;
+pub mod traits;
+pub mod value;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use inkwell::types::BasicType;
+use inkwell::values::BasicValue;
+
+use crate::debug_config::DebugConfig;
+use crate::optimizer::Optimizer;
+
+use self::function::declaration::Declaration as FunctionDeclaration;
+use self::pointer::Pointer;
+use self::r#loop::Loop;
+use self::traits::address_space::IAddressSpace;
+use self::traits::evmla_data::IEVMLAData;
+use self::traits::evmla_function::IEVMLAFunction;
+use self::traits::solidity_data::ISolidityData;
+use self::traits::yul_data::IYulData;
+
+///
+/// The LLVM module context trait.
+///
+pub trait IContext<'ctx> {
+    ///
+    /// The address space unique to each target.
+    ///
+    type AddressSpace: IAddressSpace
+        + Clone
+        + Copy
+        + PartialEq
+        + Eq
+        + Into<inkwell::AddressSpace>
+        + std::fmt::Debug;
+
+    ///
+    /// The function type.
+    ///
+    type Function: IEVMLAFunction<'ctx>;
+
+    ///
+    /// The Solidity extra data type.
+    ///
+    type SolidityData: ISolidityData;
+
+    ///
+    /// The Yul extra data type.
+    ///
+    type YulData: IYulData;
+
+    ///
+    /// The EVMLA extra data type.
+    ///
+    type EVMLAData: IEVMLAData<'ctx>;
+
+    ///
+    /// The Solidity extra data type.
+    ///
+    type VyperData;
+
+    ///
+    /// Returns the inner LLVM context.
+    ///
+    fn llvm(&self) -> &'ctx inkwell::context::Context;
+
+    ///
+    /// Returns the LLVM IR builder.
+    ///
+    fn builder(&self) -> &inkwell::builder::Builder<'ctx>;
+
+    ///
+    /// Returns the current LLVM IR module reference.
+    ///
+    fn module(&self) -> &inkwell::module::Module<'ctx>;
+
+    ///
+    /// Returns the optimizer reference.
+    ///
+    fn optimizer(&self) -> &Optimizer;
+
+    ///
+    /// Returns the debug config reference.
+    ///
+    fn debug_config(&self) -> Option<&DebugConfig>;
+
+    ///
+    /// Sets the code type.
+    ///
+    fn set_code_segment(&mut self, code_segment: era_compiler_common::CodeSegment);
+
+    ///
+    /// Returns the code type.
+    ///
+    fn code_segment(&self) -> Option<era_compiler_common::CodeSegment>;
+
+    ///
+    /// Appends a new basic block to the current function.
+    ///
+    fn append_basic_block(&self, name: &str) -> inkwell::basic_block::BasicBlock<'ctx>;
+
+    ///
+    /// Sets the current basic block.
+    ///
+    fn set_basic_block(&self, block: inkwell::basic_block::BasicBlock<'ctx>);
+
+    ///
+    /// Returns the current basic block.
+    ///
+    fn basic_block(&self) -> inkwell::basic_block::BasicBlock<'ctx>;
+
+    ///
+    /// Pushes a new loop context to the stack.
+    ///
+    fn push_loop(
+        &mut self,
+        body_block: inkwell::basic_block::BasicBlock<'ctx>,
+        continue_block: inkwell::basic_block::BasicBlock<'ctx>,
+        join_block: inkwell::basic_block::BasicBlock<'ctx>,
+    );
+
+    ///
+    /// Pops the current loop context from the stack.
+    ///
+    fn pop_loop(&mut self);
+
+    ///
+    /// Returns the current loop context.
+    ///
+    fn r#loop(&self) -> &Loop<'ctx>;
+
+    ///
+    /// Appends a function to the current module.
+    ///
+    fn add_function(
+        &mut self,
+        name: &str,
+        r#type: inkwell::types::FunctionType<'ctx>,
+        return_values_length: usize,
+        linkage: Option<inkwell::module::Linkage>,
+    ) -> anyhow::Result<Rc<RefCell<Self::Function>>>;
+
+    ///
+    /// Returns a shared reference to the specified function.
+    ///
+    fn get_function(&self, name: &str) -> Option<Rc<RefCell<Self::Function>>>;
+
+    ///
+    /// Returns a shared reference to the current active function.
+    ///
+    fn current_function(&self) -> Rc<RefCell<Self::Function>>;
+
+    ///
+    /// Sets the current active function.
+    ///
+    fn set_current_function(&mut self, name: &str) -> anyhow::Result<()>;
+
+    ///
+    /// Builds a stack allocation instruction.
+    ///
+    /// Sets the alignment to 256 bits.
+    ///
+    fn build_alloca<T>(
+        &self,
+        r#type: T,
+        name: &str,
+    ) -> anyhow::Result<Pointer<'ctx, Self::AddressSpace>>
+    where
+        T: BasicType<'ctx> + Clone + Copy,
+    {
+        let pointer = self.builder().build_alloca(r#type, name)?;
+        self.basic_block()
+            .get_last_instruction()
+            .expect("Always exists")
+            .set_alignment(era_compiler_common::BYTE_LENGTH_FIELD as u32)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        Ok(Pointer::new(r#type, Self::AddressSpace::stack(), pointer))
+    }
+
+    ///
+    /// Builds a stack load instruction.
+    ///
+    /// Sets the alignment to 256 bits for the stack and 1 bit for the heap, parent, and child.
+    ///
+    fn build_load(
+        &self,
+        pointer: Pointer<'ctx, Self::AddressSpace>,
+        name: &str,
+    ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
+        let value = self
+            .builder()
+            .build_load(pointer.r#type, pointer.value, name)?;
+
+        let alignment = if Self::AddressSpace::stack() == pointer.address_space {
+            era_compiler_common::BYTE_LENGTH_FIELD
+        } else {
+            era_compiler_common::BYTE_LENGTH_BYTE
+        };
+
+        self.basic_block()
+            .get_last_instruction()
+            .expect("Always exists")
+            .set_alignment(alignment as u32)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        Ok(value)
+    }
+
+    ///
+    /// Builds a stack store instruction.
+    ///
+    /// Sets the alignment to 256 bits for the stack and 1 bit for the heap, parent, and child.
+    ///
+    fn build_store<V>(
+        &self,
+        pointer: Pointer<'ctx, Self::AddressSpace>,
+        value: V,
+    ) -> anyhow::Result<()>
+    where
+        V: BasicValue<'ctx>,
+    {
+        let instruction = self.builder().build_store(pointer.value, value)?;
+
+        let alignment = if Self::AddressSpace::stack() == pointer.address_space {
+            era_compiler_common::BYTE_LENGTH_FIELD
+        } else {
+            era_compiler_common::BYTE_LENGTH_BYTE
+        };
+
+        instruction
+            .set_alignment(alignment as u32)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        Ok(())
+    }
+
+    ///
+    /// Builds a GEP instruction.
+    ///
+    fn build_gep<T>(
+        &self,
+        pointer: Pointer<'ctx, Self::AddressSpace>,
+        indexes: &[inkwell::values::IntValue<'ctx>],
+        element_type: T,
+        name: &str,
+    ) -> anyhow::Result<Pointer<'ctx, Self::AddressSpace>>
+    where
+        T: BasicType<'ctx>,
+    {
+        let value = unsafe {
+            self.builder()
+                .build_gep(pointer.r#type, pointer.value, indexes, name)?
+        };
+        Ok(Pointer::new(element_type, pointer.address_space, value))
+    }
+
+    ///
+    /// Builds a conditional branch.
+    ///
+    /// Checks if there are no other terminators in the block.
+    ///
+    fn build_conditional_branch(
+        &self,
+        comparison: inkwell::values::IntValue<'ctx>,
+        then_block: inkwell::basic_block::BasicBlock<'ctx>,
+        else_block: inkwell::basic_block::BasicBlock<'ctx>,
+    ) -> anyhow::Result<()> {
+        if self.basic_block().get_terminator().is_some() {
+            return Ok(());
+        }
+
+        self.builder()
+            .build_conditional_branch(comparison, then_block, else_block)?;
+        Ok(())
+    }
+
+    ///
+    /// Builds an unconditional branch.
+    ///
+    /// Checks if there are no other terminators in the block.
+    ///
+    fn build_unconditional_branch(
+        &self,
+        destination_block: inkwell::basic_block::BasicBlock<'ctx>,
+    ) -> anyhow::Result<()> {
+        if self.basic_block().get_terminator().is_some() {
+            return Ok(());
+        }
+
+        self.builder()
+            .build_unconditional_branch(destination_block)?;
+        Ok(())
+    }
+
+    ///
+    /// Builds a call.
+    ///
+    fn build_call(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>;
+
+    ///
+    /// Builds a call with metadata arguments.
+    ///
+    fn build_call_metadata(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicMetadataValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>;
+
+    ///
+    /// Builds an invoke.
+    ///
+    /// Is defaulted to a call if there is no global exception handler.
+    ///
+    fn build_invoke(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        arguments: &[inkwell::values::BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>;
+
+    ///
+    /// Builds a memory copy call.
+    ///
+    /// Sets the alignment to `1`, since all non-stack memory pages have such alignment.
+    ///
+    fn build_memcpy(
+        &self,
+        function: FunctionDeclaration<'ctx>,
+        destination: Pointer<'ctx, Self::AddressSpace>,
+        source: Pointer<'ctx, Self::AddressSpace>,
+        size: inkwell::values::IntValue<'ctx>,
+        name: &str,
+    ) -> anyhow::Result<()> {
+        let call_site_value = self.builder().build_indirect_call(
+            function.r#type,
+            function.value.as_global_value().as_pointer_value(),
+            &[
+                destination.value.as_basic_value_enum().into(),
+                source.value.as_basic_value_enum().into(),
+                size.as_basic_value_enum().into(),
+                self.bool_type().const_zero().as_basic_value_enum().into(),
+            ],
+            name,
+        )?;
+
+        call_site_value.set_alignment_attribute(inkwell::attributes::AttributeLoc::Param(0), 1);
+        call_site_value.set_alignment_attribute(inkwell::attributes::AttributeLoc::Param(1), 1);
+        Ok(())
+    }
+
+    ///
+    /// Builds a return.
+    ///
+    /// Checks if there are no other terminators in the block.
+    ///
+    fn build_return(&self, value: Option<&dyn BasicValue<'ctx>>) -> anyhow::Result<()> {
+        if self.basic_block().get_terminator().is_some() {
+            return Ok(());
+        }
+
+        self.builder().build_return(value)?;
+        Ok(())
+    }
+
+    ///
+    /// Builds an unreachable.
+    ///
+    /// Checks if there are no other terminators in the block.
+    ///
+    fn build_unreachable(&self) -> anyhow::Result<()> {
+        if self.basic_block().get_terminator().is_some() {
+            return Ok(());
+        }
+
+        self.builder().build_unreachable()?;
+        Ok(())
+    }
+
+    ///
+    /// Returns a boolean type constant.
+    ///
+    fn bool_const(&self, value: bool) -> inkwell::values::IntValue<'ctx> {
+        self.bool_type().const_int(u64::from(value), false)
+    }
+
+    ///
+    /// Returns an integer type constant.
+    ///
+    fn integer_const(&self, bit_length: usize, value: u64) -> inkwell::values::IntValue<'ctx> {
+        self.integer_type(bit_length).const_int(value, false)
+    }
+
+    ///
+    /// Returns a 256-bit field type constant.
+    ///
+    fn field_const(&self, value: u64) -> inkwell::values::IntValue<'ctx> {
+        self.field_type().const_int(value, false)
+    }
+
+    ///
+    /// Returns a 256-bit field type undefined value.
+    ///
+    fn field_undef(&self) -> inkwell::values::IntValue<'ctx> {
+        self.field_type().get_undef()
+    }
+
+    ///
+    /// Returns a field type constant from a decimal string.
+    ///
+    fn field_const_str_dec(&self, value: &str) -> inkwell::values::IntValue<'ctx> {
+        self.field_type()
+            .const_int_from_string(value, inkwell::types::StringRadix::Decimal)
+            .unwrap_or_else(|| panic!("Invalid string constant `{value}`"))
+    }
+
+    ///
+    /// Returns a field type constant from a hexadecimal string.
+    ///
+    fn field_const_str_hex(&self, value: &str) -> inkwell::values::IntValue<'ctx> {
+        self.field_type()
+            .const_int_from_string(
+                value.strip_prefix("0x").unwrap_or(value),
+                inkwell::types::StringRadix::Hexadecimal,
+            )
+            .unwrap_or_else(|| panic!("Invalid string constant `{value}`"))
+    }
+
+    ///
+    /// Returns the void type.
+    ///
+    fn void_type(&self) -> inkwell::types::VoidType<'ctx> {
+        self.llvm().void_type()
+    }
+
+    ///
+    /// Returns the boolean type.
+    ///
+    fn bool_type(&self) -> inkwell::types::IntType<'ctx> {
+        self.llvm().bool_type()
+    }
+
+    ///
+    /// Returns the default byte type.
+    ///
+    fn byte_type(&self) -> inkwell::types::IntType<'ctx> {
+        self.integer_type(era_compiler_common::BIT_LENGTH_BYTE)
+    }
+
+    ///
+    /// Returns the integer type of the specified bit-length.
+    ///
+    fn integer_type(&self, bit_length: usize) -> inkwell::types::IntType<'ctx> {
+        self.llvm().custom_width_int_type(bit_length as u32)
+    }
+
+    ///
+    /// Returns the default field type.
+    ///
+    fn field_type(&self) -> inkwell::types::IntType<'ctx> {
+        self.integer_type(era_compiler_common::BIT_LENGTH_FIELD)
+    }
+
+    ///
+    /// Returns the pointer type with a specified address space.
+    ///
+    fn ptr_type(&self, address_space: inkwell::AddressSpace) -> inkwell::types::PointerType<'ctx> {
+        self.llvm().ptr_type(address_space)
+    }
+
+    ///
+    /// Returns the array type with the specified length.
+    ///
+    fn array_type<T>(&self, element_type: T, length: usize) -> inkwell::types::ArrayType<'ctx>
+    where
+        T: BasicType<'ctx>,
+    {
+        element_type.array_type(length as u32)
+    }
+
+    ///
+    /// Returns the structure type with specified fields.
+    ///
+    fn structure_type<T>(&self, field_types: &[T]) -> inkwell::types::StructType<'ctx>
+    where
+        T: BasicType<'ctx>,
+    {
+        let field_types: Vec<inkwell::types::BasicTypeEnum<'ctx>> =
+            field_types.iter().map(T::as_basic_type_enum).collect();
+        self.llvm().struct_type(field_types.as_slice(), false)
+    }
+
+    ///
+    /// Sets the Solidity data.
+    ///
+    fn set_solidity_data(&mut self, data: Self::SolidityData);
+
+    ///
+    /// Returns the Solidity data reference.
+    ///
+    /// # Panics
+    /// If the Solidity data has not been initialized.
+    ///
+    fn solidity(&self) -> Option<&Self::SolidityData>;
+
+    ///
+    /// Returns the Solidity data mutable reference.
+    ///
+    /// # Panics
+    /// If the Solidity data has not been initialized.
+    ///
+    fn solidity_mut(&mut self) -> Option<&mut Self::SolidityData>;
+
+    ///
+    /// Sets the Yul data.
+    ///
+    fn set_yul_data(&mut self, data: Self::YulData);
+
+    ///
+    /// Returns the Yul data reference.
+    ///
+    /// # Panics
+    /// If the Yul data has not been initialized.
+    ///
+    fn yul(&self) -> Option<&Self::YulData>;
+
+    ///
+    /// Returns the Yul data mutable reference.
+    ///
+    /// # Panics
+    /// If the Yul data has not been initialized.
+    ///
+    fn yul_mut(&mut self) -> Option<&mut Self::YulData>;
+
+    ///
+    /// Sets the EVM legacy assembly data.
+    ///
+    fn set_evmla_data(&mut self, data: Self::EVMLAData);
+
+    ///
+    /// Returns the EVM legacy assembly data reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    fn evmla(&self) -> Option<&Self::EVMLAData>;
+
+    ///
+    /// Returns the EVM legacy assembly data mutable reference.
+    ///
+    /// # Panics
+    /// If the EVM data has not been initialized.
+    ///
+    fn evmla_mut(&mut self) -> Option<&mut Self::EVMLAData>;
+
+    ///
+    /// Sets the EVM legacy assembly data.
+    ///
+    fn set_vyper_data(&mut self, data: Self::VyperData);
+
+    ///
+    /// Returns the Vyper data reference.
+    ///
+    /// # Panics
+    /// If the Vyper data has not been initialized.
+    ///
+    fn vyper(&self) -> Option<&Self::VyperData>;
+
+    ///
+    /// Returns the Vyper data mutable reference.
+    ///
+    /// # Panics
+    /// If the Vyper data has not been initialized.
+    ///
+    fn vyper_mut(&mut self) -> Option<&mut Self::VyperData>;
+}

--- a/solx-codegen-evm/src/context/pointer.rs
+++ b/solx-codegen-evm/src/context/pointer.rs
@@ -1,0 +1,119 @@
+//!
+//! The LLVM pointer.
+//!
+
+use inkwell::types::BasicType;
+use inkwell::values::BasicValue;
+
+use crate::context::traits::address_space::IAddressSpace;
+use crate::context::IContext;
+
+///
+/// The LLVM pointer.
+///
+#[derive(Debug, Clone, Copy)]
+pub struct Pointer<'ctx, AS>
+where
+    AS: IAddressSpace
+        + Clone
+        + Copy
+        + PartialEq
+        + Eq
+        + Into<inkwell::AddressSpace>
+        + std::fmt::Debug,
+{
+    /// The pointee type.
+    pub r#type: inkwell::types::BasicTypeEnum<'ctx>,
+    /// The address space.
+    pub address_space: AS,
+    /// The pointer value.
+    pub value: inkwell::values::PointerValue<'ctx>,
+}
+
+impl<'ctx, AS> Pointer<'ctx, AS>
+where
+    AS: IAddressSpace
+        + Clone
+        + Copy
+        + PartialEq
+        + Eq
+        + Into<inkwell::AddressSpace>
+        + std::fmt::Debug,
+{
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new<T>(r#type: T, address_space: AS, value: inkwell::values::PointerValue<'ctx>) -> Self
+    where
+        T: BasicType<'ctx>,
+    {
+        Self {
+            r#type: r#type.as_basic_type_enum(),
+            address_space,
+            value,
+        }
+    }
+
+    ///
+    /// Wraps a 256-bit primitive type pointer.
+    ///
+    pub fn new_stack_field<C>(context: &C, value: inkwell::values::PointerValue<'ctx>) -> Self
+    where
+        C: IContext<'ctx>,
+    {
+        Self {
+            r#type: context.field_type().as_basic_type_enum(),
+            address_space: AS::stack(),
+            value,
+        }
+    }
+
+    ///
+    /// Creates a new pointer with the specified `offset`.
+    ///
+    pub fn new_with_offset<C, T>(
+        context: &C,
+        address_space: AS,
+        r#type: T,
+        offset: inkwell::values::IntValue<'ctx>,
+        name: &str,
+    ) -> anyhow::Result<Self>
+    where
+        C: IContext<'ctx>,
+        T: BasicType<'ctx>,
+    {
+        assert_ne!(
+            address_space,
+            AS::stack(),
+            "Stack pointers cannot be addressed"
+        );
+
+        let value = context.builder().build_int_to_ptr(
+            offset,
+            context.ptr_type(address_space.into()),
+            name,
+        )?;
+        Ok(Self::new(r#type, address_space, value))
+    }
+
+    ///
+    /// Casts the pointer into another type.
+    ///
+    pub fn cast<T>(self, r#type: T) -> Self
+    where
+        T: BasicType<'ctx>,
+    {
+        Self {
+            r#type: r#type.as_basic_type_enum(),
+            address_space: self.address_space,
+            value: self.value,
+        }
+    }
+
+    ///
+    /// Converts the pointer to a value enum.
+    ///
+    pub fn as_basic_value_enum(self) -> inkwell::values::BasicValueEnum<'ctx> {
+        self.value.as_basic_value_enum()
+    }
+}

--- a/solx-codegen-evm/src/context/traits/address_space.rs
+++ b/solx-codegen-evm/src/context/traits/address_space.rs
@@ -1,0 +1,13 @@
+//!
+//! The LLVM IR address space trait.
+//!
+
+///
+/// The LLVM IR address space trait.
+///
+pub trait IAddressSpace {
+    ///
+    /// Returns the stack address space.
+    ///
+    fn stack() -> Self;
+}

--- a/solx-codegen-evm/src/context/traits/evmla_data.rs
+++ b/solx-codegen-evm/src/context/traits/evmla_data.rs
@@ -1,0 +1,34 @@
+//!
+//! The LLVM IR EVMLA data trait.
+//!
+
+use crate::context::value::Value;
+
+///
+/// The LLVM IR EVMLA data trait.
+///
+pub trait IEVMLAData<'ctx> {
+    ///
+    /// Returns the element from the specified stack position.
+    ///
+    /// # Panics
+    /// If `position` is out of bounds.
+    ///
+    fn get_element(&self, position: usize) -> &Value<'ctx>;
+
+    ///
+    /// Sets the element at the specified stack position.
+    ///
+    /// # Panics
+    /// If `position` is out of bounds.
+    ///
+    fn set_element(&mut self, position: usize, value: Value<'ctx>);
+
+    ///
+    /// Sets the compile-time string representation to the element at the specified stack position.
+    ///
+    /// # Panics
+    /// If `position` is out of bounds.
+    ///
+    fn set_original(&mut self, position: usize, original: String);
+}

--- a/solx-codegen-evm/src/context/traits/evmla_function.rs
+++ b/solx-codegen-evm/src/context/traits/evmla_function.rs
@@ -1,0 +1,18 @@
+//!
+//! The LLVM IR EVMLA function trait.
+//!
+
+use crate::context::function::block::key::Key as BlockKey;
+use crate::context::function::block::Block;
+
+///
+/// The LLVM IR EVMLA function trait.
+///
+pub trait IEVMLAFunction<'ctx> {
+    ///
+    /// Returns the block with the specified tag and initial stack pattern.
+    ///
+    /// If there is only one block, it is returned unconditionally.
+    ///
+    fn find_block(&self, key: &BlockKey, stack_hash: &u64) -> anyhow::Result<Block<'ctx>>;
+}

--- a/solx-codegen-evm/src/context/traits/mod.rs
+++ b/solx-codegen-evm/src/context/traits/mod.rs
@@ -1,0 +1,9 @@
+//!
+//! The LLVM context traits.
+//!
+
+pub mod address_space;
+pub mod evmla_data;
+pub mod evmla_function;
+pub mod solidity_data;
+pub mod yul_data;

--- a/solx-codegen-evm/src/context/traits/solidity_data.rs
+++ b/solx-codegen-evm/src/context/traits/solidity_data.rs
@@ -1,0 +1,15 @@
+//!
+//! The LLVM IR Solidity data trait.
+//!
+
+use std::collections::BTreeSet;
+
+///
+/// The LLVM IR Solidity data trait.
+///
+pub trait ISolidityData {
+    ///
+    /// Returns all runtime code offsets for the specified `id`.
+    ///
+    fn offsets(&mut self, id: &str) -> Option<BTreeSet<u64>>;
+}

--- a/solx-codegen-evm/src/context/traits/yul_data.rs
+++ b/solx-codegen-evm/src/context/traits/yul_data.rs
@@ -1,0 +1,13 @@
+//!
+//! The LLVM IR Yul data trait.
+//!
+
+///
+/// The LLVM IR Yul data trait.
+///
+pub trait IYulData {
+    ///
+    /// Resolves the full contract path by the Yul object identifier.
+    ///
+    fn resolve_path(&self, identifier: &str) -> Option<&str>;
+}

--- a/solx-codegen-evm/src/context/value.rs
+++ b/solx-codegen-evm/src/context/value.rs
@@ -1,0 +1,76 @@
+//!
+//! The LLVM compile-time value with metadata.
+//!
+
+///
+/// The LLVM compile-time value with metadata.
+///
+#[derive(Debug, Clone)]
+pub struct Value<'ctx> {
+    /// The actual LLVM operand.
+    pub value: inkwell::values::BasicValueEnum<'ctx>,
+    /// The original AST value. Used mostly for string literals.
+    pub original: Option<String>,
+    /// The preserved constant value, if available.
+    pub constant: Option<num::BigUint>,
+}
+
+impl<'ctx> Value<'ctx> {
+    /// The calldata offset argument index.
+    pub const ARGUMENT_INDEX_CALLDATA_OFFSET: usize = 0;
+
+    /// The calldata length argument index.
+    pub const ARGUMENT_INDEX_CALLDATA_LENGTH: usize = 1;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(value: inkwell::values::BasicValueEnum<'ctx>) -> Self {
+        Self {
+            value,
+            original: None,
+            constant: None,
+        }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new_with_original(
+        value: inkwell::values::BasicValueEnum<'ctx>,
+        original: String,
+    ) -> Self {
+        Self {
+            value,
+            original: Some(original),
+            constant: None,
+        }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new_with_constant(
+        value: inkwell::values::BasicValueEnum<'ctx>,
+        constant: num::BigUint,
+    ) -> Self {
+        Self {
+            value,
+            original: None,
+            constant: Some(constant),
+        }
+    }
+
+    ///
+    /// Returns the inner LLVM value.
+    ///
+    pub fn to_llvm(&self) -> inkwell::values::BasicValueEnum<'ctx> {
+        self.value
+    }
+}
+
+impl<'ctx> From<inkwell::values::BasicValueEnum<'ctx>> for Value<'ctx> {
+    fn from(value: inkwell::values::BasicValueEnum<'ctx>) -> Self {
+        Self::new(value)
+    }
+}

--- a/solx-codegen-evm/src/debug_config/ir_type.rs
+++ b/solx-codegen-evm/src/debug_config/ir_type.rs
@@ -1,0 +1,43 @@
+//!
+//! The debug IR type.
+//!
+
+///
+/// The debug IR type.
+///
+#[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IRType {
+    /// Whether to dump the Yul code.
+    Yul,
+    /// Whether to dump the EVM legacy assembly code.
+    EVMLA,
+    /// Whether to dump the Ethereal IR code.
+    EthIR,
+    /// Whether to dump the Vyper LLL IR code.
+    LLL,
+    /// Whether to dump the LLVM IR code.
+    LLVM,
+    /// Whether to dump the EraVM assembly code.
+    EraVMAssembly,
+    /// Whether to dump the EVM assembly code.
+    EVMAssembly,
+}
+
+impl IRType {
+    ///
+    /// Returns the file extension for the specified IR.
+    ///
+    pub fn file_extension(&self) -> &'static str {
+        match self {
+            Self::Yul => era_compiler_common::EXTENSION_YUL,
+            Self::EthIR => era_compiler_common::EXTENSION_ETHIR,
+            Self::EVMLA => era_compiler_common::EXTENSION_EVMLA,
+            Self::LLL => era_compiler_common::EXTENSION_LLL,
+            Self::LLVM => era_compiler_common::EXTENSION_LLVM_SOURCE,
+            Self::EraVMAssembly => era_compiler_common::EXTENSION_ERAVM_ASSEMBLY,
+            Self::EVMAssembly => era_compiler_common::EXTENSION_EVM_ASSEMBLY,
+        }
+    }
+}

--- a/solx-codegen-evm/src/debug_config/mod.rs
+++ b/solx-codegen-evm/src/debug_config/mod.rs
@@ -1,0 +1,204 @@
+//!
+//! The debug configuration.
+//!
+
+pub mod ir_type;
+
+use std::path::PathBuf;
+
+use self::ir_type::IRType;
+
+///
+/// The debug configuration.
+///
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DebugConfig {
+    /// The directory to dump the IRs to.
+    pub output_directory: PathBuf,
+}
+
+impl DebugConfig {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(output_directory: PathBuf) -> Self {
+        Self { output_directory }
+    }
+
+    ///
+    /// Create a subdirectory and return a copy of `DebugConfig` pointing there.
+    ///
+    pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
+        let sanitized_name = Self::sanitize_filename_fragment(directory_name);
+        let subdirectory_path = self.output_directory.join(sanitized_name.as_str());
+        std::fs::create_dir_all(subdirectory_path.as_path())?;
+        Ok(Self {
+            output_directory: subdirectory_path,
+        })
+    }
+
+    ///
+    /// Dumps the Yul IR.
+    ///
+    pub fn dump_yul(&self, contract_path: &str, code: &str) -> anyhow::Result<()> {
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name = Self::full_file_name(contract_path, None, IRType::Yul);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the EVM legacy assembly IR.
+    ///
+    pub fn dump_evmla(&self, contract_path: &str, code: &str) -> anyhow::Result<()> {
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name = Self::full_file_name(contract_path, None, IRType::EVMLA);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the Ethereal IR.
+    ///
+    pub fn dump_ethir(&self, contract_path: &str, code: &str) -> anyhow::Result<()> {
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name = Self::full_file_name(contract_path, None, IRType::EthIR);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the LLL IR.
+    ///
+    pub fn dump_lll(&self, contract_path: &str, code: &str) -> anyhow::Result<()> {
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name = Self::full_file_name(contract_path, None, IRType::LLL);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the unoptimized LLVM IR.
+    ///
+    pub fn dump_llvm_ir_unoptimized(
+        &self,
+        contract_path: &str,
+        module: &inkwell::module::Module,
+        is_size_fallback: bool,
+        spill_area: Option<(u64, u64)>,
+    ) -> anyhow::Result<()> {
+        let llvm_code = module.print_to_string().to_string();
+
+        let mut suffix = "unoptimized".to_owned();
+        if is_size_fallback {
+            suffix.push_str(".size_fallback");
+        }
+        if let Some((offset, size)) = spill_area {
+            suffix.push_str(format!(".o{offset}s{size}").as_str());
+        }
+
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name =
+            Self::full_file_name(contract_path, Some(suffix.as_str()), IRType::LLVM);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, llvm_code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the optimized LLVM IR.
+    ///
+    pub fn dump_llvm_ir_optimized(
+        &self,
+        contract_path: &str,
+        module: &inkwell::module::Module,
+        is_size_fallback: bool,
+        spill_area: Option<(u64, u64)>,
+    ) -> anyhow::Result<()> {
+        let llvm_code = module.print_to_string().to_string();
+
+        let mut suffix = "optimized".to_owned();
+        if is_size_fallback {
+            suffix.push_str(".size_fallback");
+        }
+        if let Some((offset, size)) = spill_area {
+            suffix.push_str(format!(".o{offset}s{size}").as_str());
+        }
+
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name =
+            Self::full_file_name(contract_path, Some(suffix.as_str()), IRType::LLVM);
+        file_path.push(full_file_name);
+        std::fs::write(file_path, llvm_code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Dumps the assembly.
+    ///
+    pub fn dump_assembly(
+        &self,
+        contract_path: &str,
+        target: era_compiler_common::Target,
+        code: &str,
+        is_size_fallback: bool,
+        spill_area: Option<(u64, u64)>,
+    ) -> anyhow::Result<()> {
+        let mut suffix = if is_size_fallback {
+            Some("size_fallback".to_owned())
+        } else {
+            None
+        };
+        if let Some((offset, size)) = spill_area {
+            suffix
+                .get_or_insert_with(String::new)
+                .push_str(format!(".o{offset}s{size}").as_str());
+        }
+
+        let mut file_path = self.output_directory.to_owned();
+        let full_file_name = Self::full_file_name(
+            contract_path,
+            suffix.as_deref(),
+            match target {
+                era_compiler_common::Target::EraVM => IRType::EraVMAssembly,
+                era_compiler_common::Target::EVM => IRType::EVMAssembly,
+            },
+        );
+        file_path.push(full_file_name);
+        std::fs::write(file_path, code)?;
+
+        Ok(())
+    }
+
+    ///
+    /// Rules to encode a string into a valid filename.
+    ///
+    fn sanitize_filename_fragment(string: &str) -> String {
+        string.replace([' ', ':', '/', '\\'], "_")
+    }
+
+    ///
+    /// Creates a full file name, given the contract full path, suffix, and extension.
+    ///
+    fn full_file_name(contract_path: &str, suffix: Option<&str>, ir_type: IRType) -> String {
+        let mut full_file_name = Self::sanitize_filename_fragment(contract_path);
+
+        if let Some(suffix) = suffix {
+            full_file_name.push('.');
+            full_file_name.push_str(suffix);
+        }
+        full_file_name.push('.');
+        full_file_name.push_str(ir_type.file_extension());
+        full_file_name
+    }
+}

--- a/solx-codegen-evm/src/lib.rs
+++ b/solx-codegen-evm/src/lib.rs
@@ -1,0 +1,76 @@
+//!
+//! EVM codegen library.
+//!
+
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::upper_case_acronyms)]
+
+pub(crate) mod codegen;
+pub(crate) mod r#const;
+pub(crate) mod context;
+pub(crate) mod debug_config;
+pub(crate) mod optimizer;
+pub(crate) mod target_machine;
+
+pub use self::codegen::append_metadata;
+pub use self::codegen::assemble;
+pub use self::codegen::attribute::Attribute as EVMAttribute;
+pub use self::codegen::build::Build;
+pub use self::codegen::context::address_space::AddressSpace;
+pub use self::codegen::context::evmla_data::EVMLAData as ContextEVMLAData;
+pub use self::codegen::context::function::intrinsics::Intrinsics;
+pub use self::codegen::context::function::runtime::entry::Entry as EntryFunction;
+pub use self::codegen::context::function::vyper_data::VyperData;
+pub use self::codegen::context::function::Function;
+pub use self::codegen::context::solidity_data::SolidityData as ContextSolidityData;
+pub use self::codegen::context::yul_data::YulData as ContextYulData;
+pub use self::codegen::context::Context;
+pub use self::codegen::initialize_target;
+pub use self::codegen::instructions::arithmetic;
+pub use self::codegen::instructions::bitwise;
+pub use self::codegen::instructions::call;
+pub use self::codegen::instructions::calldata;
+pub use self::codegen::instructions::code;
+pub use self::codegen::instructions::comparison;
+pub use self::codegen::instructions::contract_context;
+pub use self::codegen::instructions::create;
+pub use self::codegen::instructions::ether_gas;
+pub use self::codegen::instructions::event;
+pub use self::codegen::instructions::immutable;
+pub use self::codegen::instructions::math;
+pub use self::codegen::instructions::memory;
+pub use self::codegen::instructions::r#return;
+pub use self::codegen::instructions::return_data;
+pub use self::codegen::instructions::storage;
+pub use self::codegen::link;
+pub use self::codegen::minimal_deploy_code;
+pub use self::codegen::profiler::run::Run;
+pub use self::codegen::profiler::Profiler;
+pub use self::codegen::warning::Warning;
+pub use self::codegen::DummyLLVMWritable;
+pub use self::codegen::WriteLLVM;
+pub use self::codegen::IS_SIZE_FALLBACK;
+pub use self::context::attribute::memory::Memory;
+pub use self::context::attribute::Attribute;
+pub use self::context::function::block::evmla_data::EVMLAData as FunctionBlockEVMLAData;
+pub use self::context::function::block::key::Key as BlockKey;
+pub use self::context::function::block::Block as FunctionBlock;
+pub use self::context::function::declaration::Declaration as FunctionDeclaration;
+pub use self::context::function::evmla_data::EVMLAData as FunctionEVMLAData;
+pub use self::context::function::r#return::Return as FunctionReturn;
+pub use self::context::pointer::Pointer;
+pub use self::context::r#loop::Loop;
+pub use self::context::traits::address_space::IAddressSpace;
+pub use self::context::traits::evmla_data::IEVMLAData;
+pub use self::context::traits::evmla_function::IEVMLAFunction;
+pub use self::context::traits::solidity_data::ISolidityData;
+pub use self::context::traits::yul_data::IYulData;
+pub use self::context::value::Value;
+pub use self::context::IContext;
+pub use self::debug_config::ir_type::IRType;
+pub use self::debug_config::DebugConfig;
+pub use self::optimizer::settings::size_level::SizeLevel;
+pub use self::optimizer::settings::Settings as OptimizerSettings;
+pub use self::optimizer::Optimizer;
+pub use self::r#const::*;
+pub use self::target_machine::TargetMachine;

--- a/solx-codegen-evm/src/optimizer/mod.rs
+++ b/solx-codegen-evm/src/optimizer/mod.rs
@@ -1,0 +1,48 @@
+//!
+//! The LLVM optimizing tools.
+//!
+
+pub mod settings;
+
+use crate::target_machine::TargetMachine;
+
+use self::settings::Settings;
+
+///
+/// The LLVM optimizing tools.
+///
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Optimizer {
+    /// The optimizer settings.
+    settings: Settings,
+}
+
+impl Optimizer {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(settings: Settings) -> Self {
+        Self { settings }
+    }
+
+    ///
+    /// Runs the new pass manager.
+    ///
+    pub fn run(
+        &self,
+        target_machine: &TargetMachine,
+        module: &inkwell::module::Module,
+    ) -> Result<(), inkwell::support::LLVMString> {
+        target_machine.run_optimization_passes(
+            module,
+            format!("default<O{}>", self.settings.middle_end_as_char()).as_str(),
+        )
+    }
+
+    ///
+    /// Returns the optimizer settings reference.
+    ///
+    pub fn settings(&self) -> &Settings {
+        &self.settings
+    }
+}

--- a/solx-codegen-evm/src/optimizer/settings/mod.rs
+++ b/solx-codegen-evm/src/optimizer/settings/mod.rs
@@ -1,0 +1,310 @@
+//!
+//! The LLVM optimizer settings.
+//!
+
+pub mod size_level;
+
+use itertools::Itertools;
+
+use self::size_level::SizeLevel;
+
+///
+/// The LLVM optimizer settings.
+///
+#[derive(Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Settings {
+    /// The middle-end optimization level.
+    pub level_middle_end: inkwell::OptimizationLevel,
+    /// The middle-end size optimization level.
+    pub level_middle_end_size: SizeLevel,
+    /// The back-end optimization level.
+    pub level_back_end: inkwell::OptimizationLevel,
+    /// Fallback to optimizing for size if the bytecode is too large.
+    pub is_fallback_to_size_enabled: bool,
+
+    /// Size of the spill area used for stack-too-deep mitigation.
+    pub spill_area_size: Option<u64>,
+    /// Metadata size, used for LLVM for gas/size tradeoffs.
+    pub metadata_size: Option<u64>,
+
+    /// Whether the LLVM `verify each` option is enabled.
+    pub is_verify_each_enabled: bool,
+    /// Whether the LLVM `debug logging` option is enabled.
+    pub is_debug_logging_enabled: bool,
+}
+
+impl Settings {
+    /// The jump table density threshold used with the EVM interpreter.
+    pub const JUMP_TABLE_DENSITY_THRESHOLD: u32 = 10;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(
+        level_middle_end: inkwell::OptimizationLevel,
+        level_middle_end_size: SizeLevel,
+        level_back_end: inkwell::OptimizationLevel,
+    ) -> Self {
+        Self::new_debug(
+            level_middle_end,
+            level_middle_end_size,
+            level_back_end,
+            false,
+            false,
+        )
+    }
+
+    ///
+    /// A shortcut constructor with debugging tools.
+    ///
+    pub fn new_debug(
+        level_middle_end: inkwell::OptimizationLevel,
+        level_middle_end_size: SizeLevel,
+        level_back_end: inkwell::OptimizationLevel,
+
+        is_verify_each_enabled: bool,
+        is_debug_logging_enabled: bool,
+    ) -> Self {
+        Self {
+            level_middle_end,
+            level_middle_end_size,
+            level_back_end,
+            is_fallback_to_size_enabled: false,
+
+            spill_area_size: None,
+            metadata_size: None,
+
+            is_verify_each_enabled,
+            is_debug_logging_enabled,
+        }
+    }
+
+    ///
+    /// Creates settings from a CLI optimization parameter.
+    ///
+    pub fn try_from_cli(value: char) -> anyhow::Result<Self> {
+        Ok(match value {
+            '0' => Self::new(
+                // The middle-end optimization level.
+                inkwell::OptimizationLevel::None,
+                // The middle-end size optimization level.
+                SizeLevel::Zero,
+                // The back-end optimization level.
+                inkwell::OptimizationLevel::None,
+            ),
+            '1' => Self::new(
+                inkwell::OptimizationLevel::Less,
+                SizeLevel::Zero,
+                // The back-end does not currently distinguish between O1, O2, and O3.
+                inkwell::OptimizationLevel::Less,
+            ),
+            '2' => Self::new(
+                inkwell::OptimizationLevel::Default,
+                SizeLevel::Zero,
+                // The back-end does not currently distinguish between O1, O2, and O3.
+                inkwell::OptimizationLevel::Default,
+            ),
+            '3' => Self::new(
+                inkwell::OptimizationLevel::Aggressive,
+                SizeLevel::Zero,
+                inkwell::OptimizationLevel::Aggressive,
+            ),
+            's' => Self::new(
+                // The middle-end optimization level is ignored when SizeLevel is set.
+                inkwell::OptimizationLevel::Default,
+                SizeLevel::S,
+                inkwell::OptimizationLevel::Aggressive,
+            ),
+            'z' => Self::new(
+                // The middle-end optimization level is ignored when SizeLevel is set.
+                inkwell::OptimizationLevel::Default,
+                SizeLevel::Z,
+                inkwell::OptimizationLevel::Aggressive,
+            ),
+            char => anyhow::bail!("unexpected optimization option '{char}'"),
+        })
+    }
+
+    ///
+    /// Returns the settings without optimizations.
+    ///
+    pub fn none() -> Self {
+        Self::new(
+            inkwell::OptimizationLevel::None,
+            SizeLevel::Zero,
+            inkwell::OptimizationLevel::None,
+        )
+    }
+
+    ///
+    /// Returns the settings for the optimal number of VM execution cycles.
+    ///
+    pub fn cycles() -> Self {
+        Self::new(
+            inkwell::OptimizationLevel::Aggressive,
+            SizeLevel::Zero,
+            inkwell::OptimizationLevel::Aggressive,
+        )
+    }
+
+    ///
+    /// Returns the settings for the optimal size.
+    ///
+    pub fn size() -> Self {
+        Self::new(
+            inkwell::OptimizationLevel::Default,
+            SizeLevel::Z,
+            inkwell::OptimizationLevel::Aggressive,
+        )
+    }
+
+    ///
+    /// Returns the middle-end optimization parameter as string.
+    ///
+    pub fn middle_end_as_char(&self) -> char {
+        match (self.level_middle_end, self.level_middle_end_size) {
+            (inkwell::OptimizationLevel::None, SizeLevel::Zero) => '0',
+            (inkwell::OptimizationLevel::Less, SizeLevel::Zero) => '1',
+            (inkwell::OptimizationLevel::Default, SizeLevel::Zero) => '2',
+            (inkwell::OptimizationLevel::Aggressive, SizeLevel::Zero) => '3',
+            (_, SizeLevel::S) => 's',
+            (_, SizeLevel::Z) => 'z',
+        }
+    }
+
+    ///
+    /// Checks whether there are middle-end optimizations enabled.
+    ///
+    pub fn is_middle_end_enabled(&self) -> bool {
+        self.level_middle_end != inkwell::OptimizationLevel::None
+            || self.level_middle_end_size != SizeLevel::Zero
+    }
+
+    ///
+    /// Returns all possible combinations of the optimizer settings.
+    ///
+    /// Used only for testing purposes.
+    ///
+    pub fn combinations(target: era_compiler_common::Target) -> Vec<Self> {
+        let middle_end_levels = match target {
+            era_compiler_common::Target::EraVM => vec![
+                inkwell::OptimizationLevel::None,
+                inkwell::OptimizationLevel::Less,
+                inkwell::OptimizationLevel::Default,
+                inkwell::OptimizationLevel::Aggressive,
+            ],
+            era_compiler_common::Target::EVM => vec![
+                inkwell::OptimizationLevel::Less,
+                inkwell::OptimizationLevel::Default,
+                inkwell::OptimizationLevel::Aggressive,
+            ],
+        };
+        let back_end_levels = match target {
+            era_compiler_common::Target::EraVM => vec![
+                inkwell::OptimizationLevel::None,
+                inkwell::OptimizationLevel::Aggressive,
+            ],
+            era_compiler_common::Target::EVM => vec![inkwell::OptimizationLevel::Aggressive],
+        };
+
+        let performance_combinations: Vec<Self> = middle_end_levels
+            .into_iter()
+            .cartesian_product(back_end_levels.clone())
+            .map(|(optimization_level_middle, optimization_level_back)| {
+                Self::new(
+                    optimization_level_middle,
+                    SizeLevel::Zero,
+                    optimization_level_back,
+                )
+            })
+            .collect();
+
+        let size_combinations: Vec<Self> = vec![SizeLevel::S, SizeLevel::Z]
+            .into_iter()
+            .cartesian_product(back_end_levels)
+            .map(|(size_level, optimization_level_back)| {
+                Self::new(
+                    inkwell::OptimizationLevel::Default,
+                    size_level,
+                    optimization_level_back,
+                )
+            })
+            .collect();
+
+        let mut combinations = performance_combinations;
+        combinations.extend(size_combinations);
+
+        combinations
+    }
+
+    ///
+    /// Sets the fallback to optimizing for size if the bytecode is too large.
+    ///
+    pub fn enable_fallback_to_size(&mut self) {
+        self.is_fallback_to_size_enabled = true;
+    }
+
+    ///
+    /// Whether the fallback to optimizing for size is enabled.
+    ///
+    pub fn is_fallback_to_size_enabled(&self) -> bool {
+        self.is_fallback_to_size_enabled
+    }
+
+    ///
+    /// Switches the optimization modes to the size fallback mode.
+    ///
+    pub fn switch_to_size_fallback(&mut self) {
+        self.level_middle_end = inkwell::OptimizationLevel::Default;
+        self.level_middle_end_size = SizeLevel::Z;
+        self.level_back_end = inkwell::OptimizationLevel::Aggressive;
+        self.enable_fallback_to_size();
+    }
+
+    ///
+    /// Sets the deploy code spill area size.
+    ///
+    pub fn set_spill_area_size(&mut self, size: u64) {
+        self.spill_area_size = Some(size);
+    }
+
+    ///
+    /// Returns the spill area size depending on the code segment.
+    ///
+    pub fn spill_area_size(&self) -> Option<u64> {
+        self.spill_area_size
+    }
+
+    ///
+    /// Sets the metadata size.
+    ///
+    pub fn set_metadata_size(&mut self, size: u64) {
+        self.metadata_size = Some(size);
+    }
+
+    ///
+    /// Returns the metadata size.
+    ///
+    pub fn metadata_size(&self) -> Option<u64> {
+        self.metadata_size
+    }
+}
+
+impl PartialEq for Settings {
+    fn eq(&self, other: &Self) -> bool {
+        self.level_middle_end == other.level_middle_end
+            && self.level_middle_end_size == other.level_middle_end_size
+            && self.level_back_end == other.level_back_end
+    }
+}
+
+impl std::fmt::Display for Settings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "M{}B{}",
+            self.middle_end_as_char(),
+            self.level_back_end as u8,
+        )
+    }
+}

--- a/solx-codegen-evm/src/optimizer/settings/size_level.rs
+++ b/solx-codegen-evm/src/optimizer/settings/size_level.rs
@@ -1,0 +1,36 @@
+//!
+//! The LLVM optimizer settings size level.
+//!
+
+///
+/// The LLVM optimizer settings size level.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SizeLevel {
+    /// No size optimizations.
+    Zero,
+    /// The default size optimizations.
+    S,
+    /// The aggresize size optimizations.
+    Z,
+}
+
+impl From<SizeLevel> for u32 {
+    fn from(level: SizeLevel) -> Self {
+        match level {
+            SizeLevel::Zero => 0,
+            SizeLevel::S => 1,
+            SizeLevel::Z => 2,
+        }
+    }
+}
+
+impl std::fmt::Display for SizeLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SizeLevel::Zero => write!(f, "0"),
+            SizeLevel::S => write!(f, "s"),
+            SizeLevel::Z => write!(f, "z"),
+        }
+    }
+}

--- a/solx-codegen-evm/src/target_machine.rs
+++ b/solx-codegen-evm/src/target_machine.rs
@@ -1,0 +1,130 @@
+//!
+//! EVM target machine.
+//!
+
+use crate::optimizer::settings::Settings as OptimizerSettings;
+
+///
+/// EVM target machine.
+///
+#[derive(Debug)]
+pub struct TargetMachine {
+    /// The LLVM target machine reference.
+    target_machine: inkwell::targets::TargetMachine,
+    /// The optimizer settings.
+    optimizer_settings: OptimizerSettings,
+}
+
+impl TargetMachine {
+    /// The EVM target identifier.
+    const TARGET: era_compiler_common::Target = era_compiler_common::Target::EVM;
+
+    ///
+    /// A shortcut constructor.
+    ///
+    /// Supported LLVM options:
+    /// `-evm-stack-region-size <value>`
+    /// `-evm-stack-region-offset <value>`
+    /// `-evm-metadata-size <value>`
+    ///
+    pub fn new(
+        optimizer_settings: &OptimizerSettings,
+        llvm_options: &[String],
+    ) -> anyhow::Result<Self> {
+        let mut arguments = Vec::with_capacity(1 + llvm_options.len());
+        arguments.push(Self::TARGET.to_string());
+        arguments.extend_from_slice(llvm_options);
+        if let Some(size) = optimizer_settings.spill_area_size {
+            arguments.push(format!(
+                "-evm-stack-region-offset={}",
+                crate::r#const::SOLC_GENERAL_MEMORY_OFFSET
+            ));
+            arguments.push(format!("-evm-stack-region-size={size}"));
+        }
+        if let Some(size) = optimizer_settings.metadata_size {
+            arguments.push(format!("-evm-metadata-size={size}"));
+        }
+        if arguments.len() > 1 {
+            let arguments: Vec<&str> = arguments.iter().map(|argument| argument.as_str()).collect();
+            inkwell::support::parse_command_line_options(arguments.as_slice(), "LLVM options");
+        }
+
+        let target_machine = inkwell::targets::Target::from_name(Self::TARGET.to_string().as_str())
+            .ok_or_else(|| anyhow::anyhow!("LLVM target machine `{}` not found", Self::TARGET))?
+            .create_target_machine(
+                &inkwell::targets::TargetTriple::create(Self::TARGET.triple()),
+                "",
+                "",
+                optimizer_settings.level_back_end,
+                inkwell::targets::RelocMode::Default,
+                inkwell::targets::CodeModel::Default,
+            )
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "LLVM target machine `{}` initialization error",
+                    Self::TARGET
+                )
+            })?;
+
+        Ok(Self {
+            target_machine,
+            optimizer_settings: optimizer_settings.to_owned(),
+        })
+    }
+
+    ///
+    /// Sets the target-specific data in the module.
+    ///
+    pub fn set_target_data(&self, module: &inkwell::module::Module) {
+        module.set_triple(&self.target_machine.get_triple());
+        module.set_data_layout(&self.target_machine.get_target_data().get_data_layout());
+    }
+
+    ///
+    /// Sets the assembly printer verbosity.
+    ///
+    pub fn set_asm_verbosity(&self, verbosity: bool) {
+        self.target_machine.set_asm_verbosity(verbosity);
+    }
+
+    ///
+    /// Writes the LLVM module to a memory buffer.
+    ///
+    pub fn write_to_memory_buffer(
+        &self,
+        module: &inkwell::module::Module,
+        file_type: inkwell::targets::FileType,
+    ) -> Result<inkwell::memory_buffer::MemoryBuffer, inkwell::support::LLVMString> {
+        self.target_machine
+            .write_to_memory_buffer(module, file_type)
+    }
+
+    ///
+    /// Runs the optimization passes on `module`.
+    ///
+    pub fn run_optimization_passes(
+        &self,
+        module: &inkwell::module::Module,
+        passes: &str,
+    ) -> Result<(), inkwell::support::LLVMString> {
+        let pass_builder_options = inkwell::passes::PassBuilderOptions::create();
+        pass_builder_options.set_verify_each(self.optimizer_settings.is_verify_each_enabled);
+        pass_builder_options.set_debug_logging(self.optimizer_settings.is_debug_logging_enabled);
+
+        module.run_passes(passes, &self.target_machine, pass_builder_options)
+    }
+
+    ///
+    /// Returns the target triple.
+    ///
+    pub fn get_triple(&self) -> inkwell::targets::TargetTriple {
+        self.target_machine.get_triple()
+    }
+
+    ///
+    /// Returns the target data.
+    ///
+    pub fn get_target_data(&self) -> inkwell::targets::TargetData {
+        self.target_machine.get_target_data()
+    }
+}

--- a/solx-evm-assembly/Cargo.toml
+++ b/solx-evm-assembly/Cargo.toml
@@ -21,8 +21,8 @@ hex = "0.4"
 num = "0.4"
 
 solx-yul = { path = "../solx-yul" }
+solx-codegen-evm = { path = "../solx-codegen-evm" }
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]

--- a/solx-evm-assembly/src/assembly/instruction/codecopy.rs
+++ b/solx-evm-assembly/src/assembly/instruction/codecopy.rs
@@ -4,13 +4,13 @@
 
 use inkwell::values::BasicValue;
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 ///
 /// Translates the contract hash copying.
 ///
 pub fn dependency<'ctx>(
-    context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+    context: &mut solx_codegen_evm::Context<'ctx>,
     offset: inkwell::values::IntValue<'ctx>,
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()> {
@@ -22,7 +22,7 @@ pub fn dependency<'ctx>(
         "datacopy_dependency_offset",
     )?;
 
-    era_compiler_llvm_context::evm_memory::store(context, offset, value)?;
+    solx_codegen_evm::memory::store(context, offset, value)?;
 
     Ok(())
 }
@@ -31,7 +31,7 @@ pub fn dependency<'ctx>(
 /// Translates the static data copying.
 ///
 pub fn static_data<'ctx>(
-    context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+    context: &mut solx_codegen_evm::Context<'ctx>,
     destination: inkwell::values::IntValue<'ctx>,
     source: &str,
 ) -> anyhow::Result<()> {
@@ -39,7 +39,7 @@ pub fn static_data<'ctx>(
     let source_type = context.array_type(context.byte_type(), source.len());
     let source_global = context.module().add_global(
         source_type,
-        Some(era_compiler_llvm_context::EVMAddressSpace::Code.into()),
+        Some(solx_codegen_evm::AddressSpace::Code.into()),
         "codecopy_bytes_global",
     );
     source_global.set_initializer(
@@ -50,15 +50,15 @@ pub fn static_data<'ctx>(
     );
     source_global.set_constant(true);
     source_global.set_linkage(inkwell::module::Linkage::Private);
-    let source_pointer = era_compiler_llvm_context::Pointer::new(
+    let source_pointer = solx_codegen_evm::Pointer::new(
         source_type,
-        era_compiler_llvm_context::EVMAddressSpace::Code,
+        solx_codegen_evm::AddressSpace::Code,
         source_global.as_pointer_value(),
     );
 
-    let destination_pointer = era_compiler_llvm_context::Pointer::new_with_offset(
+    let destination_pointer = solx_codegen_evm::Pointer::new_with_offset(
         context,
-        era_compiler_llvm_context::EVMAddressSpace::Heap,
+        solx_codegen_evm::AddressSpace::Heap,
         context.field_type(),
         destination,
         "codecopy_bytes_destination_pointer",

--- a/solx-evm-assembly/src/assembly/instruction/jump.rs
+++ b/solx-evm-assembly/src/assembly/instruction/jump.rs
@@ -2,8 +2,8 @@
 //! Translates the jump operations.
 //!
 
-use era_compiler_llvm_context::IEVMLAData;
-use era_compiler_llvm_context::IEVMLAFunction;
+use solx_codegen_evm::IEVMLAData;
+use solx_codegen_evm::IEVMLAFunction;
 
 ///
 /// Translates the unconditional jump.
@@ -14,19 +14,19 @@ pub fn unconditional<'ctx, C>(
     stack_hash: u64,
 ) -> anyhow::Result<()>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let code_segment = context
         .code_segment()
         .ok_or_else(|| anyhow::anyhow!("Contract code segment is undefined"))?;
     let block_key = match code_segment {
         era_compiler_common::CodeSegment::Deploy if destination > num::BigUint::from(u32::MAX) => {
-            era_compiler_llvm_context::BlockKey::new(
+            solx_codegen_evm::BlockKey::new(
                 era_compiler_common::CodeSegment::Runtime,
                 destination.to_owned() - num::BigUint::from(1u64 << 32),
             )
         }
-        code_segment => era_compiler_llvm_context::BlockKey::new(code_segment, destination),
+        code_segment => solx_codegen_evm::BlockKey::new(code_segment, destination),
     };
 
     let block = context
@@ -48,19 +48,19 @@ pub fn conditional<'ctx, C>(
     stack_height: usize,
 ) -> anyhow::Result<()>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let code_segment = context
         .code_segment()
         .ok_or_else(|| anyhow::anyhow!("Contract code segment is undefined"))?;
     let block_key = match code_segment {
         era_compiler_common::CodeSegment::Deploy if destination > num::BigUint::from(u32::MAX) => {
-            era_compiler_llvm_context::BlockKey::new(
+            solx_codegen_evm::BlockKey::new(
                 era_compiler_common::CodeSegment::Runtime,
                 destination.to_owned() - num::BigUint::from(1u64 << 32),
             )
         }
-        code_segment => era_compiler_llvm_context::BlockKey::new(code_segment, destination),
+        code_segment => solx_codegen_evm::BlockKey::new(code_segment, destination),
     };
 
     let condition_pointer = context
@@ -70,7 +70,7 @@ where
         .to_llvm()
         .into_pointer_value();
     let condition = context.build_load(
-        era_compiler_llvm_context::Pointer::new_stack_field(context, condition_pointer),
+        solx_codegen_evm::Pointer::new_stack_field(context, condition_pointer),
         format!("conditional_{block_key}_condition").as_str(),
     )?;
     let condition = context.builder().build_int_compare(

--- a/solx-evm-assembly/src/assembly/instruction/mod.rs
+++ b/solx-evm-assembly/src/assembly/instruction/mod.rs
@@ -340,11 +340,11 @@ impl Instruction {
     ///
     pub fn recursive_call(
         name: String,
-        entry_key: era_compiler_llvm_context::BlockKey,
+        entry_key: solx_codegen_evm::BlockKey,
         stack_hash: u64,
         input_size: usize,
         output_size: usize,
-        return_address: era_compiler_llvm_context::BlockKey,
+        return_address: solx_codegen_evm::BlockKey,
         previous: &Self,
     ) -> Self {
         Self {

--- a/solx-evm-assembly/src/assembly/instruction/name.rs
+++ b/solx-evm-assembly/src/assembly/instruction/name.rs
@@ -368,7 +368,7 @@ pub enum Name {
         /// The called function name.
         name: String,
         /// The called function key.
-        entry_key: era_compiler_llvm_context::BlockKey,
+        entry_key: solx_codegen_evm::BlockKey,
         /// The stack state hash after return.
         stack_hash: u64,
         /// The input size.
@@ -376,7 +376,7 @@ pub enum Name {
         /// The output size.
         output_size: usize,
         /// The return address.
-        return_address: era_compiler_llvm_context::BlockKey,
+        return_address: solx_codegen_evm::BlockKey,
     },
     /// The recursive function return instruction.
     #[serde(skip)]

--- a/solx-evm-assembly/src/assembly/instruction/stack.rs
+++ b/solx-evm-assembly/src/assembly/instruction/stack.rs
@@ -4,7 +4,7 @@
 
 use inkwell::values::BasicValue;
 
-use era_compiler_llvm_context::IEVMLAData;
+use solx_codegen_evm::IEVMLAData;
 
 ///
 /// Translates the ordinar value push.
@@ -14,7 +14,7 @@ pub fn push<'ctx, C>(
     value: String,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let result = context
         .field_type()
@@ -35,7 +35,7 @@ pub fn push_tag<'ctx, C>(
     value: String,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let result = context
         .field_type()
@@ -54,17 +54,14 @@ pub fn dup<'ctx, C>(
     original: &mut Option<String>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let element = context
         .evmla()
         .expect("Always exists")
         .get_element(height - offset - 1);
     let value = context.build_load(
-        era_compiler_llvm_context::Pointer::new_stack_field(
-            context,
-            element.to_llvm().into_pointer_value(),
-        ),
+        solx_codegen_evm::Pointer::new_stack_field(context, element.to_llvm().into_pointer_value()),
         format!("dup{offset}").as_str(),
     )?;
 
@@ -78,14 +75,14 @@ where
 ///
 pub fn swap<'ctx, C>(context: &mut C, offset: usize, height: usize) -> anyhow::Result<()>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     let top_element = context
         .evmla()
         .expect("Always exists")
         .get_element(height - 1)
         .to_owned();
-    let top_pointer = era_compiler_llvm_context::Pointer::new_stack_field(
+    let top_pointer = solx_codegen_evm::Pointer::new_stack_field(
         context,
         top_element.to_llvm().into_pointer_value(),
     );
@@ -96,7 +93,7 @@ where
         .expect("Always exists")
         .get_element(height - offset - 1)
         .to_owned();
-    let swap_pointer = era_compiler_llvm_context::Pointer::new_stack_field(
+    let swap_pointer = solx_codegen_evm::Pointer::new_stack_field(
         context,
         swap_element.to_llvm().into_pointer_value(),
     );
@@ -127,7 +124,7 @@ where
 ///
 pub fn pop<'ctx, C>(_context: &mut C) -> anyhow::Result<()>
 where
-    C: era_compiler_llvm_context::IContext<'ctx>,
+    C: solx_codegen_evm::IContext<'ctx>,
 {
     Ok(())
 }

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -12,7 +12,7 @@ use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 use twox_hash::XxHash3_64;
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::ethereal_ir::entry_link::EntryLink;
 use crate::ethereal_ir::EtherealIR;
@@ -341,15 +341,12 @@ impl Assembly {
     }
 }
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Assembly {
-    fn declare(
-        &mut self,
-        _context: &mut era_compiler_llvm_context::EVMContext,
-    ) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Assembly {
+    fn declare(&mut self, _context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let full_path = self.full_path().to_owned();
 
         let (code_segment, blocks) = if let Ok(runtime_code) = self.runtime_code() {
@@ -396,8 +393,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Assembly {
             (era_compiler_common::CodeSegment::Runtime, blocks)
         };
 
-        let mut entry =
-            era_compiler_llvm_context::EVMEntryFunction::new(EntryLink::new(code_segment));
+        let mut entry = solx_codegen_evm::EntryFunction::new(EntryLink::new(code_segment));
         entry.declare(context)?;
 
         let mut ethereal_ir = EtherealIR::new(

--- a/solx-evm-assembly/src/ethereal_ir/entry_link.rs
+++ b/solx-evm-assembly/src/ethereal_ir/entry_link.rs
@@ -2,7 +2,7 @@
 //! The Ethereal IR entry function link.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::ethereal_ir::EtherealIR;
 
@@ -26,8 +26,8 @@ impl EntryLink {
     }
 }
 
-impl era_compiler_llvm_context::EVMWriteLLVM for EntryLink {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for EntryLink {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let target = context
             .get_function(EtherealIR::DEFAULT_ENTRY_FUNCTION_NAME)
             .expect("Always exists")

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -7,8 +7,8 @@ pub mod stack;
 use inkwell::values::BasicValue;
 use num::ToPrimitive;
 
-use era_compiler_llvm_context::IContext;
-use era_compiler_llvm_context::IEVMLAFunction;
+use solx_codegen_evm::IContext;
+use solx_codegen_evm::IEVMLAFunction;
 
 use crate::assembly::instruction::name::Name as InstructionName;
 use crate::assembly::instruction::Instruction;
@@ -52,7 +52,7 @@ impl Element {
     ///
     fn pop_arguments_llvm<'ctx>(
         &mut self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+        context: &mut solx_codegen_evm::Context<'ctx>,
     ) -> anyhow::Result<Vec<inkwell::values::BasicValueEnum<'ctx>>> {
         let input_size = self
             .instruction
@@ -65,7 +65,7 @@ impl Element {
                 .to_llvm()
                 .into_pointer_value();
             let value = context.build_load(
-                era_compiler_llvm_context::Pointer::new_stack_field(context, pointer),
+                solx_codegen_evm::Pointer::new_stack_field(context, pointer),
                 format!("argument_{index}").as_str(),
             )?;
             arguments.push(value);
@@ -74,11 +74,8 @@ impl Element {
     }
 }
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Element {
-    fn into_llvm(
-        mut self,
-        context: &mut era_compiler_llvm_context::EVMContext,
-    ) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Element {
+    fn into_llvm(mut self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let mut original = self.instruction.value.clone();
 
         let result = match self.instruction.name.clone() {
@@ -133,16 +130,14 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                     .instruction
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Data offset identifier is missing"))?;
-                era_compiler_llvm_context::evm_code::data_offset(context, object_name.as_str())
-                    .map(Some)
+                solx_codegen_evm::code::data_offset(context, object_name.as_str()).map(Some)
             }
             InstructionName::PUSH_DataSize => {
                 let object_name = self
                     .instruction
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Data size identifier is missing"))?;
-                era_compiler_llvm_context::evm_code::data_size(context, object_name.as_str())
-                    .map(Some)
+                solx_codegen_evm::code::data_size(context, object_name.as_str()).map(Some)
             }
             InstructionName::PUSHLIB => {
                 let path = self
@@ -150,7 +145,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Instruction value missing"))?;
 
-                era_compiler_llvm_context::evm_call::linker_symbol(context, path.as_str()).map(Some)
+                solx_codegen_evm::call::linker_symbol(context, path.as_str()).map(Some)
             }
             InstructionName::PUSH_Data => {
                 let value = self
@@ -176,7 +171,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                     .settings()
                     .spill_area_size()
                     .unwrap_or_default();
-                era_compiler_llvm_context::evm_arithmetic::addition(
+                solx_codegen_evm::arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
                     context.field_const(spill_area),
@@ -432,7 +427,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::ADD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::addition(
+                solx_codegen_evm::arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -441,7 +436,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SUB => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::subtraction(
+                solx_codegen_evm::arithmetic::subtraction(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -450,7 +445,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::MUL => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::multiplication(
+                solx_codegen_evm::arithmetic::multiplication(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -459,7 +454,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::DIV => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::division(
+                solx_codegen_evm::arithmetic::division(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -468,7 +463,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::MOD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::remainder(
+                solx_codegen_evm::arithmetic::remainder(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -477,7 +472,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SDIV => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::division_signed(
+                solx_codegen_evm::arithmetic::division_signed(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -486,7 +481,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SMOD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_arithmetic::remainder_signed(
+                solx_codegen_evm::arithmetic::remainder_signed(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -496,7 +491,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::LT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -506,7 +501,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::GT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -516,7 +511,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::EQ => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -526,7 +521,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::ISZERO => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     context.field_const(0),
@@ -536,7 +531,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SLT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -546,7 +541,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SGT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -557,7 +552,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::OR => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::or(
+                solx_codegen_evm::bitwise::or(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -566,7 +561,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::XOR => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::xor(
+                solx_codegen_evm::bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -575,7 +570,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::NOT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::xor(
+                solx_codegen_evm::bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
                     context.field_type().const_all_ones(),
@@ -584,7 +579,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::AND => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::and(
+                solx_codegen_evm::bitwise::and(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -593,7 +588,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SHL => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_left(
+                solx_codegen_evm::bitwise::shift_left(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -602,7 +597,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SHR => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_right(
+                solx_codegen_evm::bitwise::shift_right(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -611,7 +606,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SAR => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_right_arithmetic(
+                solx_codegen_evm::bitwise::shift_right_arithmetic(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -620,7 +615,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::BYTE => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_bitwise::byte(
+                solx_codegen_evm::bitwise::byte(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -630,7 +625,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::ADDMOD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_math::add_mod(
+                solx_codegen_evm::math::add_mod(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -640,7 +635,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::MULMOD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_math::mul_mod(
+                solx_codegen_evm::math::mul_mod(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -650,7 +645,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::EXP => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_math::exponent(
+                solx_codegen_evm::math::exponent(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -659,7 +654,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::SIGNEXTEND => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_math::sign_extend(
+                solx_codegen_evm::math::sign_extend(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -669,7 +664,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::SHA3 | InstructionName::KECCAK256 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_math::keccak256(
+                solx_codegen_evm::math::keccak256(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -679,12 +674,11 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::MLOAD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_memory::load(context, arguments[0].into_int_value())
-                    .map(Some)
+                solx_codegen_evm::memory::load(context, arguments[0].into_int_value()).map(Some)
             }
             InstructionName::MSTORE => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_memory::store(
+                solx_codegen_evm::memory::store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -693,7 +687,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::MSTORE8 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_memory::store_byte(
+                solx_codegen_evm::memory::store_byte(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -702,16 +696,16 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::MCOPY => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                let destination = era_compiler_llvm_context::Pointer::new_with_offset(
+                let destination = solx_codegen_evm::Pointer::new_with_offset(
                     context,
-                    era_compiler_llvm_context::EVMAddressSpace::Heap,
+                    solx_codegen_evm::AddressSpace::Heap,
                     context.byte_type(),
                     arguments[0].into_int_value(),
                     "mcopy_destination",
                 )?;
-                let source = era_compiler_llvm_context::Pointer::new_with_offset(
+                let source = solx_codegen_evm::Pointer::new_with_offset(
                     context,
-                    era_compiler_llvm_context::EVMAddressSpace::Heap,
+                    solx_codegen_evm::AddressSpace::Heap,
                     context.byte_type(),
                     arguments[1].into_int_value(),
                     "mcopy_source",
@@ -729,12 +723,11 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
             InstructionName::SLOAD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_storage::load(context, arguments[0].into_int_value())
-                    .map(Some)
+                solx_codegen_evm::storage::load(context, arguments[0].into_int_value()).map(Some)
             }
             InstructionName::SSTORE => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_storage::store(
+                solx_codegen_evm::storage::store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -743,15 +736,12 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::TLOAD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_storage::transient_load(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::storage::transient_load(context, arguments[0].into_int_value())
+                    .map(Some)
             }
             InstructionName::TSTORE => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_storage::transient_store(
+                solx_codegen_evm::storage::transient_store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -763,7 +753,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                     .instruction
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Instruction value missing"))?;
-                era_compiler_llvm_context::evm_immutable::load(context, id.as_str()).map(Some)
+                solx_codegen_evm::immutable::load(context, id.as_str()).map(Some)
             }
             InstructionName::ASSIGNIMMUTABLE => {
                 let arguments = self.pop_arguments_llvm(context)?;
@@ -775,29 +765,18 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
 
                 let base_offset = arguments[0].into_int_value();
                 let value = arguments[1].into_int_value();
-                era_compiler_llvm_context::evm_immutable::store(
-                    context,
-                    id.as_str(),
-                    base_offset,
-                    value,
-                )
-                .map(|_| None)
+                solx_codegen_evm::immutable::store(context, id.as_str(), base_offset, value)
+                    .map(|_| None)
             }
 
             InstructionName::CALLDATALOAD => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_calldata::load(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::calldata::load(context, arguments[0].into_int_value()).map(Some)
             }
-            InstructionName::CALLDATASIZE => {
-                era_compiler_llvm_context::evm_calldata::size(context).map(Some)
-            }
+            InstructionName::CALLDATASIZE => solx_codegen_evm::calldata::size(context).map(Some),
             InstructionName::CALLDATACOPY => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_calldata::copy(
+                solx_codegen_evm::calldata::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -805,9 +784,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 )?;
                 Ok(None)
             }
-            InstructionName::CODESIZE => {
-                era_compiler_llvm_context::evm_code::size(context).map(Some)
-            }
+            InstructionName::CODESIZE => solx_codegen_evm::code::size(context).map(Some),
             InstructionName::CODECOPY => {
                 let arguments = self.pop_arguments_llvm(context)?;
 
@@ -819,7 +796,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                             data.as_str(),
                         )
                     }
-                    _ => era_compiler_llvm_context::evm_code::copy(
+                    _ => solx_codegen_evm::code::copy(
                         context,
                         arguments[0].into_int_value(),
                         arguments[1].into_int_value(),
@@ -830,15 +807,14 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::PUSHSIZE => {
                 let object_name = context.module().get_name().to_string_lossy().to_string();
-                era_compiler_llvm_context::evm_code::data_size(context, object_name.as_str())
-                    .map(Some)
+                solx_codegen_evm::code::data_size(context, object_name.as_str()).map(Some)
             }
             InstructionName::RETURNDATASIZE => {
-                era_compiler_llvm_context::evm_return_data::size(context).map(Some)
+                solx_codegen_evm::r#return_data::size(context).map(Some)
             }
             InstructionName::RETURNDATACOPY => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_return_data::copy(
+                solx_codegen_evm::r#return_data::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -848,15 +824,11 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::EXTCODESIZE => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_code::ext_size(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::code::ext_size(context, arguments[0].into_int_value()).map(Some)
             }
             InstructionName::EXTCODECOPY => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_code::ext_copy(
+                solx_codegen_evm::code::ext_copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -867,16 +839,12 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::EXTCODEHASH => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_code::ext_hash(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::code::ext_hash(context, arguments[0].into_int_value()).map(Some)
             }
 
             InstructionName::RETURN => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_return::r#return(
+                solx_codegen_evm::r#return::r#return(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -885,23 +853,19 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::REVERT => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_return::revert(
+                solx_codegen_evm::r#return::revert(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
                 )
                 .map(|_| None)
             }
-            InstructionName::STOP => {
-                era_compiler_llvm_context::evm_return::stop(context).map(|_| None)
-            }
-            InstructionName::INVALID => {
-                era_compiler_llvm_context::evm_return::invalid(context).map(|_| None)
-            }
+            InstructionName::STOP => solx_codegen_evm::r#return::stop(context).map(|_| None),
+            InstructionName::INVALID => solx_codegen_evm::r#return::invalid(context).map(|_| None),
 
             InstructionName::LOG0 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -911,7 +875,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::LOG1 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -924,7 +888,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::LOG2 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -937,7 +901,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::LOG3 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -950,7 +914,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
             }
             InstructionName::LOG4 => {
                 let arguments = self.pop_arguments_llvm(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -973,7 +937,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 let output_offset = arguments.remove(0).into_int_value();
                 let output_size = arguments.remove(0).into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::call(
+                Ok(Some(solx_codegen_evm::call::call(
                     context,
                     gas,
                     address,
@@ -994,7 +958,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 let output_offset = arguments.remove(0).into_int_value();
                 let output_size = arguments.remove(0).into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::static_call(
+                Ok(Some(solx_codegen_evm::call::static_call(
                     context,
                     gas,
                     address,
@@ -1014,7 +978,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 let output_offset = arguments.remove(0).into_int_value();
                 let output_size = arguments.remove(0).into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::delegate_call(
+                Ok(Some(solx_codegen_evm::call::delegate_call(
                     context,
                     gas,
                     address,
@@ -1032,13 +996,8 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 let input_offset = arguments[1].into_int_value();
                 let input_length = arguments[2].into_int_value();
 
-                era_compiler_llvm_context::evm_create::create(
-                    context,
-                    value,
-                    input_offset,
-                    input_length,
-                )
-                .map(Some)
+                solx_codegen_evm::create::create(context, value, input_offset, input_length)
+                    .map(Some)
             }
             InstructionName::CREATE2 => {
                 let arguments = self.pop_arguments_llvm(context)?;
@@ -1048,14 +1007,8 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 let input_length = arguments[2].into_int_value();
                 let salt = arguments[3].into_int_value();
 
-                era_compiler_llvm_context::evm_create::create2(
-                    context,
-                    value,
-                    input_offset,
-                    input_length,
-                    salt,
-                )
-                .map(Some)
+                solx_codegen_evm::create::create2(context, value, input_offset, input_length, salt)
+                    .map(Some)
             }
 
             InstructionName::ADDRESS => {
@@ -1065,66 +1018,59 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 context.build_call(context.intrinsics().caller, &[], "caller")
             }
 
-            InstructionName::CALLVALUE => {
-                era_compiler_llvm_context::evm_ether_gas::callvalue(context).map(Some)
-            }
-            InstructionName::GAS => {
-                era_compiler_llvm_context::evm_ether_gas::gas(context).map(Some)
-            }
+            InstructionName::CALLVALUE => solx_codegen_evm::ether_gas::callvalue(context).map(Some),
+            InstructionName::GAS => solx_codegen_evm::ether_gas::gas(context).map(Some),
             InstructionName::BALANCE => {
                 let arguments = self.pop_arguments_llvm(context)?;
 
                 let address = arguments[0].into_int_value();
-                era_compiler_llvm_context::evm_ether_gas::balance(context, address).map(Some)
+                solx_codegen_evm::ether_gas::balance(context, address).map(Some)
             }
             InstructionName::SELFBALANCE => {
-                era_compiler_llvm_context::evm_ether_gas::self_balance(context).map(Some)
+                solx_codegen_evm::ether_gas::self_balance(context).map(Some)
             }
 
             InstructionName::GASLIMIT => {
-                era_compiler_llvm_context::evm_contract_context::gas_limit(context).map(Some)
+                solx_codegen_evm::contract_context::gas_limit(context).map(Some)
             }
             InstructionName::GASPRICE => {
-                era_compiler_llvm_context::evm_contract_context::gas_price(context).map(Some)
+                solx_codegen_evm::contract_context::gas_price(context).map(Some)
             }
             InstructionName::ORIGIN => {
-                era_compiler_llvm_context::evm_contract_context::origin(context).map(Some)
+                solx_codegen_evm::contract_context::origin(context).map(Some)
             }
             InstructionName::CHAINID => {
-                era_compiler_llvm_context::evm_contract_context::chain_id(context).map(Some)
+                solx_codegen_evm::contract_context::chain_id(context).map(Some)
             }
             InstructionName::TIMESTAMP => {
-                era_compiler_llvm_context::evm_contract_context::block_timestamp(context).map(Some)
+                solx_codegen_evm::contract_context::block_timestamp(context).map(Some)
             }
             InstructionName::NUMBER => {
-                era_compiler_llvm_context::evm_contract_context::block_number(context).map(Some)
+                solx_codegen_evm::contract_context::block_number(context).map(Some)
             }
             InstructionName::BLOCKHASH => {
                 let arguments = self.pop_arguments_llvm(context)?;
                 let index = arguments[0].into_int_value();
 
-                era_compiler_llvm_context::evm_contract_context::block_hash(context, index)
-                    .map(Some)
+                solx_codegen_evm::contract_context::block_hash(context, index).map(Some)
             }
             InstructionName::BLOBHASH => {
                 let _arguments = self.pop_arguments_llvm(context)?;
                 anyhow::bail!("The `BLOBHASH` instruction is not supported");
             }
             InstructionName::DIFFICULTY | InstructionName::PREVRANDAO => {
-                era_compiler_llvm_context::evm_contract_context::difficulty(context).map(Some)
+                solx_codegen_evm::contract_context::difficulty(context).map(Some)
             }
             InstructionName::COINBASE => {
-                era_compiler_llvm_context::evm_contract_context::coinbase(context).map(Some)
+                solx_codegen_evm::contract_context::coinbase(context).map(Some)
             }
             InstructionName::BASEFEE => {
-                era_compiler_llvm_context::evm_contract_context::basefee(context).map(Some)
+                solx_codegen_evm::contract_context::basefee(context).map(Some)
             }
             InstructionName::BLOBBASEFEE => {
                 anyhow::bail!("The `BLOBBASEFEE` instruction is not supported");
             }
-            InstructionName::MSIZE => {
-                era_compiler_llvm_context::evm_contract_context::msize(context).map(Some)
-            }
+            InstructionName::MSIZE => solx_codegen_evm::contract_context::msize(context).map(Some),
 
             InstructionName::CALLCODE => {
                 let mut _arguments = self.pop_arguments_llvm(context)?;
@@ -1168,7 +1114,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                             .to_llvm()
                             .into_pointer_value();
                         context.build_store(
-                            era_compiler_llvm_context::Pointer::new_stack_field(context, pointer),
+                            solx_codegen_evm::Pointer::new_stack_field(context, pointer),
                             value,
                         )?;
                     }
@@ -1180,9 +1126,9 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                                 index as u32,
                                 format!("return_value_element_{index}").as_str(),
                             )?;
-                            let pointer = era_compiler_llvm_context::Pointer::new(
+                            let pointer = solx_codegen_evm::Pointer::new(
                                 context.field_type(),
-                                era_compiler_llvm_context::EVMAddressSpace::Stack,
+                                solx_codegen_evm::AddressSpace::Stack,
                                 context.evmla().expect("Always exists").stack
                                     [self.stack.elements.len() - output_size + index]
                                     .to_llvm()
@@ -1210,12 +1156,12 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 arguments.pop();
 
                 match context.current_function().borrow().r#return() {
-                    era_compiler_llvm_context::FunctionReturn::None => {}
-                    era_compiler_llvm_context::FunctionReturn::Primitive { pointer } => {
+                    solx_codegen_evm::FunctionReturn::None => {}
+                    solx_codegen_evm::FunctionReturn::Primitive { pointer } => {
                         assert_eq!(arguments.len(), 1);
                         context.build_store(pointer, arguments.remove(0))?;
                     }
-                    era_compiler_llvm_context::FunctionReturn::Compound { pointer, .. } => {
+                    solx_codegen_evm::FunctionReturn::Compound { pointer, .. } => {
                         for (index, argument) in arguments.into_iter().enumerate() {
                             let element_pointer = context.build_gep(
                                 pointer,
@@ -1246,7 +1192,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Element {
                 .to_llvm()
                 .into_pointer_value();
             context.build_store(
-                era_compiler_llvm_context::Pointer::new_stack_field(context, pointer),
+                solx_codegen_evm::Pointer::new_stack_field(context, pointer),
                 result,
             )?;
             context.evmla_mut().expect("Always exists").stack[self.stack.elements.len() - 1]

--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -20,13 +20,13 @@ use self::element::Element;
 #[derive(Debug, Clone)]
 pub struct Block {
     /// The block key.
-    pub key: era_compiler_llvm_context::BlockKey,
+    pub key: solx_codegen_evm::BlockKey,
     /// The block instance.
     pub instance: Option<usize>,
     /// The block elements relevant to the stack consistency.
     pub elements: Vec<Element>,
     /// The block predecessors.
-    pub predecessors: BTreeSet<(era_compiler_llvm_context::BlockKey, usize)>,
+    pub predecessors: BTreeSet<(solx_codegen_evm::BlockKey, usize)>,
     /// The initial stack state.
     pub initial_stack: ElementStack,
     /// The stack.
@@ -64,7 +64,7 @@ impl Block {
         };
 
         let mut block = Self {
-            key: era_compiler_llvm_context::BlockKey::new(code_segment, tag),
+            key: solx_codegen_evm::BlockKey::new(code_segment, tag),
             instance: None,
             elements: Vec::with_capacity(Self::ELEMENTS_VECTOR_DEFAULT_CAPACITY),
             predecessors: BTreeSet::new(),
@@ -107,17 +107,13 @@ impl Block {
     ///
     /// Inserts a predecessor tag.
     ///
-    pub fn insert_predecessor(
-        &mut self,
-        key: era_compiler_llvm_context::BlockKey,
-        instance: usize,
-    ) {
+    pub fn insert_predecessor(&mut self, key: solx_codegen_evm::BlockKey, instance: usize) {
         self.predecessors.insert((key, instance));
     }
 }
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Block {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Block {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         for element in self.elements.into_iter() {
             element.into_llvm(context)?;
         }

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -22,8 +22,8 @@ use num::One;
 use num::ToPrimitive;
 use num::Zero;
 
-use era_compiler_llvm_context::IContext;
-use era_compiler_llvm_context::IEVMLAFunction;
+use solx_codegen_evm::IContext;
+use solx_codegen_evm::IEVMLAFunction;
 
 use crate::assembly::instruction::name::Name as InstructionName;
 use crate::assembly::instruction::Instruction;
@@ -52,7 +52,7 @@ pub struct Function {
     /// The optional code segment. Only used for the EVM target.
     pub code_segment: Option<era_compiler_common::CodeSegment>,
     /// The separately labelled blocks.
-    pub blocks: BTreeMap<era_compiler_llvm_context::BlockKey, Vec<Block>>,
+    pub blocks: BTreeMap<solx_codegen_evm::BlockKey, Vec<Block>>,
     /// The function type.
     pub r#type: Type,
     /// The function stack size.
@@ -92,8 +92,8 @@ impl Function {
     ///
     pub fn traverse(
         &mut self,
-        blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
-        functions: &mut BTreeMap<era_compiler_llvm_context::BlockKey, Self>,
+        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut BTreeSet<VisitedElement>,
     ) -> anyhow::Result<()> {
@@ -117,10 +117,7 @@ impl Function {
                         visited_functions,
                         &mut visited_blocks,
                         QueueElement::new(
-                            era_compiler_llvm_context::BlockKey::new(
-                                code_segment,
-                                num::BigUint::zero(),
-                            ),
+                            solx_codegen_evm::BlockKey::new(code_segment, num::BigUint::zero()),
                             None,
                             Stack::new(),
                         ),
@@ -163,8 +160,8 @@ impl Function {
     ///
     fn consume_block(
         &mut self,
-        blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
-        functions: &mut BTreeMap<era_compiler_llvm_context::BlockKey, Self>,
+        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut BTreeSet<VisitedElement>,
         visited_blocks: &mut BTreeSet<VisitedElement>,
@@ -241,8 +238,8 @@ impl Function {
     /// the invalid part is truncated after terminating with an `INVALID` instruction.
     ///
     fn handle_instruction(
-        blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
-        functions: &mut BTreeMap<era_compiler_llvm_context::BlockKey, Self>,
+        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut BTreeSet<VisitedElement>,
         code_segment: era_compiler_common::CodeSegment,
@@ -274,15 +271,14 @@ impl Function {
                     .ok_or_else(|| anyhow::anyhow!("Destination tag is missing"))?
                 {
                     Element::Tag(destination) if destination > &num::BigUint::from(u32::MAX) => {
-                        era_compiler_llvm_context::BlockKey::new(
+                        solx_codegen_evm::BlockKey::new(
                             era_compiler_common::CodeSegment::Runtime,
                             destination.to_owned() - num::BigUint::from(1u64 << 32),
                         )
                     }
-                    Element::Tag(destination) => era_compiler_llvm_context::BlockKey::new(
-                        code_segment,
-                        destination.to_owned(),
-                    ),
+                    Element::Tag(destination) => {
+                        solx_codegen_evm::BlockKey::new(code_segment, destination.to_owned())
+                    }
                     Element::ReturnAddress(output_size) => {
                         block_element.instruction =
                             Instruction::recursive_return(1 + output_size, instruction);
@@ -337,15 +333,14 @@ impl Function {
                     .ok_or_else(|| anyhow::anyhow!("Destination tag is missing"))?
                 {
                     Element::Tag(destination) if destination > &num::BigUint::from(u32::MAX) => {
-                        era_compiler_llvm_context::BlockKey::new(
+                        solx_codegen_evm::BlockKey::new(
                             era_compiler_common::CodeSegment::Runtime,
                             destination.to_owned() - num::BigUint::from(1u64 << 32),
                         )
                     }
-                    Element::Tag(destination) => era_compiler_llvm_context::BlockKey::new(
-                        code_segment,
-                        destination.to_owned(),
-                    ),
+                    Element::Tag(destination) => {
+                        solx_codegen_evm::BlockKey::new(code_segment, destination.to_owned())
+                    }
                     element => {
                         return Err(anyhow::anyhow!(
                             "The {} instruction expected a tag or return address, found {}",
@@ -370,7 +365,7 @@ impl Function {
                 ..
             } => {
                 let tag: num::BigUint = tag.parse().expect("Always valid");
-                let block_key = era_compiler_llvm_context::BlockKey::new(code_segment, tag);
+                let block_key = solx_codegen_evm::BlockKey::new(code_segment, tag);
 
                 queue_element.predecessor = Some((queue_element.block_key.clone(), instance));
                 queue_element.block_key = block_key.clone();
@@ -1032,24 +1027,23 @@ impl Function {
     ///
     fn handle_recursive_function_call(
         recursive_function: &ExtraMetadataRecursiveFunction,
-        blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
-        functions: &mut BTreeMap<era_compiler_llvm_context::BlockKey, Self>,
+        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut BTreeSet<VisitedElement>,
-        block_key: era_compiler_llvm_context::BlockKey,
+        block_key: solx_codegen_evm::BlockKey,
         block_stack: &mut Stack,
         block_element: &mut BlockElement,
         version: &semver::Version,
-    ) -> anyhow::Result<(era_compiler_llvm_context::BlockKey, Vec<Element>)> {
+    ) -> anyhow::Result<(solx_codegen_evm::BlockKey, Vec<Element>)> {
         let return_address_offset = block_stack.elements.len() - 2 - recursive_function.input_size;
         let input_arguments_offset = return_address_offset + 1;
         let callee_tag_offset = input_arguments_offset + recursive_function.input_size;
 
         let return_address = match block_stack.elements[return_address_offset] {
-            Element::Tag(ref return_address) => era_compiler_llvm_context::BlockKey::new(
-                block_key.code_segment,
-                return_address.to_owned(),
-            ),
+            Element::Tag(ref return_address) => {
+                solx_codegen_evm::BlockKey::new(block_key.code_segment, return_address.to_owned())
+            }
             ref element => anyhow::bail!("Expected the function return address, found {element}"),
         };
         let mut stack = Stack::with_capacity(1 + recursive_function.input_size);
@@ -1131,13 +1125,13 @@ impl Function {
     /// Checks both deploy and runtime code.
     ///
     fn is_tag_value_valid(
-        blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
+        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
         tag: &num::BigUint,
     ) -> bool {
-        blocks.contains_key(&era_compiler_llvm_context::BlockKey::new(
+        blocks.contains_key(&solx_codegen_evm::BlockKey::new(
             era_compiler_common::CodeSegment::Deploy,
             tag & num::BigUint::from(u32::MAX),
-        )) || blocks.contains_key(&era_compiler_llvm_context::BlockKey::new(
+        )) || blocks.contains_key(&solx_codegen_evm::BlockKey::new(
             era_compiler_common::CodeSegment::Runtime,
             tag & num::BigUint::from(u32::MAX),
         ))
@@ -1162,11 +1156,8 @@ impl Function {
     }
 }
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Function {
-    fn declare(
-        &mut self,
-        context: &mut era_compiler_llvm_context::EVMContext,
-    ) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Function {
+    fn declare(&mut self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let (function_type, output_size) = match self.r#type {
             Type::Initial => {
                 let output_size = 0;
@@ -1199,14 +1190,12 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Function {
         )?;
         function
             .borrow_mut()
-            .set_evmla_data(era_compiler_llvm_context::FunctionEVMLAData::new(
-                self.stack_size,
-            ));
+            .set_evmla_data(solx_codegen_evm::FunctionEVMLAData::new(self.stack_size));
 
         Ok(())
     }
 
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         context.set_current_function(self.name.as_str())?;
 
         for (key, blocks) in self.blocks.iter() {
@@ -1214,9 +1203,8 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Function {
                 let inner = context.append_basic_block(format!("block_{key}/{index}").as_str());
                 let mut stack_hashes = vec![block.initial_stack.hash()];
                 stack_hashes.extend_from_slice(block.extra_hashes.as_slice());
-                let evmla_data =
-                    era_compiler_llvm_context::FunctionBlockEVMLAData::new(stack_hashes);
-                let mut block = era_compiler_llvm_context::FunctionBlock::new(inner);
+                let evmla_data = solx_codegen_evm::FunctionBlockEVMLAData::new(stack_hashes);
+                let mut block = solx_codegen_evm::FunctionBlock::new(inner);
                 block.set_evmla_data(evmla_data);
                 context
                     .current_function()
@@ -1248,7 +1236,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Function {
                 _ => context.field_const(0).as_basic_value_enum(),
             };
             context.build_store(pointer, value)?;
-            stack_variables.push(era_compiler_llvm_context::Value::new(
+            stack_variables.push(solx_codegen_evm::Value::new(
                 pointer.value.as_basic_value_enum(),
             ));
         }
@@ -1257,7 +1245,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Function {
         match self.r#type {
             Type::Initial => {
                 let initial_block = context.current_function().borrow().find_block(
-                    &era_compiler_llvm_context::BlockKey::new(
+                    &solx_codegen_evm::BlockKey::new(
                         context.code_segment().expect("Must be set at this point"),
                         num::BigUint::zero(),
                     ),
@@ -1300,14 +1288,14 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Function {
 
         context.set_basic_block(context.current_function().borrow().return_block());
         match context.current_function().borrow().r#return() {
-            era_compiler_llvm_context::FunctionReturn::None => {
+            solx_codegen_evm::FunctionReturn::None => {
                 context.build_return(None)?;
             }
-            era_compiler_llvm_context::FunctionReturn::Primitive { pointer } => {
+            solx_codegen_evm::FunctionReturn::Primitive { pointer } => {
                 let return_value = context.build_load(pointer, "return_value")?;
                 context.build_return(Some(&return_value))?;
             }
-            era_compiler_llvm_context::FunctionReturn::Compound { pointer, .. } => {
+            solx_codegen_evm::FunctionReturn::Compound { pointer, .. } => {
                 let return_value = context.build_load(pointer, "return_value")?;
                 context.build_return(Some(&return_value))?;
             }

--- a/solx-evm-assembly/src/ethereal_ir/function/queue_element.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/queue_element.rs
@@ -10,9 +10,9 @@ use crate::ethereal_ir::function::block::element::stack::Stack;
 #[derive(Debug)]
 pub struct QueueElement {
     /// The block key.
-    pub block_key: era_compiler_llvm_context::BlockKey,
+    pub block_key: solx_codegen_evm::BlockKey,
     /// The block predecessor.
-    pub predecessor: Option<(era_compiler_llvm_context::BlockKey, usize)>,
+    pub predecessor: Option<(solx_codegen_evm::BlockKey, usize)>,
     /// The predecessor's last stack state.
     pub stack: Stack,
 }
@@ -22,8 +22,8 @@ impl QueueElement {
     /// A shortcut constructor.
     ///
     pub fn new(
-        block_key: era_compiler_llvm_context::BlockKey,
-        predecessor: Option<(era_compiler_llvm_context::BlockKey, usize)>,
+        block_key: solx_codegen_evm::BlockKey,
+        predecessor: Option<(solx_codegen_evm::BlockKey, usize)>,
         stack: Stack,
     ) -> Self {
         Self {

--- a/solx-evm-assembly/src/ethereal_ir/function/type.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/type.rs
@@ -14,7 +14,7 @@ pub enum Type {
         /// The function name.
         name: String,
         /// The function initial block key.
-        block_key: era_compiler_llvm_context::BlockKey,
+        block_key: solx_codegen_evm::BlockKey,
         /// The size of stack input (in cells or 256-bit words).
         input_size: usize,
         /// The size of stack output (in cells or 256-bit words).
@@ -35,7 +35,7 @@ impl Type {
     ///
     pub fn new_recursive(
         name: String,
-        block_key: era_compiler_llvm_context::BlockKey,
+        block_key: solx_codegen_evm::BlockKey,
         input_size: usize,
         output_size: usize,
     ) -> Self {

--- a/solx-evm-assembly/src/ethereal_ir/function/visited_element.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/visited_element.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct VisitedElement {
     /// The block key.
-    pub block_key: era_compiler_llvm_context::BlockKey,
+    pub block_key: solx_codegen_evm::BlockKey,
     /// The initial stack state hash.
     pub stack_hash: u64,
 }
@@ -19,7 +19,7 @@ impl VisitedElement {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(block_key: era_compiler_llvm_context::BlockKey, stack_hash: u64) -> Self {
+    pub fn new(block_key: solx_codegen_evm::BlockKey, stack_hash: u64) -> Self {
         Self {
             block_key,
             stack_hash,

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -29,13 +29,13 @@ semver = { version = "1.0", features = [ "serde" ] }
 hex = "0.4"
 num = "0.4"
 
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 solx-solc = { path = "../solx-solc" }
 solx-standard-json = { path = "../solx-standard-json" }
 solx-evm-assembly = { path = "../solx-evm-assembly" }
 solx-yul = { path = "../solx-yul" }
+solx-codegen-evm = { path = "../solx-codegen-evm" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/solx/src/build/contract/object.rs
+++ b/solx/src/build/contract/object.rs
@@ -39,7 +39,7 @@ pub struct Object {
     /// Whether the size fallback was activated during the compilation.
     pub is_size_fallback: bool,
     /// Compilation warnings.
-    pub warnings: Vec<era_compiler_llvm_context::EVMWarning>,
+    pub warnings: Vec<solx_codegen_evm::Warning>,
     /// Compilation pipeline benchmarks.
     pub benchmarks: Vec<(String, u64)>,
 }
@@ -62,7 +62,7 @@ impl Object {
         metadata_bytes: Option<Vec<u8>>,
         dependencies: solx_yul::Dependencies,
         is_size_fallback: bool,
-        warnings: Vec<era_compiler_llvm_context::EVMWarning>,
+        warnings: Vec<solx_codegen_evm::Warning>,
         benchmarks: Vec<(String, u64)>,
     ) -> Self {
         let bytecode_hex = bytecode.as_ref().map(hex::encode);
@@ -103,10 +103,8 @@ impl Object {
         if let (era_compiler_common::CodeSegment::Runtime, Some(metadata_bytes)) =
             (self.code_segment, &self.metadata_bytes)
         {
-            memory_buffer = era_compiler_llvm_context::evm_append_metadata(
-                memory_buffer,
-                metadata_bytes.as_slice(),
-            )?;
+            memory_buffer =
+                solx_codegen_evm::append_metadata(memory_buffer, metadata_bytes.as_slice())?;
         }
 
         Ok(memory_buffer)
@@ -150,7 +148,7 @@ impl Object {
             .iter()
             .map(|(identifier, _memory_buffer)| identifier.as_str())
             .collect::<Vec<&str>>();
-        era_compiler_llvm_context::evm_assemble(
+        solx_codegen_evm::assemble(
             bytecode_buffers.as_slice(),
             bytecode_ids.as_slice(),
             self.code_segment,
@@ -173,8 +171,8 @@ impl Object {
             false,
         );
 
-        let linked_object = era_compiler_llvm_context::evm_link(memory_buffer, linker_symbols)?;
-        let linked_object_with_placeholders = era_compiler_llvm_context::evm_link(
+        let linked_object = solx_codegen_evm::link(memory_buffer, linker_symbols)?;
+        let linked_object_with_placeholders = solx_codegen_evm::link(
             linked_object,
             &self
                 .unlinked_symbols

--- a/solx/src/lib.rs
+++ b/solx/src/lib.rs
@@ -48,9 +48,9 @@ pub fn yul_to_evm(
     messages: Arc<Mutex<Vec<solx_standard_json::OutputError>>>,
     metadata_hash_type: era_compiler_common::EVMMetadataHashType,
     append_cbor: bool,
-    optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    optimizer_settings: solx_codegen_evm::OptimizerSettings,
     llvm_options: Vec<String>,
-    debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+    debug_config: Option<solx_codegen_evm::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
     let libraries = era_compiler_common::Libraries::try_from(libraries)?;
     let linker_symbols = libraries.as_linker_symbols()?;
@@ -98,9 +98,9 @@ pub fn llvm_ir_to_evm(
     messages: Arc<Mutex<Vec<solx_standard_json::OutputError>>>,
     metadata_hash_type: era_compiler_common::EVMMetadataHashType,
     append_cbor: bool,
-    optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    optimizer_settings: solx_codegen_evm::OptimizerSettings,
     llvm_options: Vec<String>,
-    debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+    debug_config: Option<solx_codegen_evm::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
     let libraries = era_compiler_common::Libraries::try_from(libraries)?;
     let linker_symbols = libraries.as_linker_symbols()?;
@@ -147,11 +147,11 @@ pub fn standard_output_evm(
     allow_paths: Option<String>,
     use_import_callback: bool,
     remappings: BTreeSet<String>,
-    optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    optimizer_settings: solx_codegen_evm::OptimizerSettings,
     llvm_options: Vec<String>,
-    debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+    debug_config: Option<solx_codegen_evm::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
-    let mut profiler = era_compiler_llvm_context::EVMProfiler::default();
+    let mut profiler = solx_codegen_evm::Profiler::default();
 
     let mut solc_input = solx_standard_json::Input::try_from_solidity_paths(
         paths,
@@ -234,7 +234,7 @@ pub fn standard_json_evm(
     include_paths: Vec<String>,
     allow_paths: Option<String>,
     use_import_callback: bool,
-    debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+    debug_config: Option<solx_codegen_evm::DebugConfig>,
 ) -> anyhow::Result<()> {
     let solc_compiler = solx_solc::Compiler::default();
 
@@ -258,7 +258,7 @@ pub fn standard_json_evm(
             .unwrap_or(solx_standard_json::InputOptimizer::default_mode().expect("Always exists"))
     };
     let mut optimizer_settings =
-        era_compiler_llvm_context::OptimizerSettings::try_from_cli(optimization_mode)?;
+        solx_codegen_evm::OptimizerSettings::try_from_cli(optimization_mode)?;
     if solc_input
         .settings
         .optimizer
@@ -273,7 +273,7 @@ pub fn standard_json_evm(
     let metadata_hash_type = solc_input.settings.metadata.bytecode_hash;
     let append_cbor = solc_input.settings.metadata.append_cbor;
 
-    let mut profiler = era_compiler_llvm_context::EVMProfiler::default();
+    let mut profiler = solx_codegen_evm::Profiler::default();
     let (mut solc_output, project) = match language {
         solx_standard_json::InputLanguage::Solidity => {
             let run_solc_standard_json =

--- a/solx/src/process/input.rs
+++ b/solx/src/process/input.rs
@@ -29,11 +29,11 @@ pub struct Input {
     /// The metadata bytes.
     pub metadata_bytes: Option<Vec<u8>>,
     /// The optimizer settings.
-    pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    pub optimizer_settings: solx_codegen_evm::OptimizerSettings,
     /// The extra LLVM arguments.
     pub llvm_options: Vec<String>,
     /// The debug output config.
-    pub debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+    pub debug_config: Option<solx_codegen_evm::DebugConfig>,
 }
 
 impl Input {
@@ -48,9 +48,9 @@ impl Input {
         output_selection: solx_standard_json::InputSelection,
         immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
         metadata_bytes: Option<Vec<u8>>,
-        optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        optimizer_settings: solx_codegen_evm::OptimizerSettings,
         llvm_options: Vec<String>,
-        debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<solx_codegen_evm::DebugConfig>,
     ) -> Self {
         Self {
             contract_name,

--- a/solx/src/process/mod.rs
+++ b/solx/src/process/mod.rs
@@ -168,7 +168,7 @@ where
 pub unsafe extern "C" fn evm_stack_error_handler(spill_area_size: u64) {
     let result: Result<EVMOutput, Error> = Err(Error::stack_too_deep(
         spill_area_size,
-        era_compiler_llvm_context::EVM_IS_SIZE_FALLBACK.load(std::sync::atomic::Ordering::Relaxed),
+        solx_codegen_evm::IS_SIZE_FALLBACK.load(std::sync::atomic::Ordering::Relaxed),
     ));
     let mut buffer = Vec::with_capacity(crate::r#const::DEFAULT_SERDE_BUFFER_SIZE);
     ciborium::into_writer(&result, &mut buffer)

--- a/solx/src/project/contract/ir/yul.rs
+++ b/solx/src/project/contract/ir/yul.rs
@@ -27,7 +27,7 @@ impl Yul {
     pub fn try_from_source(
         path: &str,
         source_code: &str,
-        debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<&solx_codegen_evm::DebugConfig>,
     ) -> anyhow::Result<Option<Self>> {
         if source_code.is_empty() {
             return Ok(None);

--- a/solx/src/project/contract/metadata.rs
+++ b/solx/src/project/contract/metadata.rs
@@ -16,7 +16,7 @@ pub struct Metadata<'a> {
     /// The `solx` compiler version.
     pub solx_version: semver::Version,
     /// The LLVM compiler optimizer settings.
-    pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    pub optimizer_settings: solx_codegen_evm::OptimizerSettings,
     /// The LLVM extra arguments.
     pub llvm_options: &'a [String],
 }
@@ -26,7 +26,7 @@ impl<'a> Metadata<'a> {
     /// A shortcut constructor.
     ///
     pub fn new(
-        optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        optimizer_settings: solx_codegen_evm::OptimizerSettings,
         llvm_options: &'a [String],
     ) -> Self {
         let solc_version = solx_solc::Compiler::default().version;

--- a/solx/src/project/contract/mod.rs
+++ b/solx/src/project/contract/mod.rs
@@ -8,7 +8,7 @@ pub mod metadata;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::build::contract::object::Object as EVMContractObject;
 use crate::error::Error;
@@ -101,20 +101,20 @@ impl Contract {
         output_selection: solx_standard_json::InputSelection,
         immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
         metadata_bytes: Option<Vec<u8>>,
-        mut optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        mut optimizer_settings: solx_codegen_evm::OptimizerSettings,
         llvm_options: Vec<String>,
-        debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<solx_codegen_evm::DebugConfig>,
     ) -> Result<EVMContractObject, Error> {
-        use era_compiler_llvm_context::EVMWriteLLVM;
-        let mut profiler = era_compiler_llvm_context::EVMProfiler::default();
+        use solx_codegen_evm::WriteLLVM;
+        let mut profiler = solx_codegen_evm::Profiler::default();
 
         if let Some(ref metadata_bytes) = metadata_bytes {
             optimizer_settings.set_metadata_size(metadata_bytes.len() as u64);
         }
 
         let solc_version = solx_solc::Compiler::default().version;
-        let solidity_data = era_compiler_llvm_context::EVMContextSolidityData::new(immutables);
-        let optimizer = era_compiler_llvm_context::Optimizer::new(optimizer_settings.clone());
+        let solidity_data = solx_codegen_evm::ContextSolidityData::new(immutables);
+        let optimizer = solx_codegen_evm::Optimizer::new(optimizer_settings.clone());
         let output_bytecode = output_selection.is_bytecode_set_for_any();
 
         match (contract_ir, code_segment) {
@@ -123,7 +123,7 @@ impl Contract {
 
                 let deploy_llvm = inkwell::context::Context::create();
                 let deploy_module = deploy_llvm.create_module(contract_name.full_path.as_str());
-                let mut deploy_context = era_compiler_llvm_context::EVMContext::new(
+                let mut deploy_context = solx_codegen_evm::Context::new(
                     &deploy_llvm,
                     deploy_module,
                     llvm_options.clone(),
@@ -135,9 +135,8 @@ impl Contract {
                     crate::process::evm_stack_error_handler,
                 );
                 deploy_context.set_solidity_data(solidity_data);
-                deploy_context.set_yul_data(era_compiler_llvm_context::EVMContextYulData::new(
-                    identifier_paths,
-                ));
+                deploy_context
+                    .set_yul_data(solx_codegen_evm::ContextYulData::new(identifier_paths));
                 let run_yul_lowering = profiler.start_evm_translation_unit(
                     contract_name.full_path.as_str(),
                     code_segment,
@@ -181,7 +180,7 @@ impl Contract {
                 let runtime_llvm = inkwell::context::Context::create();
                 let runtime_module = runtime_llvm
                     .create_module(format!("{}.{code_segment}", contract_name.full_path).as_str());
-                let mut runtime_context = era_compiler_llvm_context::EVMContext::new(
+                let mut runtime_context = solx_codegen_evm::Context::new(
                     &runtime_llvm,
                     runtime_module,
                     llvm_options.clone(),
@@ -193,7 +192,7 @@ impl Contract {
                     crate::process::evm_stack_error_handler,
                 );
                 runtime_context.set_solidity_data(solidity_data);
-                runtime_context.set_yul_data(era_compiler_llvm_context::EVMContextYulData::new(
+                runtime_context.set_yul_data(solx_codegen_evm::ContextYulData::new(
                     identifier_paths.clone(),
                 ));
                 let run_yul_lowering = profiler.start_evm_translation_unit(
@@ -237,8 +236,7 @@ impl Contract {
                 Ok(runtime_object)
             }
             (IR::EVMLegacyAssembly(mut deploy_code), era_compiler_common::CodeSegment::Deploy) => {
-                let evmla_data =
-                    era_compiler_llvm_context::EVMContextEVMLAData::new(solc_version.default);
+                let evmla_data = solx_codegen_evm::ContextEVMLAData::new(solc_version.default);
                 let deploy_code_identifier = contract_name.full_path.to_owned();
                 let mut deploy_code_dependencies =
                     solx_yul::Dependencies::new(deploy_code_identifier.as_str());
@@ -248,7 +246,7 @@ impl Contract {
 
                 let deploy_llvm = inkwell::context::Context::create();
                 let deploy_module = deploy_llvm.create_module(deploy_code_identifier.as_str());
-                let mut deploy_context = era_compiler_llvm_context::EVMContext::new(
+                let mut deploy_context = solx_codegen_evm::Context::new(
                     &deploy_llvm,
                     deploy_module,
                     llvm_options.clone(),
@@ -306,12 +304,11 @@ impl Contract {
                 era_compiler_common::CodeSegment::Runtime,
             ) => {
                 let runtime_code_identifier = format!("{}.{code_segment}", contract_name.full_path);
-                let evmla_data =
-                    era_compiler_llvm_context::EVMContextEVMLAData::new(solc_version.default);
+                let evmla_data = solx_codegen_evm::ContextEVMLAData::new(solc_version.default);
 
                 let runtime_llvm = inkwell::context::Context::create();
                 let runtime_module = runtime_llvm.create_module(runtime_code_identifier.as_str());
-                let mut runtime_context = era_compiler_llvm_context::EVMContext::new(
+                let mut runtime_context = solx_codegen_evm::Context::new(
                     &runtime_llvm,
                     runtime_module,
                     llvm_options.clone(),
@@ -378,7 +375,7 @@ impl Contract {
                 let deploy_module = deploy_llvm
                     .create_module_from_ir(deploy_memory_buffer)
                     .map_err(|error| anyhow::anyhow!(error.to_string()))?;
-                let mut deploy_context = era_compiler_llvm_context::EVMContext::new(
+                let mut deploy_context = solx_codegen_evm::Context::new(
                     &deploy_llvm,
                     deploy_module,
                     llvm_options,
@@ -429,7 +426,7 @@ impl Contract {
                 let runtime_module = runtime_llvm
                     .create_module_from_ir(runtime_memory_buffer)
                     .map_err(|error| anyhow::anyhow!(error.to_string()))?;
-                let mut runtime_context = era_compiler_llvm_context::EVMContext::new(
+                let mut runtime_context = solx_codegen_evm::Context::new(
                     &runtime_llvm,
                     runtime_module,
                     llvm_options.clone(),

--- a/solx/src/project/mod.rs
+++ b/solx/src/project/mod.rs
@@ -85,7 +85,7 @@ impl Project {
         libraries: era_compiler_common::Libraries,
         via_ir: bool,
         solc_output: &mut solx_standard_json::Output,
-        debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<&solx_codegen_evm::DebugConfig>,
     ) -> anyhow::Result<Self> {
         if !via_ir {
             let legacy_assemblies: BTreeMap<
@@ -213,7 +213,7 @@ impl Project {
         libraries: era_compiler_common::Libraries,
         output_selection: &solx_standard_json::InputSelection,
         solc_output: Option<&mut solx_standard_json::Output>,
-        debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<&solx_codegen_evm::DebugConfig>,
     ) -> anyhow::Result<Self> {
         let sources = paths
             .iter()
@@ -247,7 +247,7 @@ impl Project {
         libraries: era_compiler_common::Libraries,
         output_selection: &solx_standard_json::InputSelection,
         mut solc_output: Option<&mut solx_standard_json::Output>,
-        debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<&solx_codegen_evm::DebugConfig>,
     ) -> anyhow::Result<Self> {
         let results = sources
             .into_par_iter()
@@ -377,7 +377,7 @@ impl Project {
                         era_compiler_common::Keccak256Hash::from_slice(source_code.as_bytes());
                     let metadata_json = serde_json::json!({
                         "source_hash": source_hash.to_string(),
-                        "llvm_version": era_compiler_llvm_context::LLVM_VERSION,
+                        "llvm_version": solx_codegen_evm::LLVM_VERSION,
                     });
                     Some(serde_json::to_string(&metadata_json).expect("Always valid"))
                 } else {
@@ -436,9 +436,9 @@ impl Project {
         output_selection: &solx_standard_json::InputSelection,
         metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         append_cbor: bool,
-        optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        optimizer_settings: solx_codegen_evm::OptimizerSettings,
         llvm_options: Vec<String>,
-        debug_config: Option<era_compiler_llvm_context::DebugConfig>,
+        debug_config: Option<solx_codegen_evm::DebugConfig>,
     ) -> anyhow::Result<EVMBuild> {
         let results = self
             .contracts
@@ -478,7 +478,7 @@ impl Project {
                         let deploy_code = ContractLLVMIR::new(
                             deploy_code_identifier.clone(),
                             era_compiler_common::CodeSegment::Deploy,
-                            era_compiler_llvm_context::evm_minimal_deploy_code(
+                            solx_codegen_evm::minimal_deploy_code(
                                 deploy_code_identifier.as_str(),
                                 runtime_code_identifier.as_str(),
                             ),
@@ -578,7 +578,7 @@ impl Project {
     fn cbor_metadata(
         metadata: Option<&str>,
         solc_version: Option<&solx_standard_json::Version>,
-        optimizer_settings: &era_compiler_llvm_context::OptimizerSettings,
+        optimizer_settings: &solx_codegen_evm::OptimizerSettings,
         llvm_options: &[String],
         metadata_hash_type: era_compiler_common::EVMMetadataHashType,
         append_cbor: bool,

--- a/solx/src/solx/main.rs
+++ b/solx/src/solx/main.rs
@@ -113,7 +113,7 @@ fn main_inner(
         .expect("Thread pool configuration failure");
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EVM);
+    solx_codegen_evm::initialize_target();
 
     if arguments.recursive_process {
         return solx::run_recursive();
@@ -122,7 +122,7 @@ fn main_inner(
     let (input_files, remappings) = arguments.split_input_files_and_remappings()?;
 
     let mut optimizer_settings = match arguments.optimization {
-        Some(mode) => era_compiler_llvm_context::OptimizerSettings::try_from_cli(mode)?,
+        Some(mode) => solx_codegen_evm::OptimizerSettings::try_from_cli(mode)?,
         None if arguments.standard_json.is_none() => {
             if let Ok(optimization) = std::env::var("SOLX_OPTIMIZATION") {
                 if !["1", "2", "3", "s", "z"].contains(&optimization.as_str()) {
@@ -130,14 +130,14 @@ fn main_inner(
                         "Invalid value `{optimization}` for environment variable 'SOLX_OPTIMIZATION': only values 1, 2, 3, s, z are supported."
                     );
                 }
-                era_compiler_llvm_context::OptimizerSettings::try_from_cli(
+                solx_codegen_evm::OptimizerSettings::try_from_cli(
                     optimization.chars().next().expect("Always exists"),
                 )?
             } else {
-                era_compiler_llvm_context::OptimizerSettings::cycles()
+                solx_codegen_evm::OptimizerSettings::cycles()
             }
         }
-        None => era_compiler_llvm_context::OptimizerSettings::cycles(),
+        None => solx_codegen_evm::OptimizerSettings::cycles(),
     };
     if arguments.size_fallback || std::env::var("SOLX_OPTIMIZATION_SIZE_FALLBACK").is_ok() {
         optimizer_settings.enable_fallback_to_size();
@@ -210,7 +210,7 @@ fn main_inner(
     {
         Some(ref debug_output_directory) => {
             std::fs::create_dir_all(debug_output_directory.as_path())?;
-            Some(era_compiler_llvm_context::DebugConfig::new(
+            Some(solx_codegen_evm::DebugConfig::new(
                 debug_output_directory.to_owned(),
             ))
         }

--- a/solx/src/yul/parser/dialect/era/attributes.rs
+++ b/solx/src/yul/parser/dialect/era/attributes.rs
@@ -19,7 +19,7 @@ pub const LLVM_ATTRIBUTE_SUFFIX: &str = "_llvm$";
 ///
 pub(crate) fn get_llvm_attributes(
     identifier: &Identifier,
-) -> Result<BTreeSet<era_compiler_llvm_context::Attribute>, YulError> {
+) -> Result<BTreeSet<solx_codegen_evm::Attribute>, YulError> {
     let mut valid_attributes = BTreeSet::new();
 
     let llvm_begin = identifier.inner.find(LLVM_ATTRIBUTE_PREFIX);
@@ -36,7 +36,7 @@ pub(crate) fn get_llvm_attributes(
 
     let mut invalid_attributes = BTreeSet::new();
     for value in attribute_string.split('_') {
-        match era_compiler_llvm_context::Attribute::try_from(value) {
+        match solx_codegen_evm::Attribute::try_from(value) {
             Ok(attribute) => valid_attributes.insert(attribute),
             Err(value) => invalid_attributes.insert(value),
         };
@@ -72,15 +72,13 @@ mod tests {
         }
     }
 
-    fn attribute_helper(s: &&str) -> era_compiler_llvm_context::Attribute {
-        era_compiler_llvm_context::Attribute::try_from(*s).expect(
-            "Internal error in test: trying to create an instance of `era_compiler_llvm_context::Attribute` from an invalid string representation.",
+    fn attribute_helper(s: &&str) -> solx_codegen_evm::Attribute {
+        solx_codegen_evm::Attribute::try_from(*s).expect(
+            "Internal error in test: trying to create an instance of `solx_codegen_evm::Attribute` from an invalid string representation.",
         )
     }
 
-    fn immediate_attributes(
-        representations: &[&str],
-    ) -> BTreeSet<era_compiler_llvm_context::Attribute> {
+    fn immediate_attributes(representations: &[&str]) -> BTreeSet<solx_codegen_evm::Attribute> {
         representations.iter().map(attribute_helper).collect()
     }
 

--- a/solx/src/yul/parser/dialect/era/mod.rs
+++ b/solx/src/yul/parser/dialect/era/mod.rs
@@ -19,7 +19,7 @@ use self::attributes::get_llvm_attributes;
 pub struct EraDialect {}
 
 impl Dialect for EraDialect {
-    type FunctionAttribute = era_compiler_llvm_context::Attribute;
+    type FunctionAttribute = solx_codegen_evm::Attribute;
 
     fn extract_attributes(
         identifier: &Identifier,

--- a/solx/src/yul/parser/statement/assignment.rs
+++ b/solx/src/yul/parser/statement/assignment.rs
@@ -2,8 +2,8 @@
 //! The assignment expression statement.
 //!
 
-use era_compiler_llvm_context::IContext;
 use inkwell::types::BasicType;
+use solx_codegen_evm::IContext;
 
 use crate::declare_wrapper;
 use crate::yul::parser::wrapper::Wrap;
@@ -13,11 +13,8 @@ declare_wrapper!(
     Assignment
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Assignment {
-    fn into_llvm(
-        mut self,
-        context: &mut era_compiler_llvm_context::EVMContext,
-    ) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Assignment {
+    fn into_llvm(mut self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let value = match self.0.initializer.wrap().into_llvm(context)? {
             Some(value) => value,
             None => return Ok(()),

--- a/solx/src/yul/parser/statement/block.rs
+++ b/solx/src/yul/parser/statement/block.rs
@@ -2,7 +2,7 @@
 //! The source code block.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 use solx_yul::yul::parser::statement::Statement;
 
 use crate::declare_wrapper;
@@ -14,8 +14,8 @@ declare_wrapper!(
     Block
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Block {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Block {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let current_function = context.current_function().borrow().name().to_owned();
         let current_block = context.basic_block();
 

--- a/solx/src/yul/parser/statement/code.rs
+++ b/solx/src/yul/parser/statement/code.rs
@@ -11,8 +11,8 @@ declare_wrapper!(
     Code
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Code {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Code {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         self.0.block.wrap().into_llvm(context)?;
 
         Ok(())

--- a/solx/src/yul/parser/statement/expression/function_call.rs
+++ b/solx/src/yul/parser/statement/expression/function_call.rs
@@ -2,7 +2,7 @@
 //! The function call subexpression.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use solx_yul::yul::parser::statement::expression::function_call::name::Name;
 
@@ -20,7 +20,7 @@ impl FunctionCall {
     ///
     pub fn into_llvm<'ctx>(
         mut self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+        context: &mut solx_codegen_evm::Context<'ctx>,
     ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let location = self.0.location;
 
@@ -60,7 +60,7 @@ impl FunctionCall {
 
             Name::Add => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::addition(
+                solx_codegen_evm::arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -69,7 +69,7 @@ impl FunctionCall {
             }
             Name::Sub => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::subtraction(
+                solx_codegen_evm::arithmetic::subtraction(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -78,7 +78,7 @@ impl FunctionCall {
             }
             Name::Mul => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::multiplication(
+                solx_codegen_evm::arithmetic::multiplication(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -87,7 +87,7 @@ impl FunctionCall {
             }
             Name::Div => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::division(
+                solx_codegen_evm::arithmetic::division(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -96,7 +96,7 @@ impl FunctionCall {
             }
             Name::Mod => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::remainder(
+                solx_codegen_evm::arithmetic::remainder(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -105,7 +105,7 @@ impl FunctionCall {
             }
             Name::Sdiv => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::division_signed(
+                solx_codegen_evm::arithmetic::division_signed(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -114,7 +114,7 @@ impl FunctionCall {
             }
             Name::Smod => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_arithmetic::remainder_signed(
+                solx_codegen_evm::arithmetic::remainder_signed(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -124,7 +124,7 @@ impl FunctionCall {
 
             Name::Lt => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -134,7 +134,7 @@ impl FunctionCall {
             }
             Name::Gt => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -144,7 +144,7 @@ impl FunctionCall {
             }
             Name::Eq => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -154,7 +154,7 @@ impl FunctionCall {
             }
             Name::IsZero => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     context.field_const(0),
@@ -164,7 +164,7 @@ impl FunctionCall {
             }
             Name::Slt => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -174,7 +174,7 @@ impl FunctionCall {
             }
             Name::Sgt => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_comparison::compare(
+                solx_codegen_evm::comparison::compare(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -185,7 +185,7 @@ impl FunctionCall {
 
             Name::Or => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::or(
+                solx_codegen_evm::bitwise::or(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -194,7 +194,7 @@ impl FunctionCall {
             }
             Name::Xor => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::xor(
+                solx_codegen_evm::bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -203,7 +203,7 @@ impl FunctionCall {
             }
             Name::Not => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_bitwise::xor(
+                solx_codegen_evm::bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
                     context.field_type().const_all_ones(),
@@ -212,7 +212,7 @@ impl FunctionCall {
             }
             Name::And => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::and(
+                solx_codegen_evm::bitwise::and(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -221,7 +221,7 @@ impl FunctionCall {
             }
             Name::Shl => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_left(
+                solx_codegen_evm::bitwise::shift_left(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -230,7 +230,7 @@ impl FunctionCall {
             }
             Name::Shr => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_right(
+                solx_codegen_evm::bitwise::shift_right(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -239,7 +239,7 @@ impl FunctionCall {
             }
             Name::Sar => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::shift_right_arithmetic(
+                solx_codegen_evm::bitwise::shift_right_arithmetic(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -248,7 +248,7 @@ impl FunctionCall {
             }
             Name::Byte => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_bitwise::byte(
+                solx_codegen_evm::bitwise::byte(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -262,7 +262,7 @@ impl FunctionCall {
 
             Name::AddMod => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_math::add_mod(
+                solx_codegen_evm::math::add_mod(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -272,7 +272,7 @@ impl FunctionCall {
             }
             Name::MulMod => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_math::mul_mod(
+                solx_codegen_evm::math::mul_mod(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -282,7 +282,7 @@ impl FunctionCall {
             }
             Name::Exp => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_math::exponent(
+                solx_codegen_evm::math::exponent(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -291,7 +291,7 @@ impl FunctionCall {
             }
             Name::SignExtend => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_math::sign_extend(
+                solx_codegen_evm::math::sign_extend(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -300,7 +300,7 @@ impl FunctionCall {
             }
             Name::Keccak256 => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_math::keccak256(
+                solx_codegen_evm::math::keccak256(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -310,12 +310,11 @@ impl FunctionCall {
 
             Name::MLoad => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_memory::load(context, arguments[0].into_int_value())
-                    .map(Some)
+                solx_codegen_evm::memory::load(context, arguments[0].into_int_value()).map(Some)
             }
             Name::MStore => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_memory::store(
+                solx_codegen_evm::memory::store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -324,7 +323,7 @@ impl FunctionCall {
             }
             Name::MStore8 => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_memory::store_byte(
+                solx_codegen_evm::memory::store_byte(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -333,16 +332,16 @@ impl FunctionCall {
             }
             Name::MCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                let destination = era_compiler_llvm_context::Pointer::new_with_offset(
+                let destination = solx_codegen_evm::Pointer::new_with_offset(
                     context,
-                    era_compiler_llvm_context::EVMAddressSpace::Heap,
+                    solx_codegen_evm::AddressSpace::Heap,
                     context.byte_type(),
                     arguments[0].into_int_value(),
                     "mcopy_destination",
                 )?;
-                let source = era_compiler_llvm_context::Pointer::new_with_offset(
+                let source = solx_codegen_evm::Pointer::new_with_offset(
                     context,
-                    era_compiler_llvm_context::EVMAddressSpace::Heap,
+                    solx_codegen_evm::AddressSpace::Heap,
                     context.byte_type(),
                     arguments[1].into_int_value(),
                     "mcopy_source",
@@ -360,12 +359,11 @@ impl FunctionCall {
 
             Name::SLoad => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_storage::load(context, arguments[0].into_int_value())
-                    .map(Some)
+                solx_codegen_evm::storage::load(context, arguments[0].into_int_value()).map(Some)
             }
             Name::SStore => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_storage::store(
+                solx_codegen_evm::storage::store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -374,15 +372,12 @@ impl FunctionCall {
             }
             Name::TLoad => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_storage::transient_load(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::storage::transient_load(context, arguments[0].into_int_value())
+                    .map(Some)
             }
             Name::TStore => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_storage::transient_store(
+                solx_codegen_evm::storage::transient_store(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -394,7 +389,7 @@ impl FunctionCall {
                 let id = arguments[0].original.take().ok_or_else(|| {
                     anyhow::anyhow!("{location} `loadimmutable` literal is missing")
                 })?;
-                era_compiler_llvm_context::evm_immutable::load(context, id.as_str()).map(Some)
+                solx_codegen_evm::immutable::load(context, id.as_str()).map(Some)
             }
             Name::SetImmutable => {
                 let mut arguments = self.pop_arguments::<3>(context)?;
@@ -405,27 +400,18 @@ impl FunctionCall {
 
                 let base_offset = arguments[0].to_llvm().into_int_value();
                 let value = arguments[2].to_llvm().into_int_value();
-                era_compiler_llvm_context::evm_immutable::store(
-                    context,
-                    id.as_str(),
-                    base_offset,
-                    value,
-                )
-                .map(|_| None)
+                solx_codegen_evm::immutable::store(context, id.as_str(), base_offset, value)
+                    .map(|_| None)
             }
 
             Name::CallDataLoad => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_calldata::load(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::calldata::load(context, arguments[0].into_int_value()).map(Some)
             }
-            Name::CallDataSize => era_compiler_llvm_context::evm_calldata::size(context).map(Some),
+            Name::CallDataSize => solx_codegen_evm::calldata::size(context).map(Some),
             Name::CallDataCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_calldata::copy(
+                solx_codegen_evm::calldata::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -434,12 +420,10 @@ impl FunctionCall {
                 Ok(None)
             }
 
-            Name::ReturnDataSize => {
-                era_compiler_llvm_context::evm_return_data::size(context).map(Some)
-            }
+            Name::ReturnDataSize => solx_codegen_evm::r#return_data::size(context).map(Some),
             Name::ReturnDataCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_return_data::copy(
+                solx_codegen_evm::r#return_data::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -448,10 +432,10 @@ impl FunctionCall {
                 Ok(None)
             }
 
-            Name::CodeSize => era_compiler_llvm_context::evm_code::size(context).map(Some),
+            Name::CodeSize => solx_codegen_evm::code::size(context).map(Some),
             Name::CodeCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_code::copy(
+                solx_codegen_evm::code::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -461,15 +445,11 @@ impl FunctionCall {
             }
             Name::ExtCodeSize => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_code::ext_size(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::code::ext_size(context, arguments[0].into_int_value()).map(Some)
             }
             Name::ExtCodeCopy => {
                 let arguments = self.pop_arguments_llvm::<4>(context)?;
-                era_compiler_llvm_context::evm_code::ext_copy(
+                solx_codegen_evm::code::ext_copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -480,16 +460,12 @@ impl FunctionCall {
             }
             Name::ExtCodeHash => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
-                era_compiler_llvm_context::evm_code::ext_hash(
-                    context,
-                    arguments[0].into_int_value(),
-                )
-                .map(Some)
+                solx_codegen_evm::code::ext_hash(context, arguments[0].into_int_value()).map(Some)
             }
 
             Name::Return => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_return::r#return(
+                solx_codegen_evm::r#return::r#return(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -498,19 +474,19 @@ impl FunctionCall {
             }
             Name::Revert => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_return::revert(
+                solx_codegen_evm::r#return::revert(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
                 )
                 .map(|_| None)
             }
-            Name::Stop => era_compiler_llvm_context::evm_return::stop(context).map(|_| None),
-            Name::Invalid => era_compiler_llvm_context::evm_return::invalid(context).map(|_| None),
+            Name::Stop => solx_codegen_evm::r#return::stop(context).map(|_| None),
+            Name::Invalid => solx_codegen_evm::r#return::invalid(context).map(|_| None),
 
             Name::Log0 => {
                 let arguments = self.pop_arguments_llvm::<2>(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -520,7 +496,7 @@ impl FunctionCall {
             }
             Name::Log1 => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -533,7 +509,7 @@ impl FunctionCall {
             }
             Name::Log2 => {
                 let arguments = self.pop_arguments_llvm::<4>(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -546,7 +522,7 @@ impl FunctionCall {
             }
             Name::Log3 => {
                 let arguments = self.pop_arguments_llvm::<5>(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -559,7 +535,7 @@ impl FunctionCall {
             }
             Name::Log4 => {
                 let arguments = self.pop_arguments_llvm::<6>(context)?;
-                era_compiler_llvm_context::evm_event::log(
+                solx_codegen_evm::event::log(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -582,7 +558,7 @@ impl FunctionCall {
                 let output_offset = arguments[5].value.into_int_value();
                 let output_size = arguments[6].value.into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::call(
+                Ok(Some(solx_codegen_evm::call::call(
                     context,
                     gas,
                     address,
@@ -603,7 +579,7 @@ impl FunctionCall {
                 let output_offset = arguments[4].value.into_int_value();
                 let output_size = arguments[5].value.into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::static_call(
+                Ok(Some(solx_codegen_evm::call::static_call(
                     context,
                     gas,
                     address,
@@ -623,7 +599,7 @@ impl FunctionCall {
                 let output_offset = arguments[4].value.into_int_value();
                 let output_size = arguments[5].value.into_int_value();
 
-                Ok(Some(era_compiler_llvm_context::evm_call::delegate_call(
+                Ok(Some(solx_codegen_evm::call::delegate_call(
                     context,
                     gas,
                     address,
@@ -641,13 +617,8 @@ impl FunctionCall {
                 let input_offset = arguments[1].into_int_value();
                 let input_length = arguments[2].into_int_value();
 
-                era_compiler_llvm_context::evm_create::create(
-                    context,
-                    value,
-                    input_offset,
-                    input_length,
-                )
-                .map(Some)
+                solx_codegen_evm::create::create(context, value, input_offset, input_length)
+                    .map(Some)
             }
             Name::Create2 => {
                 let arguments = self.pop_arguments_llvm::<4>(context)?;
@@ -657,14 +628,8 @@ impl FunctionCall {
                 let input_length = arguments[2].into_int_value();
                 let salt = arguments[3].into_int_value();
 
-                era_compiler_llvm_context::evm_create::create2(
-                    context,
-                    value,
-                    input_offset,
-                    input_length,
-                    salt,
-                )
-                .map(Some)
+                solx_codegen_evm::create::create2(context, value, input_offset, input_length, salt)
+                    .map(Some)
             }
             Name::DataOffset => {
                 let mut arguments = self.pop_arguments::<1>(context)?;
@@ -672,7 +637,7 @@ impl FunctionCall {
                     anyhow::anyhow!("{} `dataoffset` literal is missing", location)
                 })?;
                 let object_name = object_name.split('.').next_back().expect("Always exists");
-                era_compiler_llvm_context::evm_code::data_offset(context, object_name).map(Some)
+                solx_codegen_evm::code::data_offset(context, object_name).map(Some)
             }
             Name::DataSize => {
                 let mut arguments = self.pop_arguments::<1>(context)?;
@@ -681,11 +646,11 @@ impl FunctionCall {
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("{} `datasize` literal is missing", location))?;
                 let object_name = object_name.split('.').next_back().expect("Always exists");
-                era_compiler_llvm_context::evm_code::data_size(context, object_name).map(Some)
+                solx_codegen_evm::code::data_size(context, object_name).map(Some)
             }
             Name::DataCopy => {
                 let arguments = self.pop_arguments_llvm::<3>(context)?;
-                era_compiler_llvm_context::evm_code::copy(
+                solx_codegen_evm::code::copy(
                     context,
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
@@ -699,7 +664,7 @@ impl FunctionCall {
                 let path = arguments[0].original.take().ok_or_else(|| {
                     anyhow::anyhow!("{location} Linker symbol literal is missing")
                 })?;
-                era_compiler_llvm_context::evm_call::linker_symbol(context, path.as_str()).map(Some)
+                solx_codegen_evm::call::linker_symbol(context, path.as_str()).map(Some)
             }
             Name::MemoryGuard => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
@@ -708,7 +673,7 @@ impl FunctionCall {
                     .settings()
                     .spill_area_size()
                     .unwrap_or_default();
-                era_compiler_llvm_context::evm_arithmetic::addition(
+                solx_codegen_evm::arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
                     context.field_const(spill_area),
@@ -719,57 +684,36 @@ impl FunctionCall {
             Name::Address => context.build_call(context.intrinsics().address, &[], "address"),
             Name::Caller => context.build_call(context.intrinsics().caller, &[], "caller"),
 
-            Name::CallValue => {
-                era_compiler_llvm_context::evm_ether_gas::callvalue(context).map(Some)
-            }
-            Name::Gas => era_compiler_llvm_context::evm_ether_gas::gas(context).map(Some),
+            Name::CallValue => solx_codegen_evm::ether_gas::callvalue(context).map(Some),
+            Name::Gas => solx_codegen_evm::ether_gas::gas(context).map(Some),
             Name::Balance => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
 
                 let address = arguments[0].into_int_value();
-                era_compiler_llvm_context::evm_ether_gas::balance(context, address).map(Some)
+                solx_codegen_evm::ether_gas::balance(context, address).map(Some)
             }
-            Name::SelfBalance => {
-                era_compiler_llvm_context::evm_ether_gas::self_balance(context).map(Some)
-            }
+            Name::SelfBalance => solx_codegen_evm::ether_gas::self_balance(context).map(Some),
 
-            Name::GasLimit => {
-                era_compiler_llvm_context::evm_contract_context::gas_limit(context).map(Some)
-            }
-            Name::GasPrice => {
-                era_compiler_llvm_context::evm_contract_context::gas_price(context).map(Some)
-            }
-            Name::Origin => {
-                era_compiler_llvm_context::evm_contract_context::origin(context).map(Some)
-            }
-            Name::ChainId => {
-                era_compiler_llvm_context::evm_contract_context::chain_id(context).map(Some)
-            }
+            Name::GasLimit => solx_codegen_evm::contract_context::gas_limit(context).map(Some),
+            Name::GasPrice => solx_codegen_evm::contract_context::gas_price(context).map(Some),
+            Name::Origin => solx_codegen_evm::contract_context::origin(context).map(Some),
+            Name::ChainId => solx_codegen_evm::contract_context::chain_id(context).map(Some),
             Name::Timestamp => {
-                era_compiler_llvm_context::evm_contract_context::block_timestamp(context).map(Some)
+                solx_codegen_evm::contract_context::block_timestamp(context).map(Some)
             }
-            Name::Number => {
-                era_compiler_llvm_context::evm_contract_context::block_number(context).map(Some)
-            }
+            Name::Number => solx_codegen_evm::contract_context::block_number(context).map(Some),
             Name::BlockHash => {
                 let arguments = self.pop_arguments_llvm::<1>(context)?;
                 let index = arguments[0].into_int_value();
 
-                era_compiler_llvm_context::evm_contract_context::block_hash(context, index)
-                    .map(Some)
+                solx_codegen_evm::contract_context::block_hash(context, index).map(Some)
             }
             Name::Difficulty | Name::Prevrandao => {
-                era_compiler_llvm_context::evm_contract_context::difficulty(context).map(Some)
+                solx_codegen_evm::contract_context::difficulty(context).map(Some)
             }
-            Name::CoinBase => {
-                era_compiler_llvm_context::evm_contract_context::coinbase(context).map(Some)
-            }
-            Name::BaseFee => {
-                era_compiler_llvm_context::evm_contract_context::basefee(context).map(Some)
-            }
-            Name::MSize => {
-                era_compiler_llvm_context::evm_contract_context::msize(context).map(Some)
-            }
+            Name::CoinBase => solx_codegen_evm::contract_context::coinbase(context).map(Some),
+            Name::BaseFee => solx_codegen_evm::contract_context::basefee(context).map(Some),
+            Name::MSize => solx_codegen_evm::contract_context::msize(context).map(Some),
 
             Name::CallCode => {
                 let _arguments = self.pop_arguments_llvm::<7>(context)?;
@@ -790,7 +734,7 @@ impl FunctionCall {
     ///
     fn pop_arguments_llvm<'ctx, const N: usize>(
         &mut self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+        context: &mut solx_codegen_evm::Context<'ctx>,
     ) -> anyhow::Result<[inkwell::values::BasicValueEnum<'ctx>; N]> {
         let mut arguments = Vec::with_capacity(N);
         for expression in self.0.arguments.drain(0..N).rev() {
@@ -812,8 +756,8 @@ impl FunctionCall {
     ///
     fn pop_arguments<'ctx, const N: usize>(
         &mut self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
-    ) -> anyhow::Result<[era_compiler_llvm_context::Value<'ctx>; N]> {
+        context: &mut solx_codegen_evm::Context<'ctx>,
+    ) -> anyhow::Result<[solx_codegen_evm::Value<'ctx>; N]> {
         let mut arguments = Vec::with_capacity(N);
         for expression in self.0.arguments.drain(0..N).rev() {
             arguments.push(

--- a/solx/src/yul/parser/statement/expression/literal.rs
+++ b/solx/src/yul/parser/statement/expression/literal.rs
@@ -21,12 +21,9 @@ impl Literal {
     ///
     /// Converts the literal into its LLVM.
     ///
-    pub fn into_llvm<'ctx, C>(
-        self,
-        context: &C,
-    ) -> anyhow::Result<era_compiler_llvm_context::Value<'ctx>>
+    pub fn into_llvm<'ctx, C>(self, context: &C) -> anyhow::Result<solx_codegen_evm::Value<'ctx>>
     where
-        C: era_compiler_llvm_context::IContext<'ctx>,
+        C: solx_codegen_evm::IContext<'ctx>,
     {
         match self.0.inner {
             LexicalLiteral::Boolean(inner) => {
@@ -50,9 +47,7 @@ impl Literal {
                     BooleanLiteral::True => num::BigUint::one(),
                 };
 
-                Ok(era_compiler_llvm_context::Value::new_with_constant(
-                    value, constant,
-                ))
+                Ok(solx_codegen_evm::Value::new_with_constant(value, constant))
             }
             LexicalLiteral::Integer(inner) => {
                 let r#type = self
@@ -86,9 +81,7 @@ impl Literal {
                 }
                 .expect("Always valid");
 
-                Ok(era_compiler_llvm_context::Value::new_with_constant(
-                    value, constant,
-                ))
+                Ok(solx_codegen_evm::Value::new_with_constant(value, constant))
             }
             LexicalLiteral::String(inner) => {
                 let string = inner.inner;
@@ -163,7 +156,7 @@ impl Literal {
                 };
 
                 if hex_string.len() > era_compiler_common::BYTE_LENGTH_FIELD * 2 {
-                    return Ok(era_compiler_llvm_context::Value::new_with_original(
+                    return Ok(solx_codegen_evm::Value::new_with_original(
                         r#type.const_zero().as_basic_value_enum(),
                         string,
                     ));
@@ -183,9 +176,7 @@ impl Literal {
                     )
                     .expect("The value is valid")
                     .as_basic_value_enum();
-                Ok(era_compiler_llvm_context::Value::new_with_original(
-                    value, string,
-                ))
+                Ok(solx_codegen_evm::Value::new_with_original(value, string))
             }
         }
     }

--- a/solx/src/yul/parser/statement/expression/mod.rs
+++ b/solx/src/yul/parser/statement/expression/mod.rs
@@ -6,7 +6,7 @@ pub mod function_call;
 pub mod literal;
 
 use crate::declare_wrapper;
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::yul::parser::wrapper::Wrap;
 
@@ -21,8 +21,8 @@ impl Expression {
     ///
     pub fn into_llvm<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
-    ) -> anyhow::Result<Option<era_compiler_llvm_context::Value<'ctx>>> {
+        context: &mut solx_codegen_evm::Context<'ctx>,
+    ) -> anyhow::Result<Option<solx_codegen_evm::Value<'ctx>>> {
         match self.0 {
             solx_yul::yul::parser::statement::expression::Expression::Literal(literal) => literal
                 .clone()
@@ -57,7 +57,7 @@ impl Expression {
                 Ok(call
                     .wrap()
                     .into_llvm(context)?
-                    .map(era_compiler_llvm_context::Value::new))
+                    .map(solx_codegen_evm::Value::new))
             }
         }
     }

--- a/solx/src/yul/parser/statement/for_loop.rs
+++ b/solx/src/yul/parser/statement/for_loop.rs
@@ -2,7 +2,7 @@
 //! The for-loop statement.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::declare_wrapper;
 use crate::yul::parser::dialect::era::EraDialect;
@@ -15,8 +15,8 @@ declare_wrapper!(
     ForLoop
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for ForLoop {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for ForLoop {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         self.0.initializer.wrap().into_llvm(context)?;
 
         let condition_block = context.append_basic_block("for_condition");

--- a/solx/src/yul/parser/statement/if_conditional.rs
+++ b/solx/src/yul/parser/statement/if_conditional.rs
@@ -2,7 +2,7 @@
 //! The if-conditional statement.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::declare_wrapper;
 use crate::yul::parser::dialect::era::EraDialect;
@@ -13,8 +13,8 @@ declare_wrapper!(
     IfConditional
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for IfConditional {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for IfConditional {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let condition = self
             .0
             .condition

--- a/solx/src/yul/parser/statement/object.rs
+++ b/solx/src/yul/parser/statement/object.rs
@@ -11,16 +11,13 @@ declare_wrapper!(
     Object
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Object {
-    fn declare(
-        &mut self,
-        _context: &mut era_compiler_llvm_context::EVMContext,
-    ) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Object {
+    fn declare(&mut self, _context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         Ok(())
     }
 
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
-        let mut entry = era_compiler_llvm_context::EVMEntryFunction::new(self.0.code.wrap());
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
+        let mut entry = solx_codegen_evm::EntryFunction::new(self.0.code.wrap());
         entry.declare(context)?;
         entry.into_llvm(context)?;
         Ok(())

--- a/solx/src/yul/parser/statement/switch/mod.rs
+++ b/solx/src/yul/parser/statement/switch/mod.rs
@@ -2,7 +2,7 @@
 //! The switch statement.
 //!
 
-use era_compiler_llvm_context::IContext;
+use solx_codegen_evm::IContext;
 
 use crate::declare_wrapper;
 use crate::yul::parser::dialect::era::EraDialect;
@@ -13,13 +13,13 @@ declare_wrapper!(
     Switch
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for Switch {
-    fn into_llvm(self, context: &mut era_compiler_llvm_context::EVMContext) -> anyhow::Result<()> {
+impl solx_codegen_evm::WriteLLVM for Switch {
+    fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
         let scrutinee = self.0.expression.wrap().into_llvm(context)?;
 
         if self.0.cases.is_empty() {
             if let Some(block) = self.0.default {
-                era_compiler_llvm_context::EVMWriteLLVM::into_llvm(block.wrap(), context)?;
+                solx_codegen_evm::WriteLLVM::into_llvm(block.wrap(), context)?;
             }
             return Ok(());
         }
@@ -34,7 +34,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Switch {
             let expression_block = context
                 .append_basic_block(format!("switch_case_branch_{}_block", index + 1).as_str());
             context.set_basic_block(expression_block);
-            era_compiler_llvm_context::EVMWriteLLVM::into_llvm(case.block.wrap(), context)?;
+            solx_codegen_evm::WriteLLVM::into_llvm(case.block.wrap(), context)?;
             context.build_unconditional_branch(join_block)?;
 
             branches.push((constant.into_int_value(), expression_block));
@@ -44,7 +44,7 @@ impl era_compiler_llvm_context::EVMWriteLLVM for Switch {
             Some(default) => {
                 let default_block = context.append_basic_block("switch_default_block");
                 context.set_basic_block(default_block);
-                era_compiler_llvm_context::EVMWriteLLVM::into_llvm(default.wrap(), context)?;
+                solx_codegen_evm::WriteLLVM::into_llvm(default.wrap(), context)?;
                 context.build_unconditional_branch(join_block)?;
                 default_block
             }

--- a/solx/src/yul/parser/statement/variable_declaration.rs
+++ b/solx/src/yul/parser/statement/variable_declaration.rs
@@ -2,9 +2,9 @@
 //! The variable declaration statement.
 //!
 
-use era_compiler_llvm_context::IContext;
 use inkwell::types::BasicType;
 use inkwell::values::BasicValue;
+use solx_codegen_evm::IContext;
 
 use crate::declare_wrapper;
 use crate::yul::parser::wrapper::Wrap;
@@ -14,10 +14,10 @@ declare_wrapper!(
     VariableDeclaration
 );
 
-impl era_compiler_llvm_context::EVMWriteLLVM for VariableDeclaration {
+impl solx_codegen_evm::WriteLLVM for VariableDeclaration {
     fn into_llvm<'ctx>(
         mut self,
-        context: &mut era_compiler_llvm_context::EVMContext<'ctx>,
+        context: &mut solx_codegen_evm::Context<'ctx>,
     ) -> anyhow::Result<()> {
         if self.0.bindings.len() == 1 {
             let identifier = self.0.bindings.remove(0);

--- a/solx/src/yul/parser/type.rs
+++ b/solx/src/yul/parser/type.rs
@@ -17,7 +17,7 @@ impl Type {
     ///
     pub fn into_llvm<'ctx, C>(self, context: &C) -> inkwell::types::IntType<'ctx>
     where
-        C: era_compiler_llvm_context::IContext<'ctx>,
+        C: solx_codegen_evm::IContext<'ctx>,
     {
         match self.0 {
             YulType::Bool => context.integer_type(era_compiler_common::BIT_LENGTH_BOOLEAN),

--- a/solx/src/yul/parser/wrapper.rs
+++ b/solx/src/yul/parser/wrapper.rs
@@ -1,5 +1,5 @@
 //!
-//! Proxy trait for `era_compiler_llvm_context::WriteLLVM`.
+//! Proxy trait for `solx_codegen_evm::WriteLLVM`.
 //!
 
 ///

--- a/solx/tests/common/mod.rs
+++ b/solx/tests/common/mod.rs
@@ -60,13 +60,13 @@ pub fn build_solidity_standard_json(
     metadata_hash_type: era_compiler_common::EVMMetadataHashType,
     remappings: BTreeSet<String>,
     via_ir: bool,
-    optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    optimizer_settings: solx_codegen_evm::OptimizerSettings,
 ) -> anyhow::Result<solx_standard_json::Output> {
     self::setup()?;
 
     let solc_compiler = solx_solc::Compiler::default();
 
-    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EVM);
+    solx_codegen_evm::initialize_target();
 
     let sources: BTreeMap<String, solx_standard_json::InputSource> = sources
         .into_iter()
@@ -162,9 +162,9 @@ pub fn build_yul_standard_json(
 
     let solc_compiler = solx_solc::Compiler::default();
 
-    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EVM);
+    solx_codegen_evm::initialize_target();
 
-    let optimizer_settings = era_compiler_llvm_context::OptimizerSettings::try_from_cli(
+    let optimizer_settings = solx_codegen_evm::OptimizerSettings::try_from_cli(
         input.settings.optimizer.mode.unwrap_or_else(|| {
             solx_standard_json::InputOptimizer::default_mode().expect("Always exists")
         }),
@@ -216,9 +216,9 @@ pub fn build_llvm_ir_standard_json(
 ) -> anyhow::Result<solx_standard_json::Output> {
     self::setup()?;
 
-    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EVM);
+    solx_codegen_evm::initialize_target();
 
-    let optimizer_settings = era_compiler_llvm_context::OptimizerSettings::try_from_cli(
+    let optimizer_settings = solx_codegen_evm::OptimizerSettings::try_from_cli(
         input.settings.optimizer.mode.unwrap_or_else(|| {
             solx_standard_json::InputOptimizer::default_mode().expect("Always exists")
         }),

--- a/solx/tests/unit/ir_artifacts.rs
+++ b/solx/tests/unit/ir_artifacts.rs
@@ -17,7 +17,7 @@ fn evmla() {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         false,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
     assert!(
@@ -58,7 +58,7 @@ fn yul() {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         true,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
 
@@ -101,7 +101,7 @@ fn yul_empty_solidity_interface() {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         true,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
 

--- a/solx/tests/unit/libraries.rs
+++ b/solx/tests/unit/libraries.rs
@@ -18,7 +18,7 @@ fn not_specified(via_ir: bool) {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
 
@@ -65,7 +65,7 @@ fn specified(via_ir: bool) {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
     assert!(

--- a/solx/tests/unit/optimizer.rs
+++ b/solx/tests/unit/optimizer.rs
@@ -18,7 +18,7 @@ fn default(via_ir: bool) {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Build failure");
     let build_optimized_for_size = crate::common::build_solidity_standard_json(
@@ -27,7 +27,7 @@ fn default(via_ir: bool) {
         era_compiler_common::EVMMetadataHashType::IPFS,
         BTreeSet::new(),
         via_ir,
-        era_compiler_llvm_context::OptimizerSettings::size(),
+        solx_codegen_evm::OptimizerSettings::size(),
     )
     .expect("Build failure");
 

--- a/solx/tests/unit/remappings.rs
+++ b/solx/tests/unit/remappings.rs
@@ -23,7 +23,7 @@ fn default(via_ir: bool) {
         era_compiler_common::EVMMetadataHashType::IPFS,
         remappings,
         via_ir,
-        era_compiler_llvm_context::OptimizerSettings::cycles(),
+        solx_codegen_evm::OptimizerSettings::cycles(),
     )
     .expect("Test failure");
 }


### PR DESCRIPTION
# What ❔

Migrates the EVM codegen to this repo.

## Why ❔

We want to decouple EraVM and EVM codegens.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
