### PR TITLE
refactor(mlir): replace type cache HashMap with TypeFactory

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -790,7 +790,7 @@ impl<'context> Builder<'context> {
         let operation = block.append_operation(
             CallOperation::builder(self.context, self.unknown_location)
                 .callee(FlatSymbolRefAttribute::new(self.context, callee))
-                .results(result_types)
+                .outs(result_types)
                 .operands(operands)
                 .build()
                 .into(),

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -6,7 +6,7 @@
 //! memory, comparisons, calls, state variables, and EVM context intrinsics.
 //!
 
-use std::collections::HashMap;
+pub mod type_factory;
 
 use melior::dialect::ods::scf::IfOperation as ScfIfOperation;
 use melior::dialect::ods::scf::YieldOperation as ScfYieldOperation;
@@ -18,7 +18,6 @@ use melior::ir::Location;
 use melior::ir::Region;
 use melior::ir::RegionLike;
 use melior::ir::Type;
-use melior::ir::TypeLike;
 use melior::ir::Value;
 use melior::ir::ValueLike;
 use melior::ir::attribute::FlatSymbolRefAttribute;
@@ -31,6 +30,7 @@ use melior::ir::r#type::IntegerType;
 
 use crate::CmpPredicate;
 use crate::StateMutability;
+use crate::context::builder::type_factory::TypeFactory;
 use crate::ods::sol::AddrOfOperation;
 use crate::ods::sol::AddressCastOperation;
 use crate::ods::sol::AllocaOperation;
@@ -56,123 +56,22 @@ use crate::ods::sol::WhileOperation;
 use crate::ods::sol::YieldOperation;
 
 /// Cached MLIR types and emission methods for building MLIR operations.
-///
-/// Types are cached in a [`HashMap`] keyed by their textual representation.
-/// New types can be added without changing the struct definition.
 pub struct Builder<'context> {
     /// The MLIR context with all dialects and translations registered.
     pub context: &'context melior::Context,
     /// Cached unknown source location.
     pub unknown_location: Location<'context>,
-    /// Cached MLIR types, keyed by textual representation.
-    pub types: HashMap<&'static str, Type<'context>>,
+    /// Type factory: pre-cached common types and parameterized constructors.
+    pub types: TypeFactory<'context>,
 }
 
 impl<'context> Builder<'context> {
-    // ---- Type cache keys ----
-
-    /// 1-bit boolean type key.
-    pub const I1: &'static str = "i1";
-    /// Unsigned 160-bit integer type key (address width).
-    pub const UI160: &'static str = "ui160";
-    /// Unsigned 256-bit integer type key.
-    pub const UI256: &'static str = "ui256";
-    /// Sol address type key.
-    pub const SOL_ADDRESS: &'static str = "!sol.address";
-    /// Sol storage pointer type key.
-    pub const SOL_PTR_STORAGE: &'static str = "!sol.ptr<ui256, Storage>";
-
-    // ---- Private constants ----
-
-    /// Bit width of a Solidity function selector (4 bytes).
-    const SELECTOR_BIT_WIDTH: u32 = solx_utils::BIT_LENGTH_X32 as u32;
-
-    // ==== Constructor ====
-
     /// Creates a new builder with pre-cached types.
     pub fn new(context: &'context melior::Context) -> Self {
-        let unknown_location = Location::unknown(context);
-        let types = HashMap::from([
-            (
-                Self::I1,
-                Type::from(IntegerType::new(
-                    context,
-                    solx_utils::BIT_LENGTH_BOOLEAN as u32,
-                )),
-            ),
-            (
-                Self::UI160,
-                Type::from(IntegerType::unsigned(
-                    context,
-                    solx_utils::BIT_LENGTH_ETH_ADDRESS as u32,
-                )),
-            ),
-            (
-                Self::UI256,
-                Type::from(IntegerType::unsigned(
-                    context,
-                    solx_utils::BIT_LENGTH_FIELD as u32,
-                )),
-            ),
-            // SAFETY: `solxCreateAddressType` returns a valid MlirType from
-            // the C++ Sol dialect. The context pointer is valid.
-            (Self::SOL_ADDRESS, unsafe {
-                Type::from_raw(crate::ffi::solxCreateAddressType(context.to_raw(), false))
-            }),
-            (
-                Self::SOL_PTR_STORAGE,
-                Type::parse(context, Self::SOL_PTR_STORAGE).expect("valid sol.ptr type syntax"),
-            ),
-        ]);
         Self {
             context,
-            unknown_location,
-            types,
-        }
-    }
-
-    /// Returns a cached MLIR type by its textual key.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the key is not in the cache.
-    pub fn get_type(&self, key: &str) -> Type<'context> {
-        self.types[key]
-    }
-
-    /// Returns the bit width of an MLIR integer type, or 256 for non-integer types.
-    pub fn integer_bit_width(r#type: Type<'_>) -> u32 {
-        IntegerType::try_from(r#type).map_or(solx_utils::BIT_LENGTH_FIELD as u32, |integer_type| {
-            integer_type.width()
-        })
-    }
-
-    /// Creates a `sol::AddressType` with the given payability.
-    pub fn create_address_type(&self, payable: bool) -> Type<'context> {
-        // SAFETY: `solxCreateAddressType` returns a valid MlirType from the
-        // C++ Sol dialect. The context pointer is valid.
-        unsafe {
-            Type::from_raw(crate::ffi::solxCreateAddressType(
-                self.context.to_raw(),
-                payable,
-            ))
-        }
-    }
-
-    /// Creates a `sol::PointerType` with the given element type and data location.
-    pub fn create_pointer_type(
-        &self,
-        element_type: Type<'context>,
-        location: solx_utils::DataLocation,
-    ) -> Type<'context> {
-        // SAFETY: `solxCreatePointerType` returns a valid MlirType from the
-        // C++ Sol dialect. The context and element type pointers are valid.
-        unsafe {
-            Type::from_raw(crate::ffi::solxCreatePointerType(
-                self.context.to_raw(),
-                element_type.to_raw(),
-                location as u32,
-            ))
+            unknown_location: Location::unknown(context),
+            types: TypeFactory::new(context),
         }
     }
 
