### PR TITLE
feat(slang): migrate Sol dialect emission to ODS-generated builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2541,8 +2541,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "melior"
 version = "0.26.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c38e8ea1f1bb22ebc7fe311b3adac0e9d3591e7c4d02a3b3b9c89d3e66899c"
+source = "git+https://github.com/NomicFoundation/melior?rev=62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2#62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -2551,8 +2550,7 @@ dependencies = [
 [[package]]
 name = "melior-macro"
 version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e156c0973fdaaf2930149766775d85ff451e229739562cf50b0453f08024d2a"
+source = "git+https://github.com/NomicFoundation/melior?rev=62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2#62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",

--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/NomicFoundation/inkwell",
     "https://github.com/NomicFoundation/llvm-sys.rs",
+    "https://github.com/NomicFoundation/melior",
     "https://github.com/NomicFoundation/slang",
     "https://github.com/tomusdrw/rust-web3",
 ]

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -11,17 +11,18 @@ cc = "1.2.59"
 
 [dependencies]
 anyhow.workspace = true
-melior = { version = "0.26", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==
 # MLIR_SYS_210_PREFIX), so the pointer casts between their types are ABI-
 # compatible. If these crates diverge to different LLVM builds, the
-# transmutes in context.rs become unsound. Track mlir-sys 211 availability.
+# transmutes in context.rs become unsound.
+# TODO: Track mlir-sys 211 availability.
 mlir-sys = "210.0"
 
 inkwell = { workspace = true, features = ["llvm21-1-no-llvm-linking"] }
 
-solx-utils = { path = "../solx-utils" }
+solx-utils = { path = "../solx-utils", features = ["mlir"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/solx-mlir/build.rs
+++ b/solx-mlir/build.rs
@@ -29,6 +29,21 @@ fn main() {
 
     let include_path = std::path::PathBuf::from(&prefix).join("include");
 
+    // Track Sol/Yul dialect .td files so that Cargo re-expands the
+    // `melior::dialect!` macros in `src/ods.rs` when any definition changes.
+    for td_file in &[
+        "mlir/Dialect/Sol/SolOps.td",
+        "mlir/Dialect/Sol/SolBase.td",
+        "mlir/Dialect/Sol/SolInterfaces.td",
+        "mlir/Dialect/Yul/YulOps.td",
+        "mlir/Dialect/Yul/YulBase.td",
+    ] {
+        println!(
+            "cargo:rerun-if-changed={}",
+            include_path.join(td_file).display()
+        );
+    }
+
     // Compile stub definitions for the six MLIR ExecutionEngine C API symbols
     // that melior references unconditionally. See mlir_execution_engine_stubs.c
     // for the full explanation.

--- a/solx-mlir/src/context/builder.rs
+++ b/solx-mlir/src/context/builder.rs
@@ -8,6 +8,8 @@
 
 use std::collections::HashMap;
 
+use melior::dialect::ods::scf::IfOperation as ScfIfOperation;
+use melior::dialect::ods::scf::YieldOperation as ScfYieldOperation;
 use melior::ir::Attribute;
 use melior::ir::Block;
 use melior::ir::BlockLike;
@@ -23,7 +25,6 @@ use melior::ir::attribute::FlatSymbolRefAttribute;
 use melior::ir::attribute::IntegerAttribute;
 use melior::ir::attribute::StringAttribute;
 use melior::ir::attribute::TypeAttribute;
-use melior::ir::operation::OperationBuilder;
 use melior::ir::operation::OperationLike;
 use melior::ir::r#type::FunctionType;
 use melior::ir::r#type::IntegerType;
@@ -495,8 +496,6 @@ impl<'context> Builder<'context> {
 
     /// Emits a value-producing `scf.if` with then and else regions.
     ///
-    /// Not migrated to ODS: SCF ops have no inherent properties.
-    ///
     /// Returns `(then_block, else_block)`. Each region must be terminated
     /// with `emit_scf_yield` passing a value matching the result type.
     /// The operation result is the yielded value from the taken branch.
@@ -530,12 +529,13 @@ impl<'context> Builder<'context> {
         else_region.append_block(else_block);
 
         let operation = block.append_operation(
-            OperationBuilder::new("scf.if", self.unknown_location)
-                .add_operands(&[condition])
-                .add_results(&[result_type])
-                .add_regions([then_region, else_region])
+            ScfIfOperation::builder(self.context, self.unknown_location)
+                .results(&[result_type])
+                .condition(condition)
+                .then_region(then_region)
+                .else_region(else_region)
                 .build()
-                .expect("scf.if operation is well-formed"),
+                .into(),
         );
 
         let result = operation.result(0)?.into();
@@ -554,8 +554,6 @@ impl<'context> Builder<'context> {
 
     /// Emits a `scf.yield` region terminator with a value.
     ///
-    /// Not migrated to ODS: SCF ops have no inherent properties.
-    ///
     /// # Panics
     ///
     /// Panics if the MLIR operation cannot be constructed.
@@ -565,10 +563,10 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new("scf.yield", self.unknown_location)
-                .add_operands(operands)
+            ScfYieldOperation::builder(self.context, self.unknown_location)
+                .results(operands)
                 .build()
-                .expect("scf.yield operation is well-formed"),
+                .into(),
         );
     }
 
@@ -782,8 +780,6 @@ impl<'context> Builder<'context> {
     // ==== Memory ====
 
     /// Emits a `sol.alloca` for a local variable, returning the pointer.
-    ///
-    /// Emits a `sol.alloca` for a local variable of the given element type.
     ///
     /// Returns a `!sol.ptr<{element_type}, Stack>` pointer. Use this when
     /// the declared Solidity type is known (e.g. `uint64` → `ui64`).

--- a/solx-mlir/src/context/builder.rs
+++ b/solx-mlir/src/context/builder.rs
@@ -12,7 +12,6 @@ use melior::ir::Attribute;
 use melior::ir::Block;
 use melior::ir::BlockLike;
 use melior::ir::BlockRef;
-use melior::ir::Identifier;
 use melior::ir::Location;
 use melior::ir::Region;
 use melior::ir::RegionLike;
@@ -31,6 +30,29 @@ use melior::ir::r#type::IntegerType;
 
 use crate::CmpPredicate;
 use crate::StateMutability;
+use crate::ods::sol::AddrOfOperation;
+use crate::ods::sol::AddressCastOperation;
+use crate::ods::sol::AllocaOperation;
+use crate::ods::sol::BreakOperation;
+use crate::ods::sol::CallOperation;
+use crate::ods::sol::CastOperation;
+use crate::ods::sol::CmpOperation;
+use crate::ods::sol::ConditionOperation;
+use crate::ods::sol::ConstantOperation;
+use crate::ods::sol::ContinueOperation;
+use crate::ods::sol::ContractOperation;
+use crate::ods::sol::DoWhileOperation;
+use crate::ods::sol::ForOperation;
+use crate::ods::sol::FuncOperation;
+use crate::ods::sol::IfOperation;
+use crate::ods::sol::LoadOperation;
+use crate::ods::sol::RequireOperation;
+use crate::ods::sol::ReturnOperation;
+use crate::ods::sol::RevertOperation;
+use crate::ods::sol::StateVarOperation;
+use crate::ods::sol::StoreOperation;
+use crate::ods::sol::WhileOperation;
+use crate::ods::sol::YieldOperation;
 
 /// Cached MLIR types and emission methods for building MLIR operations.
 ///
@@ -58,94 +80,6 @@ impl<'context> Builder<'context> {
     pub const SOL_ADDRESS: &'static str = "!sol.address";
     /// Sol storage pointer type key.
     pub const SOL_PTR_STORAGE: &'static str = "!sol.ptr<ui256, Storage>";
-
-    // ---- Sol dialect operation names ----
-
-    /// `sol.contract` — contract symbol table container.
-    pub const SOL_CONTRACT: &'static str = "sol.contract";
-    /// `sol.func` — function definition with selector and mutability.
-    pub const SOL_FUNC: &'static str = "sol.func";
-    /// `sol.constant` — compile-time constant.
-    pub const SOL_CONSTANT: &'static str = "sol.constant";
-    /// `sol.exp` — exponentiation.
-    pub const SOL_EXP: &'static str = "sol.exp";
-    /// `sol.return` — return from function.
-    pub const SOL_RETURN: &'static str = "sol.return";
-    /// `sol.revert` — revert execution.
-    pub const SOL_REVERT: &'static str = "sol.revert";
-    /// `sol.require` — conditional revert.
-    pub const SOL_REQUIRE: &'static str = "sol.require";
-    /// `sol.alloca` — stack allocation.
-    pub const SOL_ALLOCA: &'static str = "sol.alloca";
-    /// `sol.load` — load from pointer.
-    pub const SOL_LOAD: &'static str = "sol.load";
-    /// `sol.store` — store to pointer.
-    pub const SOL_STORE: &'static str = "sol.store";
-    /// `sol.call` — function call.
-    pub const SOL_CALL: &'static str = "sol.call";
-    /// `sol.if` — structured if/else.
-    pub const SOL_IF: &'static str = "sol.if";
-    /// `sol.add` — unchecked addition.
-    pub const SOL_ADD: &'static str = "sol.add";
-    /// `sol.sub` — unchecked subtraction.
-    pub const SOL_SUB: &'static str = "sol.sub";
-    /// `sol.mul` — unchecked multiplication.
-    pub const SOL_MUL: &'static str = "sol.mul";
-    /// `sol.cadd` — checked addition (reverts on overflow).
-    pub const SOL_CADD: &'static str = "sol.cadd";
-    /// `sol.csub` — checked subtraction (reverts on underflow).
-    pub const SOL_CSUB: &'static str = "sol.csub";
-    /// `sol.cmul` — checked multiplication (reverts on overflow).
-    pub const SOL_CMUL: &'static str = "sol.cmul";
-    /// `sol.cdiv` — checked division (reverts on `int.min / -1` overflow).
-    pub const SOL_CDIV: &'static str = "sol.cdiv";
-    /// `sol.div` — unchecked division.
-    pub const SOL_DIV: &'static str = "sol.div";
-    /// `sol.mod` — unchecked modulo.
-    pub const SOL_MOD: &'static str = "sol.mod";
-    /// `sol.cmp` — comparison.
-    pub const SOL_CMP: &'static str = "sol.cmp";
-    /// `sol.cast` — type cast.
-    pub const SOL_CAST: &'static str = "sol.cast";
-    /// `sol.address_cast` — address type cast.
-    pub const SOL_ADDRESS_CAST: &'static str = "sol.address_cast";
-    /// `sol.state_var` — state variable declaration.
-    pub const SOL_STATE_VAR: &'static str = "sol.state_var";
-    /// `sol.and` — bitwise AND.
-    pub const SOL_AND: &'static str = "sol.and";
-    /// `sol.or` — bitwise OR.
-    pub const SOL_OR: &'static str = "sol.or";
-    /// `sol.xor` — bitwise XOR.
-    pub const SOL_XOR: &'static str = "sol.xor";
-    /// `sol.shl` — shift left.
-    pub const SOL_SHL: &'static str = "sol.shl";
-    /// `sol.shr` — shift right.
-    pub const SOL_SHR: &'static str = "sol.shr";
-    /// `sol.addr_of` — address of a declared state variable.
-    pub const SOL_ADDR_OF: &'static str = "sol.addr_of";
-
-    // ---- Sol dialect EVM context operation names ----
-
-    /// `sol.caller` — `msg.sender`.
-    pub const SOL_CALLER: &'static str = "sol.caller";
-    /// `sol.origin` — `tx.origin`.
-    pub const SOL_ORIGIN: &'static str = "sol.origin";
-    /// `sol.gasprice` — `tx.gasprice`.
-    pub const SOL_GASPRICE: &'static str = "sol.gasprice";
-    /// `sol.callvalue` — `msg.value`.
-    pub const SOL_CALLVALUE: &'static str = "sol.callvalue";
-    /// `sol.timestamp` — `block.timestamp`.
-    pub const SOL_TIMESTAMP: &'static str = "sol.timestamp";
-    /// `sol.blocknumber` — `block.number`.
-    pub const SOL_BLOCKNUMBER: &'static str = "sol.blocknumber";
-    /// `sol.coinbase` — `block.coinbase`.
-    pub const SOL_COINBASE: &'static str = "sol.coinbase";
-    /// `sol.chainid` — `block.chainid`.
-    pub const SOL_CHAINID: &'static str = "sol.chainid";
-    /// `sol.basefee` — `block.basefee`.
-    pub const SOL_BASEFEE: &'static str = "sol.basefee";
-    /// `sol.gaslimit` — `block.gaslimit`.
-    pub const SOL_GASLIMIT: &'static str = "sol.gaslimit";
 
     // ---- Private constants ----
 
@@ -230,6 +164,8 @@ impl<'context> Builder<'context> {
         element_type: Type<'context>,
         location: solx_utils::DataLocation,
     ) -> Type<'context> {
+        // SAFETY: `solxCreatePointerType` returns a valid MlirType from the
+        // C++ Sol dialect. The context and element type pointers are valid.
         unsafe {
             Type::from_raw(crate::ffi::solxCreatePointerType(
                 self.context.to_raw(),
@@ -259,27 +195,23 @@ impl<'context> Builder<'context> {
         let body_block = Block::new(&[]);
         body_region.append_block(body_block);
 
-        let operation = block.append_operation(
-            OperationBuilder::new(Self::SOL_CONTRACT, self.unknown_location)
-                .add_attributes(&[
-                    (
-                        Identifier::new(self.context, "sym_name"),
-                        StringAttribute::new(self.context, name).into(),
-                    ),
-                    // SAFETY: `solxCreateContractKindAttr` returns a valid
-                    // MlirAttribute from the C++ Sol dialect.
-                    (Identifier::new(self.context, "kind"), unsafe {
-                        Attribute::from_raw(crate::ffi::solxCreateContractKindAttr(
-                            self.context.to_raw(),
-                            kind as u32,
-                        ))
-                    }),
-                ])
-                .add_regions([body_region])
-                .build()
-                .expect("sol.contract operation is well-formed"),
-        );
-        operation
+        // SAFETY: `solxCreateContractKindAttr` returns a valid MlirAttribute.
+        let kind_attribute = unsafe {
+            Attribute::from_raw(crate::ffi::solxCreateContractKindAttr(
+                self.context.to_raw(),
+                kind as u32,
+            ))
+        };
+
+        block
+            .append_operation(
+                ContractOperation::builder(self.context, self.unknown_location)
+                    .sym_name(StringAttribute::new(self.context, name))
+                    .kind(kind_attribute)
+                    .body_region(body_region)
+                    .build()
+                    .into(),
+            )
             .region(0)
             .expect("contract has one region")
             .first_block()
@@ -306,15 +238,15 @@ impl<'context> Builder<'context> {
     ) -> BlockRef<'context, 'block> {
         let function_type = FunctionType::new(self.context, parameter_types, result_types);
         let body_region = Region::new();
-        let block_argument_types: Vec<(Type<'context>, Location<'context>)> = parameter_types
-            .iter()
-            .map(|t| (*t, self.unknown_location))
-            .collect();
-        let entry_block = Block::new(&block_argument_types);
+        let entry_block = Block::new(
+            &parameter_types
+                .iter()
+                .map(|parameter_type| (*parameter_type, self.unknown_location))
+                .collect::<Vec<_>>(),
+        );
         body_region.append_block(entry_block);
 
-        // SAFETY: `solxCreateStateMutabilityAttr` returns a valid
-        // MlirAttribute from the C++ Sol dialect.
+        // SAFETY: `solxCreateStateMutabilityAttr` returns a valid MlirAttribute.
         let mutability_attribute = unsafe {
             Attribute::from_raw(crate::ffi::solxCreateStateMutabilityAttr(
                 self.context.to_raw(),
@@ -322,20 +254,11 @@ impl<'context> Builder<'context> {
             ))
         };
 
-        let mut attributes: Vec<(Identifier<'context>, Attribute<'context>)> = vec![
-            (
-                Identifier::new(self.context, "sym_name"),
-                StringAttribute::new(self.context, name).into(),
-            ),
-            (
-                Identifier::new(self.context, "function_type"),
-                TypeAttribute::new(function_type.into()).into(),
-            ),
-            (
-                Identifier::new(self.context, "state_mutability"),
-                mutability_attribute,
-            ),
-        ];
+        let mut builder = FuncOperation::builder(self.context, self.unknown_location)
+            .sym_name(StringAttribute::new(self.context, name))
+            .function_type(TypeAttribute::new(function_type.into()))
+            .state_mutability(mutability_attribute)
+            .body(body_region);
 
         if let Some(function_kind) = kind {
             // SAFETY: `solxCreateFunctionKindAttr` returns a valid MlirAttribute.
@@ -345,34 +268,21 @@ impl<'context> Builder<'context> {
                     function_kind as u32,
                 ))
             };
-            attributes.push((Identifier::new(self.context, "kind"), kind_attribute));
+            builder = builder.kind(kind_attribute);
         }
 
         if let Some(selector_value) = selector {
-            attributes.push((
-                Identifier::new(self.context, "selector"),
-                IntegerAttribute::new(
-                    IntegerType::new(self.context, Self::SELECTOR_BIT_WIDTH).into(),
-                    selector_value as i64,
-                )
-                .into(),
+            builder = builder.selector(IntegerAttribute::new(
+                IntegerType::new(self.context, Self::SELECTOR_BIT_WIDTH).into(),
+                selector_value as i64,
             ));
         }
 
         if selector.is_some() || matches!(kind, Some(crate::FunctionKind::Constructor)) {
-            attributes.push((
-                Identifier::new(self.context, "orig_fn_type"),
-                TypeAttribute::new(function_type.into()).into(),
-            ));
+            builder = builder.orig_fn_type(TypeAttribute::new(function_type.into()));
         }
 
-        let operation = block.append_operation(
-            OperationBuilder::new(Self::SOL_FUNC, self.unknown_location)
-                .add_attributes(&attributes)
-                .add_regions([body_region])
-                .build()
-                .expect("sol.func operation is well-formed"),
-        );
+        let operation = block.append_operation(builder.build().into());
         operation
             .region(0)
             .expect("func has one region")
@@ -392,21 +302,20 @@ impl<'context> Builder<'context> {
     pub fn emit_sol_constant<'block, B>(
         &self,
         value: i64,
-        ty: Type<'context>,
+        result_type: Type<'context>,
         block: &B,
     ) -> Value<'context, 'block>
     where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let attribute = IntegerAttribute::new(ty, value);
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_CONSTANT, self.unknown_location)
-                    .add_attributes(&[(Identifier::new(self.context, "value"), attribute.into())])
-                    .add_results(&[ty])
+                ConstantOperation::builder(self.context, self.unknown_location)
+                    .value(IntegerAttribute::new(result_type, value).into())
+                    .result(result_type)
                     .build()
-                    .expect("sol.constant operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.constant always produces one result")
@@ -421,16 +330,16 @@ impl<'context> Builder<'context> {
     pub fn emit_sol_constant_from_decimal_str<'block, B>(
         &self,
         value: &str,
-        ty: Type<'context>,
+        result_type: Type<'context>,
         block: &B,
     ) -> anyhow::Result<Value<'context, 'block>>
     where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let attribute = Attribute::parse(self.context, &format!("{value} : {ty}"))
-            .ok_or_else(|| anyhow::anyhow!("invalid {ty} decimal literal: {value}"))?;
-        self.emit_constant_operation(Self::SOL_CONSTANT, attribute, ty, block)
+        let attribute = Attribute::parse(self.context, &format!("{value} : {result_type}"))
+            .ok_or_else(|| anyhow::anyhow!("invalid {result_type} decimal literal: {value}"))?;
+        self.emit_constant_operation(attribute, result_type, block)
     }
 
     /// Emits a `sol.constant` of the given type from a hex string (without `0x` prefix).
@@ -441,16 +350,16 @@ impl<'context> Builder<'context> {
     pub fn emit_sol_constant_from_hex_str<'block, B>(
         &self,
         hexadecimal: &str,
-        ty: Type<'context>,
+        result_type: Type<'context>,
         block: &B,
     ) -> anyhow::Result<Value<'context, 'block>>
     where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let attribute = Attribute::parse(self.context, &format!("0x{hexadecimal} : {ty}"))
-            .ok_or_else(|| anyhow::anyhow!("invalid {ty} hex literal: 0x{hexadecimal}"))?;
-        self.emit_constant_operation(Self::SOL_CONSTANT, attribute, ty, block)
+        let attribute = Attribute::parse(self.context, &format!("0x{hexadecimal} : {result_type}"))
+            .ok_or_else(|| anyhow::anyhow!("invalid {result_type} hex literal: 0x{hexadecimal}"))?;
+        self.emit_constant_operation(attribute, result_type, block)
     }
 
     /// Emits an all-ones `sol.constant` for the given integer type.
@@ -487,13 +396,11 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new(Self::SOL_REVERT, self.unknown_location)
-                .add_attributes(&[(
-                    Identifier::new(self.context, "signature"),
-                    StringAttribute::new(self.context, "").into(),
-                )])
+            RevertOperation::builder(self.context, self.unknown_location)
+                .signature(StringAttribute::new(self.context, ""))
+                .args(&[])
                 .build()
-                .expect("sol.revert operation is well-formed"),
+                .into(),
         );
     }
 
@@ -511,14 +418,12 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new(Self::SOL_REQUIRE, self.unknown_location)
-                .add_operands(&[condition])
-                .add_attributes(&[(
-                    Identifier::new(self.context, "signature"),
-                    StringAttribute::new(self.context, "").into(),
-                )])
+            RequireOperation::builder(self.context, self.unknown_location)
+                .cond(condition)
+                .msg(StringAttribute::new(self.context, ""))
+                .args(&[])
                 .build()
-                .expect("sol.require operation is well-formed"),
+                .into(),
         );
     }
 
@@ -533,10 +438,10 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new(Self::SOL_RETURN, self.unknown_location)
-                .add_operands(operands)
+            ReturnOperation::builder(self.context, self.unknown_location)
+                .operands(operands)
                 .build()
-                .expect("sol.return operation is well-formed"),
+                .into(),
         );
     }
 
@@ -567,11 +472,12 @@ impl<'context> Builder<'context> {
         else_region.append_block(else_block);
 
         let operation = block.append_operation(
-            OperationBuilder::new("sol.if", self.unknown_location)
-                .add_operands(&[condition])
-                .add_regions([then_region, else_region])
+            IfOperation::builder(self.context, self.unknown_location)
+                .cond(condition)
+                .then_region(then_region)
+                .else_region(else_region)
                 .build()
-                .expect("sol.if operation is well-formed"),
+                .into(),
         );
 
         let then_ref = operation
@@ -588,6 +494,8 @@ impl<'context> Builder<'context> {
     }
 
     /// Emits a value-producing `scf.if` with then and else regions.
+    ///
+    /// Not migrated to ODS: SCF ops have no inherent properties.
     ///
     /// Returns `(then_block, else_block)`. Each region must be terminated
     /// with `emit_scf_yield` passing a value matching the result type.
@@ -646,6 +554,8 @@ impl<'context> Builder<'context> {
 
     /// Emits a `scf.yield` region terminator with a value.
     ///
+    /// Not migrated to ODS: SCF ops have no inherent properties.
+    ///
     /// # Panics
     ///
     /// Panics if the MLIR operation cannot be constructed.
@@ -683,10 +593,11 @@ impl<'context> Builder<'context> {
         body_region.append_block(body_block);
 
         let operation = block.append_operation(
-            OperationBuilder::new("sol.while", self.unknown_location)
-                .add_regions([cond_region, body_region])
+            WhileOperation::builder(self.context, self.unknown_location)
+                .cond(cond_region)
+                .body(body_region)
                 .build()
-                .expect("sol.while operation is well-formed"),
+                .into(),
         );
 
         let cond_ref = operation
@@ -723,10 +634,11 @@ impl<'context> Builder<'context> {
         cond_region.append_block(cond_block);
 
         let operation = block.append_operation(
-            OperationBuilder::new("sol.do", self.unknown_location)
-                .add_regions([body_region, cond_region])
+            DoWhileOperation::builder(self.context, self.unknown_location)
+                .body(body_region)
+                .cond(cond_region)
                 .build()
-                .expect("sol.do operation is well-formed"),
+                .into(),
         );
 
         let body_ref = operation
@@ -771,10 +683,12 @@ impl<'context> Builder<'context> {
         step_region.append_block(step_block);
 
         let operation = block.append_operation(
-            OperationBuilder::new("sol.for", self.unknown_location)
-                .add_regions([cond_region, body_region, step_region])
+            ForOperation::builder(self.context, self.unknown_location)
+                .cond(cond_region)
+                .body(body_region)
+                .step(step_region)
                 .build()
-                .expect("sol.for operation is well-formed"),
+                .into(),
         );
 
         let cond_ref = operation
@@ -806,9 +720,10 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new("sol.yield", self.unknown_location)
+            YieldOperation::builder(self.context, self.unknown_location)
+                .ins(&[])
                 .build()
-                .expect("sol.yield operation is well-formed"),
+                .into(),
         );
     }
 
@@ -823,10 +738,10 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new("sol.condition", self.unknown_location)
-                .add_operands(&[condition])
+            ConditionOperation::builder(self.context, self.unknown_location)
+                .condition(condition)
                 .build()
-                .expect("sol.condition operation is well-formed"),
+                .into(),
         );
     }
 
@@ -841,9 +756,9 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new("sol.break", self.unknown_location)
+            BreakOperation::builder(self.context, self.unknown_location)
                 .build()
-                .expect("sol.break operation is well-formed"),
+                .into(),
         );
     }
 
@@ -858,9 +773,9 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new("sol.continue", self.unknown_location)
+            ContinueOperation::builder(self.context, self.unknown_location)
                 .build()
-                .expect("sol.continue operation is well-formed"),
+                .into(),
         );
     }
 
@@ -889,14 +804,11 @@ impl<'context> Builder<'context> {
         let ptr_type = self.create_pointer_type(element_type, solx_utils::DataLocation::Stack);
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_ALLOCA, self.unknown_location)
-                    .add_attributes(&[(
-                        Identifier::new(self.context, "alloc_type"),
-                        TypeAttribute::new(element_type).into(),
-                    )])
-                    .add_results(&[ptr_type])
+                AllocaOperation::builder(self.context, self.unknown_location)
+                    .alloc_type(TypeAttribute::new(element_type))
+                    .addr(ptr_type)
                     .build()
-                    .expect("sol.alloca operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.alloca always produces one result")
@@ -922,11 +834,11 @@ impl<'context> Builder<'context> {
     {
         Ok(block
             .append_operation(
-                OperationBuilder::new(Self::SOL_LOAD, self.unknown_location)
-                    .add_operands(&[pointer])
-                    .add_results(&[result_type])
+                LoadOperation::builder(self.context, self.unknown_location)
+                    .addr(pointer)
+                    .out(result_type)
                     .build()
-                    .expect("sol.load operation is well-formed"),
+                    .into(),
             )
             .result(0)?
             .into())
@@ -948,10 +860,11 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         block.append_operation(
-            OperationBuilder::new(Self::SOL_STORE, self.unknown_location)
-                .add_operands(&[value, pointer])
+            StoreOperation::builder(self.context, self.unknown_location)
+                .val(value)
+                .addr(pointer)
                 .build()
-                .expect("sol.store operation is well-formed"),
+                .into(),
         );
     }
 
@@ -978,15 +891,12 @@ impl<'context> Builder<'context> {
         'context: 'block,
     {
         let operation = block.append_operation(
-            OperationBuilder::new(Self::SOL_CALL, self.unknown_location)
-                .add_operands(operands)
-                .add_attributes(&[(
-                    Identifier::new(self.context, "callee"),
-                    FlatSymbolRefAttribute::new(self.context, callee).into(),
-                )])
-                .add_results(result_types)
+            CallOperation::builder(self.context, self.unknown_location)
+                .callee(FlatSymbolRefAttribute::new(self.context, callee))
+                .operands(operands)
+                .results(result_types)
                 .build()
-                .expect("sol.call operation is well-formed"),
+                .into(),
         );
         if result_types.is_empty() {
             Ok(None)
@@ -1014,22 +924,19 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
+        let predicate_attribute = IntegerAttribute::new(
+            IntegerType::new(self.context, solx_utils::BIT_LENGTH_X64 as u32).into(),
+            predicate as i64,
+        );
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_CMP, self.unknown_location)
-                    .add_operands(&[lhs, rhs])
-                    .add_attributes(&[(
-                        Identifier::new(self.context, "predicate"),
-                        IntegerAttribute::new(
-                            IntegerType::new(self.context, solx_utils::BIT_LENGTH_X64 as u32)
-                                .into(),
-                            predicate as i64,
-                        )
-                        .into(),
-                    )])
-                    .add_results(&[self.get_type(Self::I1)])
+                CmpOperation::builder(self.context, self.unknown_location)
+                    .predicate(predicate_attribute.into())
+                    .lhs(lhs)
+                    .rhs(rhs)
+                    .result(self.get_type(Self::I1))
                     .build()
-                    .expect("sol.cmp operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.cmp always produces one result")
@@ -1056,11 +963,11 @@ impl<'context> Builder<'context> {
         }
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_CAST, self.unknown_location)
-                    .add_operands(&[value])
-                    .add_results(&[to_type])
+                CastOperation::builder(self.context, self.unknown_location)
+                    .inp(value)
+                    .out(to_type)
                     .build()
-                    .expect("sol.cast operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.cast always produces one result")
@@ -1084,11 +991,11 @@ impl<'context> Builder<'context> {
     {
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_ADDRESS_CAST, self.unknown_location)
-                    .add_operands(&[value])
-                    .add_results(&[to_type])
+                AddressCastOperation::builder(self.context, self.unknown_location)
+                    .inp(value)
+                    .out(to_type)
                     .build()
-                    .expect("sol.address_cast operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.address_cast always produces one result")
@@ -1107,34 +1014,23 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
+        let slot_attribute: IntegerAttribute =
+            Attribute::parse(self.context, &format!("{slot} : i256"))
+                .expect("valid slot literal")
+                .try_into()
+                .expect("slot literal is an integer attribute");
+        let byte_offset_attribute = IntegerAttribute::new(
+            IntegerType::new(self.context, solx_utils::BIT_LENGTH_X32 as u32).into(),
+            0,
+        );
         block.append_operation(
-            OperationBuilder::new(Self::SOL_STATE_VAR, self.unknown_location)
-                .add_attributes(&[
-                    (
-                        Identifier::new(self.context, "sym_name"),
-                        StringAttribute::new(self.context, name).into(),
-                    ),
-                    (
-                        Identifier::new(self.context, "type"),
-                        TypeAttribute::new(self.get_type(Self::UI256)).into(),
-                    ),
-                    (
-                        Identifier::new(self.context, "slot"),
-                        Attribute::parse(self.context, &format!("{slot} : i256"))
-                            .expect("valid slot literal"),
-                    ),
-                    (
-                        Identifier::new(self.context, "byte_offset"),
-                        IntegerAttribute::new(
-                            IntegerType::new(self.context, solx_utils::BIT_LENGTH_X32 as u32)
-                                .into(),
-                            0,
-                        )
-                        .into(),
-                    ),
-                ])
+            StateVarOperation::builder(self.context, self.unknown_location)
+                .sym_name(StringAttribute::new(self.context, name))
+                .r#type(TypeAttribute::new(self.get_type(Self::UI256)))
+                .slot(slot_attribute)
+                .byte_offset(byte_offset_attribute)
                 .build()
-                .expect("sol.state_var operation is well-formed"),
+                .into(),
         );
     }
 
@@ -1155,83 +1051,18 @@ impl<'context> Builder<'context> {
     {
         block
             .append_operation(
-                OperationBuilder::new(Self::SOL_ADDR_OF, self.unknown_location)
-                    .add_attributes(&[(
-                        Identifier::new(self.context, "var"),
-                        FlatSymbolRefAttribute::new(self.context, name).into(),
-                    )])
-                    .add_results(&[result_type])
+                AddrOfOperation::builder(self.context, self.unknown_location)
+                    .var(FlatSymbolRefAttribute::new(self.context, name))
+                    .addr(result_type)
                     .build()
-                    .expect("sol.addr_of operation is well-formed"),
+                    .into(),
             )
             .result(0)
             .expect("sol.addr_of always produces one result")
             .into()
     }
 
-    // ==== EVM context intrinsics ====
-
-    /// Emits a Sol dialect EVM context intrinsic (e.g. `sol.caller`, `sol.timestamp`).
-    ///
-    /// These are zero-operand operations that return a single value of
-    /// `result_type` (e.g. `ui256` for numeric intrinsics, `!sol.address`
-    /// for address-returning intrinsics like `sol.caller`).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the MLIR operation cannot be constructed.
-    pub fn emit_sol_intrinsic<'block, B>(
-        &self,
-        name: &str,
-        result_type: Type<'context>,
-        block: &B,
-    ) -> Value<'context, 'block>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        block
-            .append_operation(
-                OperationBuilder::new(name, self.unknown_location)
-                    .add_results(&[result_type])
-                    .build()
-                    .expect("sol intrinsic operation is well-formed"),
-            )
-            .result(0)
-            .expect("sol intrinsic always produces one result")
-            .into()
-    }
-
     // ==== Shared helpers ====
-
-    /// Shared helper for emitting a two-operand operation with one result.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the MLIR operation cannot be constructed.
-    pub fn emit_binary_operation<'block, B>(
-        &self,
-        operation_name: &str,
-        lhs: Value<'context, 'block>,
-        rhs: Value<'context, 'block>,
-        result_type: Type<'context>,
-        block: &B,
-    ) -> anyhow::Result<Value<'context, 'block>>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        Ok(block
-            .append_operation(
-                OperationBuilder::new(operation_name, self.unknown_location)
-                    .add_operands(&[lhs, rhs])
-                    .add_results(&[result_type])
-                    .build()?,
-            )
-            .result(0)
-            .expect("binary operation always produces one result")
-            .into())
-    }
 
     /// Shared helper for emitting a constant operation with an attribute.
     ///
