### PR TITLE
chore: migrates the LLVM builder to this monorepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayref"
@@ -185,9 +185,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -415,7 +415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "float-cmp"
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -509,9 +509,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -604,9 +604,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "multibase"
@@ -678,11 +678,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "normpath"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -966,7 +966,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1006,18 +1006,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1137,7 +1137,7 @@ dependencies = [
  "solx-yul",
  "tempfile",
  "test-case",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1152,7 +1152,7 @@ dependencies = [
  "semver",
  "serde",
  "solx-utils",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ dependencies = [
  "anyhow",
  "serde",
  "solx-utils",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1271,15 +1271,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1332,11 +1332,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,12 +1476,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
@@ -1501,16 +1495,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1531,11 +1525,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +467,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +535,36 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -496,10 +590,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -633,6 +749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +875,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +907,18 @@ name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -813,6 +957,15 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.5",
 ]
 
 [[package]]
@@ -951,6 +1104,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1166,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1029,6 +1236,15 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1097,6 +1313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "solx"
 version = "0.1.3"
 dependencies = [
@@ -1156,6 +1378,25 @@ dependencies = [
  "solx-utils",
  "solx-yul",
  "twox-hash",
+]
+
+[[package]]
+name = "solx-llvm-builder"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "assert_fs",
+ "clap",
+ "fs_extra",
+ "num_cpus",
+ "path-slash",
+ "predicates",
+ "regex",
+ "rstest",
+ "serde",
+ "solx-utils",
+ "toml",
 ]
 
 [[package]]
@@ -1334,6 +1575,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1725,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1572,6 +1903,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,21 +96,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_fs"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
-dependencies = [
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,49 +458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,36 +477,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "globset"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags",
- "ignore",
- "walkdir",
 ]
 
 [[package]]
@@ -590,32 +502,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "ignore"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
 
 [[package]]
 name = "indexmap"
@@ -749,12 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,16 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,18 +781,6 @@ name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -957,15 +819,6 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.5",
 ]
 
 [[package]]
@@ -1104,51 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rstest"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,15 +974,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "semver"
@@ -1313,12 +1112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
 name = "solx"
 version = "0.1.3"
 dependencies = [
@@ -1382,20 +1175,14 @@ dependencies = [
 
 [[package]]
 name = "solx-llvm-builder"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
- "assert_cmd",
- "assert_fs",
  "clap",
  "fs_extra",
- "num_cpus",
  "path-slash",
- "predicates",
  "regex",
- "rstest",
  "serde",
- "solx-utils",
  "toml",
 ]
 
@@ -1582,8 +1369,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1596,15 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,29 +1391,8 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.2",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
-dependencies = [
  "winnow",
 ]
 
@@ -1700,16 +1457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,15 +1472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "solx-yul",
     "solx-codegen-evm",
     "solx-utils",
+    "solx-llvm-builder",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For reference, see [llvm-sys](https://crates.io/crates/llvm-sys) and [Local LLVM
 ## License
 
 - Crates **solx** and **solx-solc** are licensed under [GNU General Public License v3.0](./solx/LICENSE.txt)
-- Crates **solx-standard-json**, **solx-evm-assembly**, **solx-yul**, **solx-codegen-evm**, **solx-utils** are licensed under the terms of either
+- Crates **solx-standard-json**, **solx-evm-assembly**, **solx-yul**, **solx-codegen-evm**, **solx-utils**, **solx-llvm-builder** are licensed under the terms of either
   - Apache License, Version 2.0 ([LICENSE-APACHE](./solx-standard-json/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
   - MIT license ([LICENSE-MIT](./solx-standard-json/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 - [`era-solidity`](https://github.com/matter-labs/era-solidity/) is licensed under [GNU General Public License v3.0](https://github.com/matter-labs/era-solidity/blob/0.8.30/LICENSE.txt)

--- a/solx-llvm-builder/Cargo.toml
+++ b/solx-llvm-builder/Cargo.toml
@@ -19,15 +19,6 @@ anyhow = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 toml = "0.8"
 
-num_cpus = "1.16"
 fs_extra = "1.3"
 path-slash = "0.2"
 regex = "1.11"
-
-solx-utils = { path = "../solx-utils" }
-
-[dev-dependencies]
-assert_cmd = "2.0"
-predicates = "3.1"
-assert_fs = "1.1"
-rstest = "0.25"

--- a/solx-llvm-builder/Cargo.toml
+++ b/solx-llvm-builder/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solx-llvm-builder"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+description = "LLVM framework builder for solx"
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "solx-llvm"
+path = "src/solx_llvm_builder/main.rs"
+
+[lib]
+doctest = false
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+anyhow = "1.0"
+serde = { version = "1.0", features = [ "derive" ] }
+toml = "0.8"
+
+num_cpus = "1.16"
+fs_extra = "1.3"
+path-slash = "0.2"
+regex = "1.11"
+
+solx-utils = { path = "../solx-utils" }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+assert_fs = "1.1"
+rstest = "0.25"

--- a/solx-llvm-builder/LICENSE-APACHE
+++ b/solx-llvm-builder/LICENSE-APACHE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2019 Matter Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/solx-llvm-builder/LICENSE-MIT
+++ b/solx-llvm-builder/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Matter Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/solx-llvm-builder/src/build_type.rs
+++ b/solx-llvm-builder/src/build_type.rs
@@ -1,0 +1,43 @@
+//!
+//! The ZKsync LLVM build type.
+//!
+
+///
+/// The ZKsync LLVM build type.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuildType {
+    /// The debug build.
+    Debug,
+    /// The release build.
+    Release,
+    /// The release with debug info build.
+    RelWithDebInfo,
+    /// The minimal size release build.
+    MinSizeRel,
+}
+
+impl std::str::FromStr for BuildType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "Debug" => Ok(Self::Debug),
+            "Release" => Ok(Self::Release),
+            "RelWithDebInfo" => Ok(Self::RelWithDebInfo),
+            "MinSizeRel" => Ok(Self::MinSizeRel),
+            value => Err(format!("Unsupported build type: `{value}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for BuildType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Debug => write!(f, "Debug"),
+            Self::Release => write!(f, "Release"),
+            Self::RelWithDebInfo => write!(f, "RelWithDebInfo"),
+            Self::MinSizeRel => write!(f, "MinSizeRel"),
+        }
+    }
+}

--- a/solx-llvm-builder/src/ccache_variant.rs
+++ b/solx-llvm-builder/src/ccache_variant.rs
@@ -1,0 +1,35 @@
+//!
+//! Compiler cache variants.
+//!
+
+///
+/// The list compiler cache variants to be used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CcacheVariant {
+    /// Standard ccache.
+    Ccache,
+    /// Mozilla's sccache.
+    Sccache,
+}
+
+impl std::str::FromStr for CcacheVariant {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ccache" => Ok(Self::Ccache),
+            "sccache" => Ok(Self::Sccache),
+            value => Err(format!("Unsupported ccache variant: `{value}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for CcacheVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ccache => write!(f, "ccache"),
+            Self::Sccache => write!(f, "sccache"),
+        }
+    }
+}

--- a/solx-llvm-builder/src/lib.rs
+++ b/solx-llvm-builder/src/lib.rs
@@ -1,0 +1,125 @@
+//!
+//! The ZKsync LLVM builder library.
+//!
+
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::upper_case_acronyms)]
+
+pub(crate) mod build_type;
+pub(crate) mod ccache_variant;
+pub(crate) mod llvm_path;
+pub(crate) mod llvm_project;
+pub(crate) mod lock;
+pub(crate) mod platforms;
+pub(crate) mod sanitizer;
+pub(crate) mod utils;
+
+pub use self::build_type::BuildType;
+pub use self::ccache_variant::CcacheVariant;
+pub use self::llvm_path::LLVMPath;
+pub use self::llvm_project::LLVMProject;
+pub use self::lock::Lock;
+pub use self::sanitizer::Sanitizer;
+pub use self::utils::exists as executable_exists;
+
+use std::collections::HashSet;
+
+///
+/// Executes the building of the LLVM framework for the platform determined by the cfg macro.
+/// Since cfg is evaluated at compile time, overriding the platform with a command-line
+/// argument is not possible. So for cross-platform testing, comment out all but the
+/// line to be tested, and perhaps also checks in the platform-specific build method.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<llvm_project::LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<ccache_variant::CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<sanitizer::Sanitizer>,
+    enable_valgrind: bool,
+    valgrind_options: Vec<String>,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
+
+    if cfg!(target_arch = "x86_64") {
+        if cfg!(target_os = "linux") {
+            platforms::x86_64_linux_gnu::build(
+                build_type,
+                llvm_projects,
+                enable_rtti,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                ccache_variant,
+                enable_assertions,
+                sanitizer,
+                enable_valgrind,
+                valgrind_options,
+            )?;
+        } else if cfg!(target_os = "macos") {
+            platforms::x86_64_macos::build(
+                build_type,
+                llvm_projects,
+                enable_rtti,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                ccache_variant,
+                enable_assertions,
+                sanitizer,
+            )?;
+        } else if cfg!(target_os = "windows") {
+            platforms::x86_64_windows_gnu::build(
+                build_type,
+                llvm_projects,
+                enable_rtti,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                ccache_variant,
+                enable_assertions,
+                sanitizer,
+            )?;
+        } else {
+            anyhow::bail!("Unsupported target OS for x86_64");
+        }
+    } else if cfg!(target_arch = "aarch64") {
+        if cfg!(target_os = "linux") {
+            platforms::aarch64_linux_gnu::build(
+                build_type,
+                llvm_projects,
+                enable_rtti,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                ccache_variant,
+                enable_assertions,
+                sanitizer,
+                enable_valgrind,
+                valgrind_options,
+            )?;
+        } else if cfg!(target_os = "macos") {
+            platforms::aarch64_macos::build(
+                build_type,
+                llvm_projects,
+                enable_rtti,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                ccache_variant,
+                enable_assertions,
+                sanitizer,
+            )?;
+        } else {
+            anyhow::bail!("Unsupported target OS for aarch64");
+        }
+    } else {
+        anyhow::bail!("Unsupported target architecture");
+    }
+
+    Ok(())
+}

--- a/solx-llvm-builder/src/llvm_path.rs
+++ b/solx-llvm-builder/src/llvm_path.rs
@@ -1,0 +1,63 @@
+//!
+//! The ZKsync LLVM builder constants.
+//!
+
+use std::path::PathBuf;
+
+///
+/// The LLVM path resolver.
+///
+pub struct LLVMPath {}
+
+impl LLVMPath {
+    /// The LLVM source directory.
+    pub const DIRECTORY_LLVM_SOURCE: &'static str = "./llvm/";
+
+    /// The LLVM target directory.
+    pub const DIRECTORY_LLVM_TARGET: &'static str = "./target-llvm/";
+
+    ///
+    /// Returns the path to the `llvm` LLVM source module directory.
+    ///
+    pub fn llvm_module_llvm() -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_SOURCE);
+        path.push("llvm");
+        crate::utils::absolute_path(path)
+    }
+
+    ///
+    /// Returns the path to the LLVM CRT build directory.
+    ///
+    pub fn llvm_build_crt() -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_TARGET);
+        path.push("build-crt");
+        crate::utils::absolute_path(path)
+    }
+
+    ///
+    /// Returns the path to the LLVM final build directory.
+    ///
+    pub fn llvm_build_final() -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_TARGET);
+        path.push("build-final");
+        crate::utils::absolute_path(path)
+    }
+
+    ///
+    /// Returns the path to the LLVM CRT target directory.
+    ///
+    pub fn llvm_target_crt() -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_TARGET);
+        path.push("target-crt");
+        crate::utils::absolute_path(path)
+    }
+
+    ///
+    /// Returns the path to the LLVM final target directory.
+    ///
+    pub fn llvm_target_final() -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_TARGET);
+        path.push("target-final");
+        crate::utils::absolute_path(path)
+    }
+}