@@ -274,7 +173,7 @@ impl<'context> Builder<'context> {
 
         if let Some(selector_value) = selector {
             builder = builder.selector(IntegerAttribute::new(
-                IntegerType::new(self.context, Self::SELECTOR_BIT_WIDTH).into(),
+                IntegerType::new(self.context, TypeFactory::SELECTOR_BIT_WIDTH).into(),
                 selector_value as i64,
             ));
         }
@@ -377,7 +276,7 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let bit_width = Self::integer_bit_width(integer_type);
+        let bit_width = TypeFactory::integer_bit_width(integer_type);
         let all_ones_hex = "f".repeat(bit_width as usize / 4);
         self.emit_sol_constant_from_hex_str(&all_ones_hex, integer_type, block)
     }
@@ -797,7 +696,9 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let ptr_type = self.create_pointer_type(element_type, solx_utils::DataLocation::Stack);
+        let ptr_type = self
+            .types
+            .pointer(element_type, solx_utils::DataLocation::Stack);
         block
             .append_operation(
                 AllocaOperation::builder(self.context, self.unknown_location)
@@ -889,8 +790,8 @@ impl<'context> Builder<'context> {
         let operation = block.append_operation(
             CallOperation::builder(self.context, self.unknown_location)
                 .callee(FlatSymbolRefAttribute::new(self.context, callee))
-                .operands(operands)
                 .results(result_types)
+                .operands(operands)
                 .build()
                 .into(),
         );
@@ -930,7 +831,7 @@ impl<'context> Builder<'context> {
                     .predicate(predicate_attribute.into())
                     .lhs(lhs)
                     .rhs(rhs)
-                    .result(self.get_type(Self::I1))
+                    .result(self.types.i1)
                     .build()
                     .into(),
             )
@@ -1022,7 +923,7 @@ impl<'context> Builder<'context> {
         block.append_operation(
             StateVarOperation::builder(self.context, self.unknown_location)
                 .sym_name(StringAttribute::new(self.context, name))
-                .r#type(TypeAttribute::new(self.get_type(Self::UI256)))
+                .r#type(TypeAttribute::new(self.types.ui256))
                 .slot(slot_attribute)
                 .byte_offset(byte_offset_attribute)
                 .build()

--- a/solx-mlir/src/context/builder/type_factory.rs
+++ b/solx-mlir/src/context/builder/type_factory.rs
@@ -1,0 +1,107 @@
+//!
+//! MLIR type factory for Sol dialect emission.
+//!
+//! Provides pre-cached common types and factory methods for constructing
+//! parameterized Sol dialect types (pointers, addresses, integers).
+//!
+
+use melior::ir::Type;
+use melior::ir::TypeLike;
+use melior::ir::r#type::IntegerType;
+
+/// MLIR type factory: pre-cached common types and parameterized constructors.
+///
+/// All types are constructed through typed APIs — no string parsing.
+pub struct TypeFactory<'context> {
+    /// The MLIR context for constructing new types.
+    context: &'context melior::Context,
+
+    /// 1-bit boolean type (`i1`).
+    pub i1: Type<'context>,
+    /// Unsigned 160-bit integer type (`ui160`, address width).
+    pub ui160: Type<'context>,
+    /// Unsigned 256-bit integer type (`ui256`).
+    pub ui256: Type<'context>,
+    /// Sol address type (`!sol.address`).
+    pub sol_address: Type<'context>,
+    /// Sol storage pointer type (`!sol.ptr<ui256, Storage>`).
+    pub sol_ptr_storage: Type<'context>,
+}
+
+impl<'context> TypeFactory<'context> {
+    /// Bit width of a Solidity function selector (4 bytes).
+    pub const SELECTOR_BIT_WIDTH: u32 = solx_utils::BIT_LENGTH_X32 as u32;
+
+    /// Creates a new type factory with pre-cached common types.
+    pub fn new(context: &'context melior::Context) -> Self {
+        let i1 = Type::from(IntegerType::new(
+            context,
+            solx_utils::BIT_LENGTH_BOOLEAN as u32,
+        ));
+        let ui160 = Type::from(IntegerType::unsigned(
+            context,
+            solx_utils::BIT_LENGTH_ETH_ADDRESS as u32,
+        ));
+        let ui256 = Type::from(IntegerType::unsigned(
+            context,
+            solx_utils::BIT_LENGTH_FIELD as u32,
+        ));
+        // SAFETY: `solxCreateAddressType` returns a valid MlirType from
+        // the C++ Sol dialect. The context pointer is valid.
+        let sol_address =
+            unsafe { Type::from_raw(crate::ffi::solxCreateAddressType(context.to_raw(), false)) };
+        // SAFETY: `solxCreatePointerType` returns a valid MlirType from
+        // the C++ Sol dialect. The context and element type pointers are valid.
+        let sol_ptr_storage = unsafe {
+            Type::from_raw(crate::ffi::solxCreatePointerType(
+                context.to_raw(),
+                ui256.to_raw(),
+                solx_utils::DataLocation::Storage as u32,
+            ))
+        };
+        Self {
+            context,
+            i1,
+            ui160,
+            ui256,
+            sol_address,
+            sol_ptr_storage,
+        }
+    }
+
+    /// Returns the bit width of an MLIR integer type, or 256 for non-integer types.
+    pub fn integer_bit_width(r#type: Type<'_>) -> u32 {
+        IntegerType::try_from(r#type).map_or(solx_utils::BIT_LENGTH_FIELD as u32, |integer_type| {
+            integer_type.width()
+        })
+    }
+
+    /// Creates a `sol::AddressType` with the given payability.
+    pub fn address(&self, payable: bool) -> Type<'context> {
+        // SAFETY: `solxCreateAddressType` returns a valid MlirType from the
+        // C++ Sol dialect. The context pointer is valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateAddressType(
+                self.context.to_raw(),
+                payable,
+            ))
+        }
+    }
+
+    /// Creates a `sol::PointerType` with the given element type and data location.
+    pub fn pointer(
+        &self,
+        element_type: Type<'context>,
+        location: solx_utils::DataLocation,
+    ) -> Type<'context> {
+        // SAFETY: `solxCreatePointerType` returns a valid MlirType from the
+        // C++ Sol dialect. The context and element type pointers are valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreatePointerType(
+                self.context.to_raw(),
+                element_type.to_raw(),
+                location as u32,
+            ))
+        }
+    }
+}

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -24,4 +24,5 @@ pub use self::attributes::function_kind::FunctionKind;
 pub use self::attributes::state_mutability::StateMutability;
 pub use self::context::Context;
 pub use self::context::builder::Builder;
