### PR TITLE
fix: cargo-deny failure from vulnerable rustls-webpki

### DIFF
--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -1,3 +1,3 @@
 [[allow.exact]]
 crate = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
The failing `cargo-checks` job on PR #334 was not caused by the `docker/build-push-action` bump itself. The job was failing in `cargo deny` because `Cargo.lock` still contained `rustls-webpki 0.103.10`, which is affected by:
- `RUSTSEC-2026-0098`
- `RUSTSEC-2026-0099`

Updating to `0.103.12` resolves the advisory failure with the smallest possible change.