--- a/solx-llvm-builder/src/llvm_project.rs
+++ b/solx-llvm-builder/src/llvm_project.rs
@@ -1,0 +1,43 @@
+//!
+//! The LLVM projects to enable during the build.
+//!
+
+///
+/// The list of LLVM projects used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LLVMProject {
+    /// The Clang compiler.
+    CLANG,
+    /// LLD, the LLVM linker.
+    LLD,
+    /// The LLVM debugger.
+    LLDB,
+    /// The MLIR compiler.
+    MLIR,
+}
+
+impl std::str::FromStr for LLVMProject {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_str() {
+            "clang" => Ok(Self::CLANG),
+            "lld" => Ok(Self::LLD),
+            "lldb" => Ok(Self::LLDB),
+            "mlir" => Ok(Self::MLIR),
+            value => Err(format!("Unsupported LLVM project to enable: `{value}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for LLVMProject {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::CLANG => write!(f, "clang"),
+            Self::LLD => write!(f, "lld"),
+            Self::LLDB => write!(f, "lldb"),
+            Self::MLIR => write!(f, "mlir"),
+        }
+    }
+}

--- a/solx-llvm-builder/src/lock.rs
+++ b/solx-llvm-builder/src/lock.rs
@@ -1,0 +1,38 @@
+//!
+//! The ZKsync LLVM builder lock file.
+//!
+
+use anyhow::Context;
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+///
+/// The lock file data.
+///
+/// This file describes the exact reference of the LLVM framework.
+///
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Lock {
+    /// The LLVM repository URL.
+    pub url: String,
+    /// The LLVM repository branch.
+    pub branch: String,
+    /// The LLVM repository commit reference.
+    pub r#ref: Option<String>,
+}
+
+impl TryFrom<&PathBuf> for Lock {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &PathBuf) -> Result<Self, Self::Error> {
+        let mut config_str = String::new();
+        let mut config_file =
+            File::open(path).with_context(|| format!("Error opening {path:?} file"))?;
+        config_file.read_to_string(&mut config_str)?;
+        Ok(toml::from_str(&config_str)?)
+    }
+}