@@ -1240,7 +1071,6 @@ impl<'context> Builder<'context> {
     /// Returns an error if the MLIR operation cannot be constructed.
     fn emit_constant_operation<'block, B>(
         &self,
-        operation_name: &str,
         attribute: Attribute<'context>,
         result_type: Type<'context>,
         block: &B,
@@ -1251,11 +1081,11 @@ impl<'context> Builder<'context> {
     {
         Ok(block
             .append_operation(
-                OperationBuilder::new(operation_name, self.unknown_location)
-                    .add_attributes(&[(Identifier::new(self.context, "value"), attribute)])
-                    .add_results(&[result_type])
+                ConstantOperation::builder(self.context, self.unknown_location)
+                    .value(attribute)
+                    .result(result_type)
                     .build()
-                    .expect("constant operation is well-formed"),
+                    .into(),
             )
             .result(0)?
             .into())

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -7,12 +7,16 @@
 //! details, analogous to how `solx-yul` uses `solx-codegen-evm`.
 //!
 
-#![allow(clippy::too_many_arguments)]
+#![expect(
+    clippy::too_many_arguments,
+    reason = "MLIR builder methods require many parameters for operation construction"
+)]
 
 pub mod attributes;
 pub mod context;
 pub mod ffi;
 pub mod llvm_module;
+pub mod ods;
 
 pub use self::attributes::cmp_predicate::CmpPredicate;
 pub use self::attributes::contract_kind::ContractKind;

--- a/solx-mlir/src/ods.rs
+++ b/solx-mlir/src/ods.rs
@@ -1,0 +1,25 @@
+//!
+//! ODS-generated typed operation wrappers for Sol and Yul dialects.
+//!
+//! Generated at compile time from the TableGen `.td` files in `solx-llvm`
+//! using the [`melior::dialect!`] proc-macro. Provides type-safe operation
+//! structs, builders with type-state enforcement, and accessor methods.
+//!
+
+// The `dialect!` macro generates public items without doc comments.
+#![expect(
+    missing_docs,
+    reason = "melior::dialect! macro generates undocumented items"
+)]
+
+melior::dialect! {
+    name: "sol",
+    files: ["SolOps.td"],
+    include_directories: ["mlir/Dialect/Sol"],
+}
+
+melior::dialect! {
+    name: "yul",
+    files: ["YulOps.td"],
+    include_directories: ["mlir/Dialect/Yul"],
+}

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -17,7 +17,7 @@ semver.workspace = true
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 # TODO: pin to a release tag instead of branch = "main"
 slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "a01bc76b742173941cea1aff0b3b68a9006b38b8", features = ["__private_backend_api", "__private_testing_utils"] }
