### PR TITLE
feat: emit a metadata tag if unsafe asm is present

### DIFF
--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -1073,6 +1073,23 @@ impl solx_codegen_evm::WriteLLVM for Element {
             InstructionName::MSIZE => solx_codegen_evm::contract_context::msize(context).map(Some),
 
             InstructionName::UNSAFEASM => {
+                if context
+                    .module()
+                    .get_global_metadata(solx_utils::UNSAFE_ASM_METADATA_KEY)
+                    .is_empty()
+                {
+                    context
+                        .module()
+                        .add_global_metadata(
+                            solx_utils::UNSAFE_ASM_METADATA_KEY,
+                            &context.llvm().metadata_node(&[context
+                                .bool_const(true)
+                                .as_basic_value_enum()
+                                .into()]),
+                        )
+                        .expect("Always valid");
+                }
+
                 if context.optimizer().settings().spill_area_size().is_some()
                     && std::env::var(solx_utils::ENV_DISABLE_UNSAFE_MEMORY_ASM_STACK_TOO_DEEP_CHECK)
                         .is_err()

--- a/solx-utils/src/lib.rs
+++ b/solx-utils/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod exit_code;
 pub(crate) mod extension;
 pub(crate) mod hash;
 pub(crate) mod libraries;
+pub(crate) mod llvm_ir;
 pub(crate) mod metadata_hash_type;
 pub(crate) mod target;
 
@@ -33,5 +34,6 @@ pub use self::hash::ipfs::IPFS as IPFSHash;
 pub use self::hash::keccak256::Keccak256 as Keccak256Hash;
 pub use self::hash::Hash;
 pub use self::libraries::Libraries;
+pub use self::llvm_ir::*;
 pub use self::metadata_hash_type::MetadataHashType;
 pub use self::target::Target;

--- a/solx-utils/src/llvm_ir.rs
+++ b/solx-utils/src/llvm_ir.rs
@@ -1,0 +1,6 @@
+//!
+//! Common LLVM IR strings.
+//!
+
+/// Unsafe assembly marker metadata key.
+pub const UNSAFE_ASM_METADATA_KEY: &str = "evm.hasunsafeasm";


### PR DESCRIPTION
# What ❔

Emits a metadata tag if unsafe asm is present in the translation unit.

Resolves https://github.com/matter-labs/era-compiler-llvm/issues/922

## Why ❔

It helps LLVM to know which optimization passes are safe to run.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
