### PR TITLE
chore: update repository reference to NomicFoundation/solx

### DIFF
--- a/install-solx
+++ b/install-solx
@@ -13,7 +13,7 @@ oo     .d8P 888   888  888   .o8"'88b
 EOF
 
 # Default values
-REPO="matter-labs/solx"
+REPO="NomicFoundation/solx"
 DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
 BINARY_NAME="solx"
 


### PR DESCRIPTION
The PR updates the `REPO` variable in the install script to reflect recent repository changes that were preventing the install script from working. The script was requesting the latest version on `matter-labs/solx` while the repo was moved to `NomicFoundation/solx`