-melior = { version = "0.26", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-core = { path = "../solx-core", features = ["mlir"] }

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -4,6 +4,7 @@
 
 use std::str::FromStr;
 
+use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -12,6 +13,8 @@ use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 
 use solx_mlir::CmpPredicate;
+use solx_mlir::ods::sol::SubOperation;
+use solx_mlir::ods::sol::XorOperation;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
@@ -53,13 +56,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             &block,
         );
         let operator = Operator::from_str(operator)?;
-        let value = self.state.builder.emit_binary_operation(
-            operator.sol_operation_name(self.checked),
-            lhs,
-            rhs,
-            result_type,
-            &block,
-        )?;
+        let value = block
+            .append_operation(operator.emit_sol_binary_operation(
+                self.checked,
+                self.state.builder.context,
+                self.state.builder.unknown_location,
+                lhs,
+                rhs,
+            ))
+            .result(0)
+            .expect("binary operation always produces one result")
+            .into();
         Ok((value, block))
     }
 
@@ -99,13 +106,20 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .state
                     .builder
                     .emit_sol_constant_all_ones(operand_type, &block)?;
-                let result = self.state.builder.emit_binary_operation(
-                    solx_mlir::Builder::SOL_XOR,
-                    value,
-                    all_ones,
-                    operand_type,
-                    &block,
-                )?;
+                let result = block
+                    .append_operation(
+                        XorOperation::builder(
+                            self.state.builder.context,
+                            self.state.builder.unknown_location,
+                        )
+                        .lhs(value)
+                        .rhs(all_ones)
+                        .build()
+                        .into(),
+                    )
+                    .result(0)
+                    .expect("sol.xor always produces one result")
+                    .into();
                 Ok((result, block))
             }
             "!" => {
@@ -137,13 +151,20 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .state
                     .builder
                     .emit_sol_constant(0, operand_type, &block);
-                let result = self.state.builder.emit_binary_operation(
-                    solx_mlir::Builder::SOL_SUB,
-                    zero,
-                    value,
-                    operand_type,
-                    &block,
-                )?;
+                let result = block
+                    .append_operation(
+                        SubOperation::builder(
+                            self.state.builder.context,
+                            self.state.builder.unknown_location,
+                        )
+                        .lhs(zero)
+                        .rhs(value)
+                        .build()
+                        .into(),
+                    )
+                    .result(0)
+                    .expect("sol.sub always produces one result")
+                    .into();
                 Ok((result, block))
             }
             _ => anyhow::bail!("unsupported prefix operator: {operator}"),
