### PR TITLE
fix: the order of benchmark data from solx-tester

### DIFF
--- a/solx-benchmark-converter/src/output/xlsx/mod.rs
+++ b/solx-benchmark-converter/src/output/xlsx/mod.rs
@@ -213,7 +213,7 @@ impl TryFrom<(Benchmark, Source)> for Xlsx {
 
         let comparison_mapping = match source {
             Source::Tooling => vec![(6, 4), (7, 5), (6, 2), (7, 3), (6, 0), (7, 1)],
-            Source::SolxTester => vec![(6, 2), (7, 3), (4, 0), (5, 1)],
+            Source::SolxTester => vec![(2, 6), (3, 7), (0, 4), (1, 5)],
         };
 
         for (index, (toolchain_id_1, toolchain_id_2)) in comparison_mapping.into_iter().enumerate()


### PR DESCRIPTION
# What ❔

Makes all Excel reports similar in terms of how they report regressions and improvements:
- positive %% are regressions
- negative %% are improvements

## Why ❔

It has been different for tooling and solx-tester reports.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