--- a/solx-llvm-builder/src/platforms/aarch64_linux_gnu.rs
+++ b/solx-llvm-builder/src/platforms/aarch64_linux_gnu.rs
@@ -1,0 +1,109 @@
+//!
+//! The ZKsync LLVM arm64 `linux-gnu` builder.
+//!
+
+use std::collections::HashSet;
+use std::process::Command;
+
+use crate::build_type::BuildType;
+use crate::ccache_variant::CcacheVariant;
+use crate::llvm_path::LLVMPath;
+use crate::llvm_project::LLVMProject;
+use crate::platforms::Platform;
+use crate::sanitizer::Sanitizer;
+
+///
+/// The building sequence.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
+    valgrind_options: Vec<String>,
+) -> anyhow::Result<()> {
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
+
+    let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
+    let llvm_build_final = LLVMPath::llvm_build_final()?;
+    let llvm_target_final = LLVMPath::llvm_target_final()?;
+
+    crate::utils::command(
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                format!(
+                    "-DLLVM_ENABLE_PROJECTS='{}'",
+                    llvm_projects
+                        .into_iter()
+                        .map(|project| project.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                "-DLLVM_USE_LINKER='lld'",
+                "-DLLVM_TARGETS_TO_BUILD=''",
+                format!(
+                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+                    [Platform::EVM, Platform::EraVM]
+                        .into_iter()
+                        .map(|platform| platform.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
+            ])
+            .args(crate::platforms::shared::shared_build_opts_tests(
+                enable_tests,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_coverage(
+                enable_coverage,
+            ))
+            .args(crate::platforms::shared::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared::shared_build_opts_werror())
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_ccache(
+                ccache_variant,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                enable_assertions,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_rtti(
+                enable_rtti,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_sanitizers(
+                sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
+                valgrind_options,
+            )),
+        "LLVM building cmake",
+    )?;
+    crate::utils::ninja(llvm_build_final.as_ref())?;
+    Ok(())
+}

--- a/solx-llvm-builder/src/platforms/aarch64_linux_gnu.rs
+++ b/solx-llvm-builder/src/platforms/aarch64_linux_gnu.rs
@@ -9,7 +9,6 @@ use crate::build_type::BuildType;
 use crate::ccache_variant::CcacheVariant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
-use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 ///
@@ -65,18 +64,8 @@ pub fn build(
                 )
                 .as_str(),
                 "-DLLVM_USE_LINKER='lld'",
-                "-DLLVM_TARGETS_TO_BUILD=''",
-                format!(
-                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
-                    [Platform::EVM, Platform::EraVM]
-                        .into_iter()
-                        .map(|platform| platform.to_string())
-                        .collect::<Vec<String>>()
-                        .join(";")
-                )
-                .as_str(),
-                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
             ])
+            .args(crate::platforms::shared::shared_build_opts_targets())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-llvm-builder/src/platforms/aarch64_macos.rs
+++ b/solx-llvm-builder/src/platforms/aarch64_macos.rs
@@ -9,7 +9,6 @@ use crate::build_type::BuildType;
 use crate::ccache_variant::CcacheVariant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
-use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 ///
@@ -58,18 +57,8 @@ pub fn build(
                 )
                 .as_str(),
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-                "-DLLVM_TARGETS_TO_BUILD=''",
-                format!(
-                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
-                    [Platform::EVM, Platform::EraVM]
-                        .into_iter()
-                        .map(|platform| platform.to_string())
-                        .collect::<Vec<String>>()
-                        .join(";")
-                )
-                .as_str(),
-                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
             ])