@@ -178,13 +199,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 // in checked mode because overflow is checked at 256-bit width.
                 let ui256 = self.state.builder.get_type(solx_mlir::Builder::UI256);
                 let one = self.state.builder.emit_sol_constant(1, ui256, block);
-                let new_value = self.state.builder.emit_binary_operation(
-                    operator.sol_operation_name(self.checked),
-                    old,
-                    one,
-                    ui256,
-                    block,
-                )?;
+                let new_value = block
+                    .append_operation(operator.emit_sol_binary_operation(
+                        self.checked,
+                        self.state.builder.context,
+                        self.state.builder.unknown_location,
+                        old,
+                        one,
+                    ))
+                    .result(0)
+                    .expect("binary operation always produces one result")
+                    .into();
                 self.emit_storage_store(slot, new_value, block);
                 Ok((old, new_value))
             }
@@ -198,13 +223,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .builder
                     .emit_sol_load(pointer, element_type, block)?;
                 let typed_one = self.state.builder.emit_sol_constant(1, element_type, block);
-                let new_value = self.state.builder.emit_binary_operation(
-                    operator.sol_operation_name(self.checked),
-                    old,
-                    typed_one,
-                    element_type,
-                    block,
-                )?;
+                let new_value = block
+                    .append_operation(operator.emit_sol_binary_operation(
+                        self.checked,
+                        self.state.builder.context,
+                        self.state.builder.unknown_location,
+                        old,
+                        typed_one,
+                    ))
+                    .result(0)
+                    .expect("binary operation always produces one result")
+                    .into();
                 self.state.builder.emit_sol_store(new_value, pointer, block);
                 Ok((old, new_value))
             }

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -4,6 +4,7 @@
 
 use std::str::FromStr;
 
