### PR TITLE
fix: add all source directories to allow-path

### DIFF
--- a/solx-codegen-evm/src/codegen/context/function/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/function/mod.rs
@@ -294,23 +294,23 @@ impl<'ctx> IEVMLAFunction<'ctx> for Function<'ctx> {
         if evmla_data
             .blocks
             .get(key)
-            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
             .len()
             == 1
         {
             return evmla_data
                 .blocks
                 .get(key)
-                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
                 .first()
                 .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key));
+                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"));
         }
 
         evmla_data
             .blocks
             .get(key)
-            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
             .iter()
             .find(|block| {
                 block
@@ -320,6 +320,6 @@ impl<'ctx> IEVMLAFunction<'ctx> for Function<'ctx> {
                     .any(|hash| hash == stack_hash)
             })
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))
+            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))
     }
 }

--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -570,9 +570,10 @@ impl<'ctx> IContext<'ctx> for Context<'ctx> {
     }
 
     fn set_current_function(&mut self, name: &str) -> anyhow::Result<()> {
-        let function = self.functions.get(name).cloned().ok_or_else(|| {
-            anyhow::anyhow!("Failed to activate an undeclared function `{}`", name)
-        })?;
+        let function =
+            self.functions.get(name).cloned().ok_or_else(|| {
+                anyhow::anyhow!("Failed to activate an undeclared function `{name}`")
+            })?;
         self.current_function = Some(function);
         Ok(())
     }

--- a/solx-evm-assembly/src/assembly/instruction/mod.rs
+++ b/solx-evm-assembly/src/assembly/instruction/mod.rs
@@ -298,7 +298,7 @@ impl Instruction {
                     ..
                 } => {
                     *value = mapping.get(value.as_str()).cloned().ok_or_else(|| {
-                        anyhow::anyhow!("Contract alias `{}` data not found", value)
+                        anyhow::anyhow!("Contract alias `{value}` data not found")
                     })?;
                 }
                 Instruction {
@@ -311,7 +311,7 @@ impl Instruction {
                     key_extended.push_str(value.as_str());
 
                     *value = mapping.get(key_extended.as_str()).cloned().ok_or_else(|| {
-                        anyhow::anyhow!("Data chunk alias `{}` data not found", key_extended)
+                        anyhow::anyhow!("Data chunk alias `{key_extended}` data not found")
                     })?;
                 }
                 _ => {}

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -1275,7 +1275,7 @@ impl solx_codegen_evm::WriteLLVM for Function {
                 .blocks
                 .get(&key)
                 .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {}", key))?
+                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
                 .into_iter()
                 .map(|block| block.inner())
                 .zip(blocks)

--- a/solx/src/lib.rs
+++ b/solx/src/lib.rs
@@ -173,7 +173,7 @@ pub fn standard_output_evm(
         use_import_callback,
         base_path.as_deref(),
         include_paths.as_slice(),
-        allow_paths.as_deref(),
+        allow_paths,
     )?;
     run_solc_standard_json.borrow_mut().finish();
     solc_output.take_and_write_warnings();
@@ -283,7 +283,7 @@ pub fn standard_json_evm(
                 use_import_callback,
                 base_path.as_deref(),
                 include_paths.as_slice(),
-                allow_paths.as_deref(),
+                allow_paths,
             )?;
             run_solc_standard_json.borrow_mut().finish();
             if solc_output.has_errors() {

--- a/solx/src/yul/parser/statement/expression/function_call.rs
+++ b/solx/src/yul/parser/statement/expression/function_call.rs
@@ -36,9 +36,9 @@ impl FunctionCall {
                     values.push(value);
                 }
                 values.reverse();
-                let function = context.get_function(name.as_str()).ok_or_else(|| {
-                    anyhow::anyhow!("{} Undeclared function `{}`", location, name)
-                })?;
+                let function = context
+                    .get_function(name.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("{location} Undeclared function `{name}`"))?;
 
                 let expected_arguments_count =
                     function.borrow().declaration().value.count_params() as usize;
@@ -633,9 +633,10 @@ impl FunctionCall {
             }
             Name::DataOffset => {
                 let mut arguments = self.pop_arguments::<1>(context)?;
-                let object_name = arguments[0].original.take().ok_or_else(|| {
-                    anyhow::anyhow!("{} `dataoffset` literal is missing", location)
-                })?;
+                let object_name = arguments[0]
+                    .original
+                    .take()
+                    .ok_or_else(|| anyhow::anyhow!("{location} `dataoffset` literal is missing"))?;
                 let object_name = object_name.split('.').next_back().expect("Always exists");
                 solx_codegen_evm::code::data_offset(context, object_name).map(Some)
             }
@@ -644,7 +645,7 @@ impl FunctionCall {
                 let object_name = arguments[0]
                     .original
                     .take()
-                    .ok_or_else(|| anyhow::anyhow!("{} `datasize` literal is missing", location))?;
+                    .ok_or_else(|| anyhow::anyhow!("{location} `datasize` literal is missing"))?;
                 let object_name = object_name.split('.').next_back().expect("Always exists");
                 solx_codegen_evm::code::data_size(context, object_name).map(Some)
             }

--- a/solx/src/yul/parser/statement/expression/mod.rs
+++ b/solx/src/yul/parser/statement/expression/mod.rs
@@ -30,10 +30,9 @@ impl Expression {
                 .into_llvm(context)
                 .map_err(|error| {
                     anyhow::anyhow!(
-                        "{} Invalid literal `{}`: {}",
+                        "{} Invalid literal `{}`: {error}",
                         literal.location,
-                        literal.inner.to_string(),
-                        error
+                        literal.inner,
                     )
                 })
                 .map(Some),


### PR DESCRIPTION
Adds all contract directories to `--allow-paths`. It must allow imports such as `import ./<name>.sol` from absolute paths or directories outside on the working one.

Fixes https://github.com/matter-labs/solx/issues/113

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