+            .args(crate::platforms::shared::shared_build_opts_targets())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-llvm-builder/src/platforms/aarch64_macos.rs
+++ b/solx-llvm-builder/src/platforms/aarch64_macos.rs
@@ -1,0 +1,101 @@
+//!
+//! The ZKsync LLVM arm64 `macos-aarch64` builder.
+//!
+
+use std::collections::HashSet;
+use std::process::Command;
+
+use crate::build_type::BuildType;
+use crate::ccache_variant::CcacheVariant;
+use crate::llvm_path::LLVMPath;
+use crate::llvm_project::LLVMProject;
+use crate::platforms::Platform;
+use crate::sanitizer::Sanitizer;
+
+///
+/// The building sequence.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<Sanitizer>,
+) -> anyhow::Result<()> {
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("ninja")?;
+
+    let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
+    let llvm_build_final = LLVMPath::llvm_build_final()?;
+    let llvm_target_final = LLVMPath::llvm_target_final()?;
+
+    crate::utils::command(
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                format!(
+                    "-DLLVM_ENABLE_PROJECTS='{}'",
+                    llvm_projects
+                        .into_iter()
+                        .map(|project| project.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
+                "-DLLVM_TARGETS_TO_BUILD=''",
+                format!(
+                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+                    [Platform::EVM, Platform::EraVM]
+                        .into_iter()
+                        .map(|platform| platform.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
+            ])
+            .args(crate::platforms::shared::shared_build_opts_tests(
+                enable_tests,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_coverage(
+                enable_coverage,
+            ))
+            .args(crate::platforms::shared::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared::shared_build_opts_werror())
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_ccache(
+                ccache_variant,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                enable_assertions,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_rtti(
+                enable_rtti,
+            ))
+            .args(crate::platforms::shared::macos_build_opts_ignore_dupicate_libs_warnings())
+            .args(crate::platforms::shared::shared_build_opts_sanitizers(
+                sanitizer,
+            )),
+        "LLVM building cmake",
+    )?;
+
+    crate::utils::ninja(llvm_build_final.as_ref())?;
+
+    Ok(())
+}

--- a/solx-llvm-builder/src/platforms/mod.rs
+++ b/solx-llvm-builder/src/platforms/mod.rs
@@ -1,0 +1,45 @@
+//!
+//! The ZKsync LLVM builder platforms.
+//!
+
+pub mod aarch64_linux_gnu;
+pub mod aarch64_macos;
+pub mod shared;
+pub mod x86_64_linux_gnu;
+pub mod x86_64_macos;
+pub mod x86_64_windows_gnu;
+
+use std::str::FromStr;
+
+///
+/// The list of platforms used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Platform {
+    /// The EVM back end developed by Matter Labs.
+    EVM,
+    /// The EraVM back end developed by Matter Labs.
+    /// TODO: remove after the migration
+    EraVM,
+}
+
+impl FromStr for Platform {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "EVM" => Ok(Self::EVM),
+            "EraVM" => Ok(Self::EraVM),
+            value => Err(format!("Unsupported platform: `{value}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::EVM => write!(f, "EVM"),
+            Self::EraVM => write!(f, "EraVM"),
+        }
+    }
+}

--- a/solx-llvm-builder/src/platforms/shared.rs
+++ b/solx-llvm-builder/src/platforms/shared.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::ccache_variant::CcacheVariant;
+use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 /// The build options shared by all platforms.
@@ -93,6 +94,24 @@ pub fn shared_build_opts_valgrind(enabled: bool, valgrind_options: Vec<String>) 
         .join(" ");
 
     vec![format!("-DLLVM_LIT_ARGS='-sv --vg --vg-leak {vg_args}'")]
+}
+
+///
+/// The LLVM targets build options shared by all platforms.
+///
+pub fn shared_build_opts_targets() -> Vec<String> {
+    vec![
+        "-DLLVM_TARGETS_TO_BUILD=''".to_owned(),
+        format!(
+            "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+            [Platform::EVM, Platform::EraVM]
+                .into_iter()
+                .map(|platform| platform.to_string())
+                .collect::<Vec<String>>()
+                .join(";")
+        ),
+        format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM),
+    ]
 }
 
 ///