+use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -85,13 +86,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 &block,
             );
             let operator = Operator::from_str(operator_text)?.arithmetic_operator();
-            let result = self.state.builder.emit_binary_operation(
-                operator.sol_operation_name(self.checked),
-                old,
-                rhs,
-                target_type,
-                &block,
-            )?;
+            let result = block
+                .append_operation(operator.emit_sol_binary_operation(
+                    self.checked,
+                    self.state.builder.context,
+                    self.state.builder.unknown_location,
+                    old,
+                    rhs,
+                ))
+                .result(0)
+                .expect("binary operation always produces one result")
+                .into();
             (result, block)
         };
 

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -4,15 +4,27 @@
 
 pub mod type_conversion;
 
+use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Value;
 use slang_solidity::backend::built_ins::BuiltIn;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::FunctionCallExpression;
+use solx_mlir::ods::sol::BaseFeeOperation;
+use solx_mlir::ods::sol::BlockNumberOperation;
+use solx_mlir::ods::sol::CallValueOperation;
+use solx_mlir::ods::sol::CallerOperation;
+use solx_mlir::ods::sol::ChainIdOperation;
+use solx_mlir::ods::sol::CoinbaseOperation;
+use solx_mlir::ods::sol::GasLimitOperation;
+use solx_mlir::ods::sol::GasPriceOperation;
+use solx_mlir::ods::sol::OriginOperation;
+use solx_mlir::ods::sol::TimestampOperation;
+
+use crate::ast::contract::function::expression::ExpressionEmitter;
 
 use self::type_conversion::TypeConversion;
