### PR TITLE
ci: add merge_group trigger to required status check workflows

### DIFF
--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -3,6 +3,7 @@ name: Sanitizer
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -3,6 +3,7 @@ name: Slang Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ name: Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Enable merge queue support by triggering the Tests, Sanitizer, and Slang Tests workflows on merge_group events. Without this, the required PR Checks would never run in the merge queue, causing it to stall.

Label-gated workflows (Sanitizer, Slang) naturally skip their tests in merge queue context since the label-check condition references pull_request labels that don't exist for merge_group events (which is what is intended).