--- a/solx-llvm-builder/src/platforms/shared.rs
+++ b/solx-llvm-builder/src/platforms/shared.rs
@@ -1,0 +1,165 @@
+//!
+//! The shared options for building various platforms.
+//!
+
+use crate::ccache_variant::CcacheVariant;
+use crate::sanitizer::Sanitizer;
+
+/// The build options shared by all platforms.
+pub const SHARED_BUILD_OPTS: [&str; 22] = [
+    "-DPACKAGE_VENDOR='Matter Labs'",
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
+    "-DLLVM_BUILD_DOCS='Off'",
+    "-DLLVM_BUILD_RUNTIME='Off'",
+    "-DLLVM_BUILD_RUNTIMES='Off'",
+    "-DLLVM_INCLUDE_DOCS='Off'",
+    "-DLLVM_INCLUDE_BENCHMARKS='Off'",
+    "-DLLVM_INCLUDE_EXAMPLES='Off'",
+    "-DLLVM_INCLUDE_RUNTIMES='Off'",
+    "-DLLVM_ENABLE_DOXYGEN='Off'",
+    "-DLLVM_ENABLE_SPHINX='Off'",
+    "-DLLVM_ENABLE_OCAMLDOC='Off'",
+    "-DLLVM_ENABLE_ZLIB='Off'",
+    "-DLLVM_ENABLE_ZSTD='Off'",
+    "-DLLVM_ENABLE_LIBXML2='Off'",
+    "-DLLVM_ENABLE_BINDINGS='Off'",
+    "-DLLVM_ENABLE_LIBEDIT='Off'",
+    "-DLLVM_ENABLE_LIBPFM='Off'",
+    "-DLLVM_OPTIMIZED_TABLEGEN='Off'",
+    "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
+    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from $PATH, not from registry
+    "-DBUG_REPORT_URL='https://github.com/matter-labs/era-compiler-llvm/issues/'",
+];
+
+///
+/// The shared build options to treat warnings as errors.
+///
+/// Disabled on Windows due to the following upstream issue with MSYS2 with mingw-w64:
+/// ProgramTest.cpp:23:15: error: '__p__environ' redeclared without 'dllimport' attribute
+///
+pub fn shared_build_opts_werror() -> Vec<String> {
+    vec![format!(
+        "-DLLVM_ENABLE_WERROR='{}'",
+        if cfg!(target_os = "windows") {
+            "Off"
+        } else {
+            "On"
+        },
+    )]
+}
+
+///
+/// The build options to enable assertions.
+///
+pub fn shared_build_opts_assertions(enabled: bool) -> Vec<String> {
+    vec![format!(
+        "-DLLVM_ENABLE_ASSERTIONS='{}'",
+        if enabled { "On" } else { "Off" },
+    )]
+}
+
+///
+/// The build options to build with RTTI support.
+///
+pub fn shared_build_opts_rtti(enabled: bool) -> Vec<String> {
+    vec![format!(
+        "-DLLVM_ENABLE_RTTI='{}'",
+        if enabled { "On" } else { "Off" },
+    )]
+}
+
+///
+/// The build options to enable sanitizers.
+///
+pub fn shared_build_opts_sanitizers(sanitizer: Option<Sanitizer>) -> Vec<String> {
+    match sanitizer {
+        Some(sanitizer) => vec![format!("-DLLVM_USE_SANITIZER='{sanitizer}'")],
+        None => vec![],
+    }
+}
+
+///
+/// The build options to enable Valgrind for LLVM regression tests.
+///
+pub fn shared_build_opts_valgrind(enabled: bool, valgrind_options: Vec<String>) -> Vec<String> {
+    if !enabled {
+        return vec![];
+    }
+
+    let vg_args = valgrind_options
+        .iter()
+        .map(|opt| format!("--vg-arg='{opt}'"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    vec![format!("-DLLVM_LIT_ARGS='-sv --vg --vg-leak {vg_args}'")]
+}
+
+///
+/// The LLVM tests build options shared by all platforms.
+///
+pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
+    vec![
+        format!(
+            "-DLLVM_BUILD_UTILS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_BUILD_TESTS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_INCLUDE_UTILS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_INCLUDE_TESTS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+    ]
+}
+
+///
+/// The code coverage build options shared by all platforms.
+///
+pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
+    vec![format!(
+        "-DLLVM_BUILD_INSTRUMENTED_COVERAGE='{}'",
+        if enabled { "On" } else { "Off" },
+    )]
+}
+
+///
+/// Use of compiler cache (ccache) to speed up the build process.
+///
+pub fn shared_build_opts_ccache(ccache_variant: Option<CcacheVariant>) -> Vec<String> {
+    match ccache_variant {
+        Some(ccache_variant) => vec![
+            format!(
+                "-DCMAKE_C_COMPILER_LAUNCHER='{}'",
+                ccache_variant.to_string()
+            ),
+            format!(
+                "-DCMAKE_CXX_COMPILER_LAUNCHER='{}'",
+                ccache_variant.to_string()
+            ),
+        ],
+        None => vec![],
+    }
+}
+
+///
+/// Ignore duplicate libraries warnings for MacOS with XCode>=15.
+///
+pub fn macos_build_opts_ignore_dupicate_libs_warnings() -> Vec<String> {
+    let xcode_version =
+        crate::utils::get_xcode_version().unwrap_or(crate::utils::XCODE_MIN_VERSION);
+    if xcode_version >= crate::utils::XCODE_VERSION_15 {
+        vec![
+            "-DCMAKE_EXE_LINKER_FLAGS='-Wl,-no_warn_duplicate_libraries'".to_owned(),
+            "-DCMAKE_SHARED_LINKER_FLAGS='-Wl,-no_warn_duplicate_libraries'".to_owned(),
+        ]
+    } else {
+        vec![]
+    }
+}

--- a/solx-llvm-builder/src/platforms/x86_64_linux_gnu.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_linux_gnu.rs
@@ -1,0 +1,109 @@
+//!
+//! The ZKsync LLVM amd64 `linux-gnu` builder.
+//!
+
+use std::collections::HashSet;
+use std::process::Command;
+
+use crate::build_type::BuildType;
+use crate::ccache_variant::CcacheVariant;
+use crate::llvm_path::LLVMPath;
+use crate::llvm_project::LLVMProject;
+use crate::platforms::Platform;
+use crate::sanitizer::Sanitizer;
+
+///
+/// The building sequence.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
+    valgrind_options: Vec<String>,
+) -> anyhow::Result<()> {
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
+
+    let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
+    let llvm_build_final = LLVMPath::llvm_build_final()?;
+    let llvm_target_final = LLVMPath::llvm_target_final()?;
+
+    crate::utils::command(
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                format!(
+                    "-DLLVM_ENABLE_PROJECTS='{}'",
+                    llvm_projects
+                        .into_iter()
+                        .map(|project| project.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                "-DLLVM_USE_LINKER='lld'",
+                "-DLLVM_TARGETS_TO_BUILD=''",
+                format!(
+                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+                    [Platform::EVM, Platform::EraVM]
+                        .into_iter()
+                        .map(|platform| platform.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
+            ])
+            .args(crate::platforms::shared::shared_build_opts_tests(
+                enable_tests,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_coverage(
+                enable_coverage,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_ccache(
+                ccache_variant,
+            ))
+            .args(crate::platforms::shared::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared::shared_build_opts_werror())
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                enable_assertions,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_rtti(
+                enable_rtti,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_sanitizers(
+                sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
+                valgrind_options,
+            )),
+        "LLVM building cmake",
+    )?;
+    crate::utils::ninja(llvm_build_final.as_ref())?;
+    Ok(())
+}

--- a/solx-llvm-builder/src/platforms/x86_64_linux_gnu.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_linux_gnu.rs
@@ -9,7 +9,6 @@ use crate::build_type::BuildType;
 use crate::ccache_variant::CcacheVariant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
-use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 ///
@@ -65,18 +64,8 @@ pub fn build(
                 )
                 .as_str(),
                 "-DLLVM_USE_LINKER='lld'",
-                "-DLLVM_TARGETS_TO_BUILD=''",
-                format!(
-                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
-                    [Platform::EVM, Platform::EraVM]
-                        .into_iter()
-                        .map(|platform| platform.to_string())
-                        .collect::<Vec<String>>()
-                        .join(";")
-                )
-                .as_str(),
-                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
             ])
+            .args(crate::platforms::shared::shared_build_opts_targets())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-llvm-builder/src/platforms/x86_64_macos.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_macos.rs
@@ -1,0 +1,101 @@
+//!
+//! The ZKsync LLVM amd64 `macos` builder.
+//!
+
+use std::collections::HashSet;
+use std::process::Command;
+
+use crate::build_type::BuildType;
+use crate::ccache_variant::CcacheVariant;
+use crate::llvm_path::LLVMPath;
+use crate::llvm_project::LLVMProject;
+use crate::platforms::Platform;
+use crate::sanitizer::Sanitizer;
+
+///
+/// The building sequence.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<Sanitizer>,
+) -> anyhow::Result<()> {
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("ninja")?;
+
+    let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
+    let llvm_build_final = LLVMPath::llvm_build_final()?;
+    let llvm_target_final = LLVMPath::llvm_target_final()?;
+
+    crate::utils::command(
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                format!(
+                    "-DLLVM_ENABLE_PROJECTS='{}'",
+                    llvm_projects
+                        .into_iter()
+                        .map(|project| project.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
+                "-DLLVM_TARGETS_TO_BUILD=''",
+                format!(
+                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+                    [Platform::EVM, Platform::EraVM]
+                        .into_iter()
+                        .map(|platform| platform.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
+            ])
+            .args(crate::platforms::shared::shared_build_opts_tests(
+                enable_tests,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_coverage(
+                enable_coverage,
+            ))
+            .args(crate::platforms::shared::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared::shared_build_opts_werror())
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_ccache(
+                ccache_variant,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                enable_assertions,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_rtti(
+                enable_rtti,
+            ))
+            .args(crate::platforms::shared::macos_build_opts_ignore_dupicate_libs_warnings())
+            .args(crate::platforms::shared::shared_build_opts_sanitizers(
+                sanitizer,
+            )),
+        "LLVM building cmake",
+    )?;
+
+    crate::utils::ninja(llvm_build_final.as_ref())?;
+
+    Ok(())
+}

--- a/solx-llvm-builder/src/platforms/x86_64_macos.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_macos.rs
@@ -9,7 +9,6 @@ use crate::build_type::BuildType;
 use crate::ccache_variant::CcacheVariant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
-use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 ///
@@ -58,18 +57,8 @@ pub fn build(
                 )
                 .as_str(),
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-                "-DLLVM_TARGETS_TO_BUILD=''",
-                format!(
-                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
-                    [Platform::EVM, Platform::EraVM]
-                        .into_iter()
-                        .map(|platform| platform.to_string())
-                        .collect::<Vec<String>>()
-                        .join(";")
-                )
-                .as_str(),
-                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
             ])
+            .args(crate::platforms::shared::shared_build_opts_targets())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-llvm-builder/src/platforms/x86_64_windows_gnu.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_windows_gnu.rs
@@ -10,7 +10,6 @@ use crate::build_type::BuildType;
 use crate::ccache_variant::CcacheVariant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
-use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
 
 ///
@@ -67,18 +66,8 @@ pub fn build(
                 )
                 .as_str(),
                 "-DLLVM_USE_LINKER='lld'",
-                "-DLLVM_TARGETS_TO_BUILD=''",
-                format!(
-                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
-                    [Platform::EVM, Platform::EraVM]
-                        .into_iter()
-                        .map(|platform| platform.to_string())
-                        .collect::<Vec<String>>()
-                        .join(";")
-                )
-                .as_str(),
-                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
             ])
+            .args(crate::platforms::shared::shared_build_opts_targets())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-llvm-builder/src/platforms/x86_64_windows_gnu.rs
+++ b/solx-llvm-builder/src/platforms/x86_64_windows_gnu.rs
@@ -1,0 +1,123 @@
+//!
+//! The ZKsync LLVM amd64 `windows-gnu` builder.
+//!
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::build_type::BuildType;
+use crate::ccache_variant::CcacheVariant;
+use crate::llvm_path::LLVMPath;
+use crate::llvm_project::LLVMProject;
+use crate::platforms::Platform;
+use crate::sanitizer::Sanitizer;
+
+///
+/// The building sequence.
+///
+pub fn build(
+    build_type: BuildType,
+    llvm_projects: HashSet<LLVMProject>,
+    enable_rtti: bool,
+    enable_tests: bool,
+    enable_coverage: bool,
+    extra_args: Vec<String>,
+    ccache_variant: Option<CcacheVariant>,
+    enable_assertions: bool,
+    sanitizer: Option<Sanitizer>,
+) -> anyhow::Result<()> {
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
+
+    let llvm_module_llvm =
+        LLVMPath::llvm_module_llvm().and_then(crate::utils::path_windows_to_unix)?;
+    let llvm_build_final =
+        LLVMPath::llvm_build_final().and_then(crate::utils::path_windows_to_unix)?;
+    let llvm_target_final =
+        LLVMPath::llvm_target_final().and_then(crate::utils::path_windows_to_unix)?;
+
+    crate::utils::command(
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                format!(
+                    "-DLLVM_ENABLE_PROJECTS='{}'",
+                    llvm_projects
+                        .into_iter()
+                        .map(|project| project.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                "-DLLVM_USE_LINKER='lld'",
+                "-DLLVM_TARGETS_TO_BUILD=''",
+                format!(
+                    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='{}'",
+                    [Platform::EVM, Platform::EraVM]
+                        .into_iter()
+                        .map(|platform| platform.to_string())
+                        .collect::<Vec<String>>()
+                        .join(";")
+                )
+                .as_str(),
+                format!("-DLLVM_DEFAULT_TARGET_TRIPLE='{}'", Platform::EVM).as_str(),
+            ])
+            .args(crate::platforms::shared::shared_build_opts_tests(
+                enable_tests,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_coverage(
+                enable_coverage,
+            ))
+            .args(crate::platforms::shared::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared::shared_build_opts_werror())
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_ccache(
+                ccache_variant,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                enable_assertions,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_rtti(
+                enable_rtti,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_sanitizers(
+                sanitizer,
+            )),
+        "LLVM building cmake",
+    )?;
+
+    crate::utils::ninja(llvm_build_final.as_ref())?;
+
+    let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
+        Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
+        Err(error) => anyhow::bail!(
+            "The `LIBSTDCPP_SOURCE_PATH` must be set to the path to the libstdc++.a static library: {error}"
+        ),
+    };
+    let mut libstdcpp_destination_path = llvm_target_final;
+    libstdcpp_destination_path.push("./lib/libstdc++.a");
+    fs_extra::file::copy(
+        crate::utils::path_windows_to_unix(libstdcpp_source_path)?,
+        crate::utils::path_windows_to_unix(libstdcpp_destination_path)?,
+        &fs_extra::file::CopyOptions::default(),
+    )?;
+
+    Ok(())
+}

--- a/solx-llvm-builder/src/sanitizer.rs
+++ b/solx-llvm-builder/src/sanitizer.rs
@@ -1,0 +1,54 @@
+//!
+//! LLVM sanitizers.
+//!
+
+///
+/// LLVM sanitizers.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Sanitizer {
+    /// The address sanitizer.
+    Address,
+    /// The memory sanitizer.
+    Memory,
+    /// The memory with origins sanitizer.
+    MemoryWithOrigins,
+    /// The undefined behavior sanitizer
+    Undefined,
+    /// The thread sanitizer.
+    Thread,
+    /// The data flow sanitizer.
+    DataFlow,
+    /// Combine address and undefined behavior sanitizer.
+    AddressUndefined,
+}
+
+impl std::str::FromStr for Sanitizer {
+    type Err = String;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_str() {
+            "address" => Ok(Self::Address),
+            "memory" => Ok(Self::Memory),
+            "memorywithorigins" => Ok(Self::MemoryWithOrigins),
+            "undefined" => Ok(Self::Undefined),
+            "thread" => Ok(Self::Thread),
+            "dataflow" => Ok(Self::DataFlow),
+            "address;undefined" => Ok(Self::AddressUndefined),
+            value => Err(format!("Unsupported sanitizer: `{value}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for Sanitizer {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Address => write!(f, "Address"),
+            Self::Memory => write!(f, "Memory"),
+            Self::MemoryWithOrigins => write!(f, "MemoryWithOrigins"),
+            Self::Undefined => write!(f, "Undefined"),
+            Self::Thread => write!(f, "Thread"),
+            Self::DataFlow => write!(f, "DataFlow"),
+            Self::AddressUndefined => write!(f, "Address;Undefined"),
+        }
+    }
+}

--- a/solx-llvm-builder/src/solx_llvm_builder/arguments.rs
+++ b/solx-llvm-builder/src/solx_llvm_builder/arguments.rs
@@ -1,0 +1,61 @@
+//!
+//! The ZKsync LLVM builder arguments.
+//!
+
+use clap::Parser;
+
+///
+/// The ZKsync LLVM builder arguments.
+///
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+pub struct Arguments {
+    /// Enables verbose output, e.g. to inspect extra flags.
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// LLVM build type (`Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`).
+    #[arg(long, default_value_t = solx_llvm_builder::BuildType::Release)]
+    pub build_type: solx_llvm_builder::BuildType,
+
+    /// LLVM projects to build LLVM with.
+    #[arg(long)]
+    pub llvm_projects: Vec<solx_llvm_builder::LLVMProject>,
+
+    /// Whether to build LLVM with run-time type information (RTTI) enabled.
+    #[arg(long)]
+    pub enable_rtti: bool,
+
+    /// Whether to build the LLVM tests.
+    #[arg(long)]
+    pub enable_tests: bool,
+
+    /// Whether to build LLVM for source-based code coverage.
+    #[arg(long)]
+    pub enable_coverage: bool,
+
+    /// Extra arguments to pass to CMake.  
+    /// A leading backslash will be unescaped.
+    #[arg(long, num_args = 1..)]
+    pub extra_args: Vec<String>,
+
+    /// Whether to use compiler cache (ccache) to speed-up builds.
+    #[arg(long)]
+    pub ccache_variant: Option<solx_llvm_builder::CcacheVariant>,
+
+    /// Whether to build with assertions enabled or not.
+    #[arg(long)]
+    pub enable_assertions: bool,
+
+    /// Build LLVM with sanitizer enabled (`Address`, `Memory`, `MemoryWithOrigins`, `Undefined`, `Thread`, `DataFlow`, or `Address;Undefined`).
+    #[arg(long)]
+    pub sanitizer: Option<solx_llvm_builder::Sanitizer>,
+
+    /// Whether to run LLVM unit tests under valgrind or not.
+    #[arg(long)]
+    pub enable_valgrind: bool,
+
+    /// Additional valgrind options to pass to the valgrind command.
+    #[arg(long)]
+    pub valgrind_options: Vec<String>,
+}

--- a/solx-llvm-builder/src/solx_llvm_builder/main.rs
+++ b/solx-llvm-builder/src/solx_llvm_builder/main.rs
@@ -1,0 +1,78 @@
+//!
+//! The ZKsync LLVM builder.
+//!
+
+pub(crate) mod arguments;
+
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use clap::Parser;
+
+use self::arguments::Arguments;
+
+/// The default path to the LLVM lock file.
+pub const LLVM_LOCK_DEFAULT_PATH: &str = "LLVM.lock";
+
+///
+/// The entry.
+///
+fn main() {
+    match main_inner() {
+        Ok(()) => std::process::exit(0),
+        Err(error) => {
+            eprintln!("Error: {error:?}");
+            std::process::exit(1)
+        }
+    }
+}
+
+///
+/// The entry result wrapper.
+///
+fn main_inner() -> anyhow::Result<()> {
+    let arguments = Arguments::parse();
+
+    let extra_args_unescaped: Vec<String> = arguments
+        .extra_args
+        .iter()
+        .map(|argument| {
+            argument
+                .strip_prefix('\\')
+                .unwrap_or(argument.as_str())
+                .to_owned()
+        })
+        .collect();
+    if arguments.verbose {
+        println!("\nextra_args: {:#?}", arguments.extra_args);
+        println!("\nextra_args_unescaped: {extra_args_unescaped:#?}");
+    }
+
+    if let Some(ccache_variant) = arguments.ccache_variant {
+        solx_llvm_builder::executable_exists(ccache_variant.to_string().as_str())?;
+    }
+
+    let mut projects = arguments
+        .llvm_projects
+        .into_iter()
+        .map(|project| solx_llvm_builder::LLVMProject::from_str(project.to_string().as_str()))
+        .collect::<Result<HashSet<solx_llvm_builder::LLVMProject>, String>>()
+        .map_err(|project| anyhow::anyhow!("Unknown LLVM project `{project}`"))?;
+    projects.insert(solx_llvm_builder::LLVMProject::LLD);
+
+    solx_llvm_builder::build(
+        arguments.build_type,
+        projects,
+        arguments.enable_rtti,
+        arguments.enable_tests,
+        arguments.enable_coverage,
+        extra_args_unescaped,
+        arguments.ccache_variant,
+        arguments.enable_assertions,
+        arguments.sanitizer,
+        arguments.enable_valgrind,
+        arguments.valgrind_options,
+    )?;
+
+    Ok(())
+}

--- a/solx-llvm-builder/src/utils.rs
+++ b/solx-llvm-builder/src/utils.rs
@@ -1,0 +1,115 @@
+//!
+//! The LLVM builder utilities.
+//!
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use path_slash::PathBufExt;
+
+/// The minimum required XCode version.
+pub const XCODE_MIN_VERSION: u32 = 11;
+
+/// The XCode version 15.
+pub const XCODE_VERSION_15: u32 = 15;
+
+///
+/// The subprocess runner.
+///
+/// Checks the status and prints `stderr`.
+///
+pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
+    if std::env::var("VERBOSE").is_ok() {
+        println!("\ndescription: {description}; command: {command:?}");
+    }
+    if std::env::var("DRY_RUN").is_ok() {
+        println!("\tOnly a dry run; not executing the command.");
+    } else {
+        let status = command
+            .status()
+            .map_err(|error| anyhow::anyhow!("{description} process: {error}"))?;
+        if !status.success() {
+            anyhow::bail!("{description} failed");
+        }
+    }
+    Ok(())
+}
+
+///
+/// Call ninja to build the LLVM.
+///
+pub fn ninja(build_dir: &Path) -> anyhow::Result<()> {
+    let mut ninja = Command::new("ninja");
+    ninja.args(["-C", build_dir.to_string_lossy().as_ref()]);
+    if std::env::var("DRY_RUN").is_ok() {
+        ninja.arg("-n");
+    }
+    command(ninja.arg("install"), "Running ninja install")?;
+    Ok(())
+}
+
+///
+/// Create an absolute path, appending it to the current working directory.
+///
+pub fn absolute_path<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
+    let mut full_path = std::env::current_dir()?;
+    full_path.push(path);
+    Ok(full_path)
+}
+
+///
+/// Converts a Windows path into a Unix path.
+///
+pub fn path_windows_to_unix<P: AsRef<Path> + PathBufExt>(path: P) -> anyhow::Result<PathBuf> {
+    path.to_slash()
+        .map(|pathbuf| PathBuf::from(pathbuf.to_string()))
+        .ok_or_else(|| anyhow::anyhow!("Windows-to-Unix path conversion error"))
+}
+
+///
+/// Checks if the tool exists in the system.
+///
+pub fn exists(name: &str) -> anyhow::Result<()> {
+    let status = Command::new("which")
+        .arg(name)
+        .status()
+        .map_err(|error| anyhow::anyhow!("`which {name}` process: {error}"))?;
+    if !status.success() {
+        anyhow::bail!("Tool `{name}` is missing. Please install");
+    }
+    Ok(())
+}
+
+///
+/// Identify XCode version using `pkgutil`.
+///
+pub fn get_xcode_version() -> anyhow::Result<u32> {
+    let pkgutil = Command::new("pkgutil")
+        .args(["--pkg-info", "com.apple.pkg.CLTools_Executables"])
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("`pkgutil` process: {error}"))?;
+    let grep_version = Command::new("grep")
+        .arg("version")
+        .stdin(Stdio::from(pkgutil.stdout.expect(
+            "Failed to identify XCode version - XCode or CLI tools are not installed",
+        )))
+        .output()
+        .map_err(|error| anyhow::anyhow!("`grep` process: {error}"))?;
+    let version_string = String::from_utf8(grep_version.stdout)?;
+    let version_regex = regex::Regex::new(r"version: (\d+)\..*")?;
+    let captures = version_regex
+        .captures(version_string.as_str())
+        .ok_or(anyhow::anyhow!(
+            "Failed to parse XCode version: {version_string}"
+        ))?;
+    let xcode_version: u32 = captures
+        .get(1)
+        .expect("Always has a major version")
+        .as_str()
+        .parse()
+        .map_err(|error| anyhow::anyhow!("Failed to parse XCode version: {error}"))?;
+    Ok(xcode_version)
+}


### PR DESCRIPTION
# What ❔

1. Migrates the https://github.com/matter-labs/era-compiler-llvm-builder to this repo.
2. Removes MUSL and experimental targets.
3. Fixes an issue where all targets had been built instead of just selected ones.
4. Makes tests of the original repo redundant, as the tool gonna be black-box tested while building solx in all workflows.

## Why ❔

There is an ongoing migration of all solx code to this monorepo.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