-use crate::ast::contract::function::expression::ExpressionEmitter;
 
 /// Lowers function call and member access expressions to MLIR.
 pub struct CallEmitter<'emitter, 'state, 'context, 'block> {
@@ -145,22 +157,58 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
         let builder = &self.expression_emitter.state.builder;
+        let context = builder.context;
+        let location = builder.unknown_location;
         let address_type = builder.get_type(solx_mlir::Builder::SOL_ADDRESS);
         let ui256_type = builder.get_type(solx_mlir::Builder::UI256);
-        let (intrinsic, result_type) = match member_identifier.resolved_built_in() {
-            Some(BuiltIn::TxOrigin) => (solx_mlir::Builder::SOL_ORIGIN, address_type),
-            Some(BuiltIn::TxGasPrice) => (solx_mlir::Builder::SOL_GASPRICE, ui256_type),
-            Some(BuiltIn::MsgSender) => (solx_mlir::Builder::SOL_CALLER, address_type),
-            Some(BuiltIn::MsgValue) => (solx_mlir::Builder::SOL_CALLVALUE, ui256_type),
-            Some(BuiltIn::BlockTimestamp) => (solx_mlir::Builder::SOL_TIMESTAMP, ui256_type),
-            Some(BuiltIn::BlockNumber) => (solx_mlir::Builder::SOL_BLOCKNUMBER, ui256_type),
-            Some(BuiltIn::BlockCoinbase) => (solx_mlir::Builder::SOL_COINBASE, address_type),
-            Some(BuiltIn::BlockChainid) => (solx_mlir::Builder::SOL_CHAINID, ui256_type),
-            Some(BuiltIn::BlockBasefee) => (solx_mlir::Builder::SOL_BASEFEE, ui256_type),
-            Some(BuiltIn::BlockGaslimit) => (solx_mlir::Builder::SOL_GASLIMIT, ui256_type),
+        let operation = match member_identifier.resolved_built_in() {
+            Some(BuiltIn::TxOrigin) => OriginOperation::builder(context, location)
+                .addr(address_type)
+                .build()
+                .into(),
+            Some(BuiltIn::TxGasPrice) => GasPriceOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::MsgSender) => CallerOperation::builder(context, location)
+                .addr(address_type)
+                .build()
+                .into(),
+            Some(BuiltIn::MsgValue) => CallValueOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockTimestamp) => TimestampOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockNumber) => BlockNumberOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockCoinbase) => CoinbaseOperation::builder(context, location)
+                .addr(address_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockChainid) => ChainIdOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockBasefee) => BaseFeeOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
+            Some(BuiltIn::BlockGaslimit) => GasLimitOperation::builder(context, location)
+                .val(ui256_type)
+                .build()
+                .into(),
             _ => anyhow::bail!("unsupported member access: {}", member_identifier.name()),
         };
