### PR TITLE
ci: free disk space on macOS runners to fix flaky builds

### DIFF
--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Clean release artifacts before debug build
       if: inputs.sanitizer == ''
-      shell: bash
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
         echo "Before release cleanup:" && df -h .
         rm -rf target/release

--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -83,6 +83,14 @@ runs:
         cargo2junit < release-results.json > "release-${{ inputs.results-xml }}" || true
         if [ -n "${CARGO_EXIT}" ]; then exit "${CARGO_EXIT}"; fi
 
+    - name: Clean release artifacts before debug build
+      if: inputs.sanitizer == ''
+      shell: bash
+      run: |
+        echo "Before release cleanup:" && df -h .
+        rm -rf target/release
+        echo "After release cleanup:" && df -h .
+
     - name: Install sanitizer components
       if: inputs.sanitizer != '' && runner.os != 'Windows'
       uses: ./.github/actions/setup-rust

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,6 +134,20 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/prepare-msys
 
+      - name: Free disk space (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "Before macOS cleanup:" && df -h .
+          # Remove simulator runtimes, extra Xcode versions, Android SDK, tool cache
+          xcrun simctl delete all 2>/dev/null || true
+          sudo rm -rf \
+            /Library/Developer/CoreSimulator \
+            /Applications/Xcode_*.app \
+            /usr/local/lib/android \
+            /opt/hostedtoolcache
+          echo "After macOS cleanup:" && df -h .
+
       - name: Cache cargo artifacts
         if: ${{ !matrix.image }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -160,6 +174,9 @@ jobs:
         run: |
           echo "Before cleanup:" && df -h .
           rm -rf solx-llvm target-llvm/build-final
+          # Remove solx-solidity source, keeping build/ and boost/ for tests
+          find solx-solidity -mindepth 1 -maxdepth 1 ! -name build ! -name boost -exec rm -rf {} +
+          rm -rf .git/modules
           echo "After cleanup:" && df -h .
 
       - name: Run tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -166,8 +166,11 @@ jobs:
                 echo "  skip (active): $app"
               else
                 echo "  removing: $app"
-                sudo rm -rfv "$app" || echo "  warning: failed to remove $app"
-                removed=$((removed + 1))
+                if sudo rm -rf "$app"; then
+                  removed=$((removed + 1))
+                else
+                  echo "  warning: failed to remove $app"
+                fi
               fi
             done
           fi
@@ -183,7 +186,7 @@ jobs:
             "${RUNNER_TOOL_CACHE:-/Users/runner/hostedtoolcache}"; do
             if [ -d "$dir" ]; then
               echo "  removing: $dir"
-              sudo rm -rfv "$dir" || echo "  warning: failed to remove $dir"
+              sudo rm -rf "$dir" || echo "  warning: failed to remove $dir"
             else
               echo "  not found (skipped): $dir"
             fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,13 +139,16 @@ jobs:
         shell: bash
         run: |
           echo "Before macOS cleanup:" && df -h .
-          # Remove simulator runtimes, extra Xcode versions, Android SDK, tool cache
+          # Simulator runtimes are on read-only APFS volumes; must use simctl to unmount them
+          xcrun simctl runtime delete all 2>/dev/null || true
           xcrun simctl delete all 2>/dev/null || true
+          # Remove extra Xcode versions, Android SDK, tool cache
           sudo rm -rf \
             /Library/Developer/CoreSimulator \
             /Applications/Xcode_*.app \
             /usr/local/lib/android \
-            /opt/hostedtoolcache
+            /opt/hostedtoolcache \
+            || true
           echo "After macOS cleanup:" && df -h .
 
       - name: Cache cargo artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,18 +138,52 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          echo "Before macOS cleanup:" && df -h .
-          # Simulator runtimes are on read-only APFS volumes; must use simctl to unmount them
-          xcrun simctl runtime delete all 2>/dev/null || true
-          xcrun simctl delete all 2>/dev/null || true
-          # Remove extra Xcode versions, Android SDK, tool cache
-          sudo rm -rf \
+          set -euo pipefail
+          echo "=== Before macOS cleanup ===" && df -h .
+
+          # 1. Simulator runtimes — stored on read-only APFS snapshot volumes,
+          #    so plain `rm` fails.  `simctl runtime delete all` unmounts them.
+          #    May warn on already-deleted runtimes; that is harmless.
+          echo "--- Removing simulator runtimes ---"
+          xcrun simctl runtime delete all 2>&1 || true
+          xcrun simctl delete all 2>&1 || true
+
+          # 2. Xcode — remove every versioned copy EXCEPT the one that
+          #    xcode-select points to (we need its toolchain for C/C++ builds).
+          #    Active Xcode path looks like /Applications/Xcode_16.2.app/Contents/Developer.
+          echo "--- Removing inactive Xcode versions ---"
+          ACTIVE_XCODE="$(xcode-select -p | sed 's|/Contents/Developer||')"
+          echo "Active Xcode (keeping): ${ACTIVE_XCODE}"
+          removed=0
+          for app in /Applications/Xcode_*.app; do
+            [ -d "$app" ] || continue
+            if [ "$app" = "$ACTIVE_XCODE" ]; then
+              echo "  skip (active): $app"
+            else
+              echo "  removing: $app"
+              sudo rm -rf "$app"
+              removed=$((removed + 1))
+            fi
+          done
+          echo "Removed ${removed} inactive Xcode version(s)"
+
+          # 3. Remaining large packages that this project never uses.
+          #    Each path is removed individually so a missing path doesn't
+          #    mask a real permission error on another.
+          echo "--- Removing unused SDKs and caches ---"
+          for dir in \
             /Library/Developer/CoreSimulator \
-            /Applications/Xcode_*.app \
             /usr/local/lib/android \
-            /opt/hostedtoolcache \
-            || true
-          echo "After macOS cleanup:" && df -h .
+            /opt/hostedtoolcache; do
+            if [ -d "$dir" ]; then
+              echo "  removing: $dir"
+              sudo rm -rf "$dir"
+            else
+              echo "  not found (skipped): $dir"
+            fi
+          done
+
+          echo "=== After macOS cleanup ===" && df -h .
 
       - name: Cache cargo artifacts
         if: ${{ !matrix.image }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,6 +122,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       # This step is required to checkout submodules
       # that are disabled in .gitmodules config
@@ -145,26 +146,31 @@ jobs:
           #    so plain `rm` fails.  `simctl runtime delete all` unmounts them.
           #    May warn on already-deleted runtimes; that is harmless.
           echo "--- Removing simulator runtimes ---"
-          xcrun simctl runtime delete all 2>&1 || true
           xcrun simctl delete all 2>&1 || true
+          xcrun simctl runtime delete all 2>&1 || true
 
           # 2. Xcode — remove every versioned copy EXCEPT the one that
           #    xcode-select points to (we need its toolchain for C/C++ builds).
           #    Active Xcode path looks like /Applications/Xcode_16.2.app/Contents/Developer.
           echo "--- Removing inactive Xcode versions ---"
-          ACTIVE_XCODE="$(xcode-select -p | sed 's|/Contents/Developer||')"
-          echo "Active Xcode (keeping): ${ACTIVE_XCODE}"
+          ACTIVE_XCODE="$(xcode-select -p 2>/dev/null | sed 's|/Contents/Developer/*$||' || true)"
+          ACTIVE_XCODE="${ACTIVE_XCODE%/}"
           removed=0
-          for app in /Applications/Xcode_*.app; do
-            [ -d "$app" ] || continue
-            if [ "$app" = "$ACTIVE_XCODE" ]; then
-              echo "  skip (active): $app"
-            else
-              echo "  removing: $app"
-              sudo rm -rf "$app"
-              removed=$((removed + 1))
-            fi
-          done
+          if [ -z "${ACTIVE_XCODE}" ] || [[ "${ACTIVE_XCODE}" != /Applications/Xcode*.app ]]; then
+            echo "  warning: active Xcode path '${ACTIVE_XCODE}' is not an Xcode app; skipping Xcode removal"
+          else
+            echo "Active Xcode (keeping): ${ACTIVE_XCODE}"
+            for app in /Applications/Xcode_*.app; do
+              [ -d "$app" ] || continue
+              if [ "$app" = "$ACTIVE_XCODE" ]; then
+                echo "  skip (active): $app"
+              else
+                echo "  removing: $app"
+                sudo rm -rfv "$app" || echo "  warning: failed to remove $app"
+                removed=$((removed + 1))
+              fi
+            done
+          fi
           echo "Removed ${removed} inactive Xcode version(s)"
 
           # 3. Remaining large packages that this project never uses.
@@ -174,10 +180,10 @@ jobs:
           for dir in \
             /Library/Developer/CoreSimulator \
             /usr/local/lib/android \
-            /opt/hostedtoolcache; do
+            "${RUNNER_TOOL_CACHE:-/Users/runner/hostedtoolcache}"; do
             if [ -d "$dir" ]; then
               echo "  removing: $dir"
-              sudo rm -rf "$dir"
+              sudo rm -rfv "$dir" || echo "  warning: failed to remove $dir"
             else
               echo "  not found (skipped): $dir"
             fi


### PR DESCRIPTION
The macos-15 ARM64 runner has only ~11 GB free after building LLVM and solc, which is insufficient for both release and debug test builds. This causes intermittent "No space left on device" failures.

- Remove simulator runtimes, extra Xcode versions, Android SDK, and tool cache on macOS before builds start (~10-20 GB recovered)
- Remove solx-solidity source files and .git/modules after builds, keeping only build/ and boost/ needed by tests (~2-5 GB)
- Clean target/release between release and debug test runs (~2-4 GB)