+pub use self::context::builder::type_factory::TypeFactory;
 pub use self::context::environment::Environment;

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -37,8 +37,8 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let (lhs, block) = self.emit_value(left, block)?;
         let (rhs, block) = self.emit_value(right, block)?;
         let result_type = target_type.unwrap_or_else(|| {
-            let lhs_width = solx_mlir::Builder::integer_bit_width(lhs.r#type());
-            let rhs_width = solx_mlir::Builder::integer_bit_width(rhs.r#type());
+            let lhs_width = solx_mlir::TypeFactory::integer_bit_width(lhs.r#type());
+            let rhs_width = solx_mlir::TypeFactory::integer_bit_width(rhs.r#type());
             if lhs_width >= rhs_width {
                 lhs.r#type()
             } else {
@@ -132,8 +132,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .state
                     .builder
                     .emit_sol_cmp(value, zero, CmpPredicate::Eq, &block);
-                let result_type = target_type
-                    .unwrap_or_else(|| self.state.builder.get_type(solx_mlir::Builder::UI256));
+                let result_type = target_type.unwrap_or_else(|| self.state.builder.types.ui256);
                 let result = TypeConversion::from_target_type(result_type, &self.state.builder)
                     .emit(cmp, &self.state.builder, &block);
                 Ok((result, block))
@@ -197,7 +196,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 // TODO: use declared element type once state variable types are tracked.
                 // Currently hardcodes ui256, so `uint8 x = 255; x++` won't revert
                 // in checked mode because overflow is checked at 256-bit width.
-                let ui256 = self.state.builder.get_type(solx_mlir::Builder::UI256);
+                let ui256 = self.state.builder.types.ui256;
                 let one = self.state.builder.emit_sol_constant(1, ui256, block);
                 let new_value = block
                     .append_operation(operator.emit_sol_binary_operation(

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -71,7 +71,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 }
                 AssignmentTarget::Storage(slot) => {
                     let old = self.emit_storage_load(slot, &block)?;
-                    (old, self.state.builder.get_type(solx_mlir::Builder::UI256))
+                    (old, self.state.builder.types.ui256)
                 }
             };
             let (rhs, block) = self.emit_value(&right, block)?;
@@ -113,7 +113,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 stored_value
             }
             AssignmentTarget::Storage(slot) => {
-                let ui256 = self.state.builder.get_type(solx_mlir::Builder::UI256);
+                let ui256 = self.state.builder.types.ui256;
                 let stored_value = self.state.builder.emit_sol_cast(value, ui256, &block);
                 self.emit_storage_store(slot, stored_value, &block);
                 value

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -159,8 +159,8 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         let builder = &self.expression_emitter.state.builder;
         let context = builder.context;
         let location = builder.unknown_location;
-        let address_type = builder.get_type(solx_mlir::Builder::SOL_ADDRESS);
-        let ui256_type = builder.get_type(solx_mlir::Builder::UI256);
+        let address_type = builder.types.sol_address;
+        let ui256_type = builder.types.ui256;
         let operation = match member_identifier.resolved_built_in() {
             Some(BuiltIn::TxOrigin) => OriginOperation::builder(context, location)
                 .addr(address_type)

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -40,8 +40,8 @@ impl<'context> TypeConversion<'context> {
                 context,
                 solx_utils::BIT_LENGTH_BOOLEAN as u32,
             )),
-            SlangType::Address(_) => builder.get_type(solx_mlir::Builder::SOL_ADDRESS),
-            SlangType::Literal(_) => builder.get_type(solx_mlir::Builder::UI256),
+            SlangType::Address(_) => builder.types.sol_address,
+            SlangType::Literal(_) => builder.types.ui256,
             _ => unimplemented!("unsupported Slang type"),
         }
     }
@@ -51,9 +51,9 @@ impl<'context> TypeConversion<'context> {
         target_type: Type<'context>,
         builder: &solx_mlir::Builder<'context>,
     ) -> Self {
-        if target_type == builder.get_type(solx_mlir::Builder::I1) {
+        if target_type == builder.types.i1 {
             Self::Bool
-        } else if target_type == builder.get_type(solx_mlir::Builder::SOL_ADDRESS) {
+        } else if target_type == builder.types.sol_address {
             Self::Address
         } else {
             Self::Cast(target_type)
@@ -76,10 +76,10 @@ impl<'context> TypeConversion<'context> {
                 builder.emit_sol_cmp(value, zero, solx_mlir::CmpPredicate::Ne, block)
             }
             Self::Address => {
-                let address_type = builder.get_type(solx_mlir::Builder::SOL_ADDRESS);
+                let address_type = builder.types.sol_address;
                 let truncated = if melior::ir::r#type::IntegerType::try_from(value.r#type()).is_ok()
                 {
-                    let ui160 = builder.get_type(solx_mlir::Builder::UI160);
+                    let ui160 = builder.types.ui160;
                     builder.emit_sol_cast(value, ui160, block)
                 } else {
                     value

--- a/solx-slang/src/ast/contract/function/expression/logical.rs
+++ b/solx-slang/src/ast/contract/function/expression/logical.rs
@@ -31,7 +31,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let common_type = if lhs.r#type() == rhs.r#type() {
             lhs.r#type()
         } else {
-            self.state.builder.get_type(solx_mlir::Builder::UI256)
+            self.state.builder.types.ui256
         };
         let lhs = TypeConversion::from_target_type(common_type, &self.state.builder).emit(
             lhs,
@@ -65,7 +65,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let (lhs, block) = self.emit_value(left, block)?;
         let lhs_bool = self.emit_is_nonzero(lhs, &block);
 
-        let i1_type = self.state.builder.get_type(solx_mlir::Builder::I1);
+        let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
         // TODO: solc uses `arith.constant false` here; consider switching to
         // arith dialect for i1 constants to match solc output exactly.
@@ -111,7 +111,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let (lhs, block) = self.emit_value(left, block)?;
         let lhs_bool = self.emit_is_nonzero(lhs, &block);
 
-        let i1_type = self.state.builder.get_type(solx_mlir::Builder::I1);
+        let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
         let true_val = self.state.builder.emit_sol_constant(1, i1_type, &block);
         self.state

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -129,12 +129,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 Ok((Some(value), block))
             }
             Expression::TrueKeyword => {
-                let i1_type = self.state.builder.get_type(solx_mlir::Builder::I1);
+                let i1_type = self.state.builder.types.i1;
                 let value = self.state.builder.emit_sol_constant(1, i1_type, &block);
                 Ok((Some(value), block))
             }
             Expression::FalseKeyword => {
-                let i1_type = self.state.builder.get_type(solx_mlir::Builder::I1);
+                let i1_type = self.state.builder.types.i1;
                 let value = self.state.builder.emit_sol_constant(0, i1_type, &block);
                 Ok((Some(value), block))
             }
@@ -279,8 +279,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let right = expression.right_operand();
                 let (lhs, block) = self.emit_value(&left, block)?;
                 let (rhs, block) = self.emit_value(&right, block)?;
-                let result_type = target_type
-                    .unwrap_or_else(|| self.state.builder.get_type(solx_mlir::Builder::UI256));
+                let result_type = target_type.unwrap_or_else(|| self.state.builder.types.ui256);
                 let lhs = TypeConversion::from_target_type(result_type, &self.state.builder).emit(
                     lhs,
                     &self.state.builder,
@@ -310,7 +309,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             Expression::ConditionalExpression(conditional) => {
                 let result_type = self
                     .resolve_expression_type(conditional.node_id())
-                    .unwrap_or_else(|| self.state.builder.get_type(solx_mlir::Builder::UI256));
+                    .unwrap_or_else(|| self.state.builder.types.ui256);
                 let condition = conditional.operand();
                 let (condition_value, block) = self.emit_value(&condition, block)?;
                 let condition_boolean = self.emit_is_nonzero(condition_value, &block);
@@ -350,7 +349,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         value: Value<'context, 'block>,
         block: &BlockRef<'context, 'block>,
     ) -> Value<'context, 'block> {
-        if solx_mlir::Builder::integer_bit_width(value.r#type()) == 1 {
+        if solx_mlir::TypeFactory::integer_bit_width(value.r#type()) == 1 {
             return value;
         }
         let zero = self

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -12,7 +12,6 @@ pub mod storage;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -26,7 +25,6 @@ use slang_solidity::cst::NodeId;
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
 use solx_mlir::Environment;
-use solx_mlir::ods::sol::ExpOperation;
 
 use self::call::type_conversion::TypeConversion;
 
@@ -185,6 +183,13 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 self.emit_binary_op(&left, &right, &operator.text, result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
+            Expression::ExponentiationExpression(expression) => {
+                let target_type = self.resolve_expression_type(expression.node_id());
+                let left = expression.left_operand();
+                let right = expression.right_operand();
+                self.emit_binary_op(&left, &right, "**", target_type, block)
+                    .map(|(value, block)| (Some(value), block))
+            }
             Expression::EqualityExpression(expression) => {
                 let left = expression.left_operand();
                 let right = expression.right_operand();
@@ -271,40 +276,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .expression()
                     .ok_or_else(|| anyhow::anyhow!("empty tuple element"))?;
                 self.emit(&inner, block)
-            }
-            Expression::ExponentiationExpression(expression) => {
-                // TODO: implement checked exponentiation (sol.cexp) for Solidity 0.8+.
-                let target_type = self.resolve_expression_type(expression.node_id());
-                let left = expression.left_operand();
-                let right = expression.right_operand();
-                let (lhs, block) = self.emit_value(&left, block)?;
-                let (rhs, block) = self.emit_value(&right, block)?;
-                let result_type = target_type.unwrap_or_else(|| self.state.builder.types.ui256);
-                let lhs = TypeConversion::from_target_type(result_type, &self.state.builder).emit(
-                    lhs,
-                    &self.state.builder,
-                    &block,
-                );
-                let rhs = TypeConversion::from_target_type(result_type, &self.state.builder).emit(
-                    rhs,
-                    &self.state.builder,
-                    &block,
-                );
-                let result = block
-                    .append_operation(
-                        ExpOperation::builder(
-                            self.state.builder.context,
-                            self.state.builder.unknown_location,
-                        )
-                        .lhs(lhs)
-                        .rhs(rhs)
-                        .build()
-                        .into(),
-                    )
-                    .result(0)
-                    .expect("sol.exp always produces one result")
-                    .into();
-                Ok((Some(result), block))
             }
             Expression::ConditionalExpression(conditional) => {
                 let result_type = self

--- a/solx-slang/src/ast/contract/function/expression/operator.rs
+++ b/solx-slang/src/ast/contract/function/expression/operator.rs
@@ -13,9 +13,11 @@ use solx_mlir::ods::sol::AddOperation;
 use solx_mlir::ods::sol::AndOperation;
 use solx_mlir::ods::sol::CAddOperation;
 use solx_mlir::ods::sol::CDivOperation;
+use solx_mlir::ods::sol::CExpOperation;
 use solx_mlir::ods::sol::CMulOperation;
 use solx_mlir::ods::sol::CSubOperation;
 use solx_mlir::ods::sol::DivOperation;
+use solx_mlir::ods::sol::ExpOperation;
 use solx_mlir::ods::sol::ModOperation;
 use solx_mlir::ods::sol::MulOperation;
 use solx_mlir::ods::sol::OrOperation;
@@ -38,6 +40,8 @@ pub enum Operator {
     Divide,
     /// `%`
     Remainder,
+    /// `**`
+    Exponentiation,
 
     // ---- Arithmetic assignment ----
     /// `+=`
@@ -120,7 +124,7 @@ impl Operator {
     /// Builds a Sol dialect binary operation via ODS-generated builders.
     ///
     /// When `checked` is true, uses checked variants (`sol.cadd`, `sol.csub`,
-    /// `sol.cmul`, `sol.cdiv`) for arithmetic operators. Modulo, bitwise,
+    /// `sol.cmul`, `sol.cdiv`, `sol.cexp`) for arithmetic operators. Modulo, bitwise,
     /// and shift operators are always unchecked. Result type is inferred
     /// from `lhs` (`SameOperandsAndResultType`).
     ///
@@ -179,6 +183,16 @@ impl Operator {
                 .build()
                 .into(),
             Self::Remainder => ModOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Exponentiation if checked => CExpOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Exponentiation => ExpOperation::builder(context, location)
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()
@@ -242,6 +256,7 @@ impl FromStr for Operator {
             "*" => Ok(Self::Multiply),
             "/" => Ok(Self::Divide),
             "%" => Ok(Self::Remainder),
+            "**" => Ok(Self::Exponentiation),
             "+=" => Ok(Self::AddAssign),
             "-=" => Ok(Self::SubtractAssign),
             "*=" => Ok(Self::MultiplyAssign),

--- a/solx-slang/src/ast/contract/function/expression/storage.rs
+++ b/solx-slang/src/ast/contract/function/expression/storage.rs
@@ -15,7 +15,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         block: &BlockRef<'context, 'block>,
     ) -> anyhow::Result<Value<'context, 'block>> {
         let pointer = self.emit_storage_addr_of(slot, block);
-        let ui256 = self.state.builder.get_type(solx_mlir::Builder::UI256);
+        let ui256 = self.state.builder.types.ui256;
         self.state.builder.emit_sol_load(pointer, ui256, block)
     }
 
@@ -36,10 +36,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         slot: u64,
         block: &BlockRef<'context, 'block>,
     ) -> Value<'context, 'block> {
-        let storage_pointer_type = self
-            .state
-            .builder
-            .get_type(solx_mlir::Builder::SOL_PTR_STORAGE);
+        let storage_pointer_type = self.state.builder.types.sol_ptr_storage;
         self.state
             .builder
             .emit_sol_addr_of(&format!("slot_{slot}"), storage_pointer_type, block)

--- a/solx-slang/src/ast/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/ast/contract/function/statement/control_flow.rs
@@ -134,7 +134,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                     .emit_sol_condition(condition_boolean, &condition_end);
             }
             ForStatementCondition::Semicolon => {
-                let i1_type = self.state.builder.get_type(solx_mlir::Builder::I1);
+                let i1_type = self.state.builder.types.i1;
                 let true_val = self
                     .state
                     .builder

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -187,7 +187,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                     &self.state.builder,
                 )
             })
-            .unwrap_or_else(|| self.state.builder.get_type(solx_mlir::Builder::UI256));
+            .unwrap_or_else(|| self.state.builder.types.ui256);
 
         let emitter = ExpressionEmitter::new(
             &self.semantic,
@@ -271,7 +271,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 .return_types
                 .first()
                 .copied()
-                .unwrap_or_else(|| self.state.builder.get_type(solx_mlir::Builder::UI256));
+                .unwrap_or_else(|| self.state.builder.types.ui256);
             let return_value = self.state.builder.emit_sol_cast(value, return_type, &block);
             self.state.builder.emit_sol_return(&[return_value], &block);
         } else {


### PR DESCRIPTION
Unifies the type logic by moving all constructors and cached types to a single module.

Replaces a HashMap with a static data structure.