-        let value = builder.emit_sol_intrinsic(intrinsic, result_type, &block);
+        let value = block
+            .append_operation(operation)
+            .result(0)
+            .expect("intrinsic always produces one result")
+            .into();
         Ok((value, block))
     }
 

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -12,6 +12,7 @@ pub mod storage;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -25,6 +26,7 @@ use slang_solidity::cst::NodeId;
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
 use solx_mlir::Environment;
+use solx_mlir::ods::sol::ExpOperation;
 
 use self::call::type_conversion::TypeConversion;
 
@@ -289,13 +291,20 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     &self.state.builder,
                     &block,
                 );
-                let result = self.state.builder.emit_binary_operation(
-                    solx_mlir::Builder::SOL_EXP,
-                    lhs,
-                    rhs,
-                    result_type,
-                    &block,
-                )?;
+                let result = block
+                    .append_operation(
+                        ExpOperation::builder(
+                            self.state.builder.context,
+                            self.state.builder.unknown_location,
+                        )
+                        .lhs(lhs)
+                        .rhs(rhs)
+                        .build()
+                        .into(),
+                    )
+                    .result(0)
+                    .expect("sol.exp always produces one result")
+                    .into();
                 Ok((Some(result), block))
             }
             Expression::ConditionalExpression(conditional) => {

--- a/solx-slang/src/ast/contract/function/expression/operator.rs
+++ b/solx-slang/src/ast/contract/function/expression/operator.rs
@@ -4,7 +4,25 @@
 
 use std::str::FromStr;
 
+use melior::ir::Location;
+use melior::ir::Value;
+use melior::ir::operation::Operation;
+
 use solx_mlir::CmpPredicate;
+use solx_mlir::ods::sol::AddOperation;
+use solx_mlir::ods::sol::AndOperation;
+use solx_mlir::ods::sol::CAddOperation;
+use solx_mlir::ods::sol::CDivOperation;
+use solx_mlir::ods::sol::CMulOperation;
+use solx_mlir::ods::sol::CSubOperation;
+use solx_mlir::ods::sol::DivOperation;
+use solx_mlir::ods::sol::ModOperation;
+use solx_mlir::ods::sol::MulOperation;
+use solx_mlir::ods::sol::OrOperation;
+use solx_mlir::ods::sol::ShlOperation;
+use solx_mlir::ods::sol::ShrOperation;
+use solx_mlir::ods::sol::SubOperation;
+use solx_mlir::ods::sol::XorOperation;
 
 /// Solidity operator parsed from source text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,32 +117,100 @@ impl Operator {
         }
     }
 
