### PR TITLE
fix: don't rematerialize CALLDATALOAD when it redefines a VR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/matter-labs/era-compiler-llvm
-	branch = dborisenkov-remove-custom-remat
+	branch = main
 	update = none
 [submodule "era-solidity"]
 	path = era-solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "llvm"]
 	path = llvm
 	url = https://github.com/matter-labs/era-compiler-llvm
-	branch = main
+	branch = dborisenkov-remove-custom-remat
 	update = none
 [submodule "era-solidity"]
 	path = era-solidity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/solx/tests/cli/standard_json.rs
+++ b/solx/tests/cli/standard_json.rs
@@ -74,6 +74,24 @@ fn recursion() -> anyhow::Result<()> {
 }
 
 #[test]
+fn fuzzed_simple_use_expression() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::TEST_SOLIDITY_STANDARD_JSON_FUZZED_SIMPLE_USE_EXPRESSION_PATH,
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("bytecode"))
+        .stdout(predicate::str::contains("object"));
+
+    Ok(())
+}
+
+#[test]
 fn yul() -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/solx/tests/common/const.rs
+++ b/solx/tests/common/const.rs
@@ -80,6 +80,10 @@ pub const TEST_SOLIDITY_STANDARD_JSON_DEPLOY_TIME_LINKING_PATH: &str =
     "tests/data/standard_json_input/solidity_deploy_time_linking.json";
 
 /// A test input file.
+pub const TEST_SOLIDITY_STANDARD_JSON_FUZZED_SIMPLE_USE_EXPRESSION_PATH: &str =
+    "tests/data/standard_json_input/solidity_fuzzed_simple_use_expression.json";
+
+/// A test input file.
 pub const TEST_SOLIDITY_STANDARD_JSON_EMPTY_SOURCES_PATH: &str =
     "tests/data/standard_json_input/solidity_empty_sources.json";
 

--- a/solx/tests/data/standard_json_input/solidity_fuzzed_simple_use_expression.json
+++ b/solx/tests/data/standard_json_input/solidity_fuzzed_simple_use_expression.json
@@ -1,0 +1,22 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "target.sol": {
+      "content": "\n        pragma solidity ^0.8.19;\n        \n        \n        contract vaqsoEkzJ3A35uUb {\n            address public state_var_0 = address(0x0000000000000000000000000000000000000000);\nint16 public state_var_1 = int16(-3);\nuint64 public state_var_2 = uint64(68);\n\n        function VPnrn2kjR8HlSL(int256 assert_in2, bool assert_in3, int256 assert_in4) external  returns (int256) {\n            \n            return ((assert_in2 /  (assert_in3 ? int256(68) : assert_in4)) %  assert_in2);\n        }\n        \n        }\n        \n\n        contract PlaceholderContract {\n            \n        function VPnrn2kjR8HlSL(int256 assert_in2, bool assert_in3, int256 assert_in4) internal  returns (int256) {\n            \n            return ((assert_in2 /  (assert_in3 ? int256(68) : assert_in4)) %  assert_in2);\n        }\n        \n\n        function vMNweLbsuKKiaQB4fc8D3(int256 assert_in0, int256 assert_in1, bool assert_in3, int256 assert_in4, bool assert_in5) internal  returns (int256) {\n            \n            return (((assert_in5 &&  assert_in3) ||  (assert_in3 &&  assert_in5)) ? ((assert_in1 -  assert_in0) *  (int256(537) *  int256(849))) : (assert_in0 +  (assert_in3 ? assert_in4 : assert_in4)));\n        }\n        \n\n        function mGXLYjQ23CK7Onb4(int256 assert_in2, bool assert_in3, int256 assert_in4) internal  returns (int256) {\n            \n            return ((((assert_in2 /  (assert_in3 ? (((int256(68) -  int256(0)) -  int256(0)) *  int256(1)) : assert_in4)) -  int256(75)) +  int256(75)) %  assert_in2);\n        }\n        \n\n        function $joPlA3NjMz6GFgqlipWRxuntdOJq(int256 assert_in0, int256 assert_in1, int256 assert_in2, bool assert_in3, int256 assert_in4, bool assert_in5) internal  returns (int256) {\n            \n            return (mGXLYjQ23CK7Onb4(assert_in2, assert_in3, assert_in4) /  (((int256(0) *  ((((int256(1) -  int256(43)) +  int256(43)) &  ((int256(1) +  (- int256(43))) +  int256(43))) /  int256(1))) +  ((- ((- ((! ((! (assert_in5 &&  assert_in3)) &&  (! (true &&  (assert_in5 &&  assert_in3))))) ? ((((assert_in1 +  (int256(0) -  (assert_in0 +  int256(0)))) |  int256(0)) *  (int256(537) *  (int256(849) -  (int256(0) |  int256(0))))) &  (((assert_in1 +  (- (assert_in0 +  int256(0)))) |  int256(0)) *  ((int256(537) &  int256(537)) *  (int256(849) -  int256(0))))) : (- (- ((- (- (assert_in0 &  ((assert_in0 -  int256(68)) +  int256(68))))) +  ((! ((! false) &&  (! (assert_in3 ||  false)))) ? assert_in4 : assert_in4)))))) &  (- ((! (! ((assert_in3 ||  (! (! ((true &&  (assert_in5 &&  assert_in3)) ||  (true &&  (assert_in5 &&  assert_in3)))))) &&  (assert_in5 ||  (! (! (true &&  (assert_in5 &&  assert_in3)))))))) ? (((assert_in1 -  (int256(0) +  assert_in0)) |  int256(0)) *  (int256(537) *  (int256(849) -  (int256(0) |  int256(0))))) : ((- (- (assert_in0 &  assert_in0))) +  ((false ||  ((false ||  (assert_in3 ||  (assert_in3 ||  false))) ||  (false ||  (assert_in3 ||  (assert_in3 ||  false))))) ? assert_in4 : assert_in4)))))) *  (((int256(1) +  (- int256(43))) +  int256(43)) &  ((int256(1) -  int256(43)) +  int256(43))))) +  (- int256(0))));\n        }\n        \n\n        function check_entrypoint(int256 assert_in0, int256 assert_in1, int256 assert_in2, bool assert_in3, int256 assert_in4, bool assert_in5) public  {\n            unchecked {\n            int256  assert_out1 = ((new vaqsoEkzJ3A35uUb()).VPnrn2kjR8HlSL(assert_in2, assert_in3, assert_in4) /  vMNweLbsuKKiaQB4fc8D3(assert_in0, assert_in1, assert_in3, assert_in4, assert_in5));\nint256  assert_out2 = $joPlA3NjMz6GFgqlipWRxuntdOJq(assert_in0, assert_in1, assert_in2, assert_in3, assert_in4, assert_in5);\nassert((assert_out1 ==  assert_out2));\n        }\n            \n        }\n        \n        }\n        \n        "
+    }
+  },
+  "optimizer": {
+    "mode": "z"
+  },
+  "settings": {
+    "evmVersion": "petersburg",
+    "viaIR": true,
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/matter-labs/solx/issues/136

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