-    /// Returns the Sol dialect operation name for arithmetic, bitwise, and step operators.
+    /// Builds a Sol dialect binary operation via ODS-generated builders.
     ///
-    /// When `checked` is true, uses `sol.cadd`/`sol.csub`/`sol.cmul`/`sol.cdiv`
-    /// for add/subtract/multiply/divide (Solidity 0.8+ default). Modulo,
-    /// bitwise, and shift operators are always unchecked.
+    /// When `checked` is true, uses checked variants (`sol.cadd`, `sol.csub`,
+    /// `sol.cmul`, `sol.cdiv`) for arithmetic operators. Modulo, bitwise,
+    /// and shift operators are always unchecked. Result type is inferred
+    /// from `lhs` (`SameOperandsAndResultType`).
     ///
     /// # Panics
     ///
     /// Panics if called on a comparison or assignment operator.
-    pub fn sol_operation_name(self, checked: bool) -> &'static str {
+    pub fn emit_sol_binary_operation<'context>(
+        self,
+        checked: bool,
+        context: &'context melior::Context,
+        location: Location<'context>,
+        lhs: Value<'context, '_>,
+        rhs: Value<'context, '_>,
+    ) -> Operation<'context> {
         match self {
-            Self::Add | Self::Increment if checked => solx_mlir::Builder::SOL_CADD,
-            Self::Add | Self::Increment => solx_mlir::Builder::SOL_ADD,
-            Self::Subtract | Self::Decrement if checked => solx_mlir::Builder::SOL_CSUB,
-            Self::Subtract | Self::Decrement => solx_mlir::Builder::SOL_SUB,
-            Self::Multiply if checked => solx_mlir::Builder::SOL_CMUL,
-            Self::Multiply => solx_mlir::Builder::SOL_MUL,
-            Self::Divide if checked => solx_mlir::Builder::SOL_CDIV,
-            Self::Divide => solx_mlir::Builder::SOL_DIV,
-            Self::Remainder => solx_mlir::Builder::SOL_MOD,
-            Self::BitwiseAnd => solx_mlir::Builder::SOL_AND,
-            Self::BitwiseOr => solx_mlir::Builder::SOL_OR,
-            Self::BitwiseXor => solx_mlir::Builder::SOL_XOR,
-            Self::ShiftLeft => solx_mlir::Builder::SOL_SHL,
-            Self::ShiftRight => solx_mlir::Builder::SOL_SHR,
-            _ => unreachable!("sol_operation_name called on non-arithmetic operator: {self:?}"),
+            Self::Add | Self::Increment if checked => CAddOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Add | Self::Increment => AddOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Subtract | Self::Decrement if checked => {
+                CSubOperation::builder(context, location)
+                    .lhs(lhs)
+                    .rhs(rhs)
+                    .build()
+                    .into()
+            }
+            Self::Subtract | Self::Decrement => SubOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Multiply if checked => CMulOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Multiply => MulOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Divide if checked => CDivOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Divide => DivOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Remainder => ModOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::BitwiseAnd => AndOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::BitwiseOr => OrOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::BitwiseXor => XorOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::ShiftLeft => ShlOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::ShiftRight => ShrOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            _ => unreachable!(
+                "emit_sol_binary_operation called on non-arithmetic operator: {self:?}"
+            ),
         }
     }
 


### PR DESCRIPTION
Replace all `OperationBuilder::new("sol.X", ...)` patterns in solx-mlir and solx-slang with type-safe builders generated by `melior::dialect!` from the Sol dialect TableGen definitions.

<h3>Type strings (out of scope)</h3>
I am looking into replacing type strings with some static type storage maintained at compile time, but will do this in a follow-up PR as it may require moving some modules around.

<h3>Exceptions (out of scope)</h3>
<p>Some attributes are not defined in the ODS and must keep the original dictionary approach.</p>
<p>Three module-level attributes are set via raw FFI (<code>mlirOperationSetAttributeByName</code>) rather than ODS-generated builders.

Attribute / Operation | Key | Type | Why Not Typed
-- | -- | -- | --
sol.evm_version | "sol.evm_version" | Sol_EvmVersionAttr (ODS enum) | Module-level; no ODS operation owns it. Set via FFI solxCreateEvmVersionAttr.
llvm.data_layout | "llvm.data_layout" | StringAttr | LLVM dialect convention required by translateModuleToLLVMIR.
llvm.target_triple | "llvm.target_triple" | StringAttr | LLVM dialect convention required by translateModuleToLLVMIR.