### PR TITLE
feat(slang): add checked exponentiation

### DIFF
--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -12,7 +12,6 @@ pub mod storage;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -26,7 +25,6 @@ use slang_solidity::cst::NodeId;
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
 use solx_mlir::Environment;
-use solx_mlir::ods::sol::ExpOperation;
 
 use self::call::type_conversion::TypeConversion;
 
@@ -185,6 +183,13 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 self.emit_binary_op(&left, &right, &operator.text, result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
+            Expression::ExponentiationExpression(expression) => {
+                let target_type = self.resolve_expression_type(expression.node_id());
+                let left = expression.left_operand();
+                let right = expression.right_operand();
+                self.emit_binary_op(&left, &right, "**", target_type, block)
+                    .map(|(value, block)| (Some(value), block))
+            }
             Expression::EqualityExpression(expression) => {
                 let left = expression.left_operand();
                 let right = expression.right_operand();
@@ -271,40 +276,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .expression()
                     .ok_or_else(|| anyhow::anyhow!("empty tuple element"))?;
                 self.emit(&inner, block)
-            }
-            Expression::ExponentiationExpression(expression) => {
-                // TODO: implement checked exponentiation (sol.cexp) for Solidity 0.8+.
-                let target_type = self.resolve_expression_type(expression.node_id());
-                let left = expression.left_operand();
-                let right = expression.right_operand();
-                let (lhs, block) = self.emit_value(&left, block)?;
-                let (rhs, block) = self.emit_value(&right, block)?;
-                let result_type = target_type.unwrap_or_else(|| self.state.builder.types.ui256);
-                let lhs = TypeConversion::from_target_type(result_type, &self.state.builder).emit(
-                    lhs,
-                    &self.state.builder,
-                    &block,
-                );
-                let rhs = TypeConversion::from_target_type(result_type, &self.state.builder).emit(
-                    rhs,
-                    &self.state.builder,
-                    &block,
-                );
-                let result = block
-                    .append_operation(
-                        ExpOperation::builder(
-                            self.state.builder.context,
-                            self.state.builder.unknown_location,
-                        )
-                        .lhs(lhs)
-                        .rhs(rhs)
-                        .build()
-                        .into(),
-                    )
-                    .result(0)
-                    .expect("sol.exp always produces one result")
-                    .into();
-                Ok((Some(result), block))
             }
             Expression::ConditionalExpression(conditional) => {
                 let result_type = self

--- a/solx-slang/src/ast/contract/function/expression/operator.rs
+++ b/solx-slang/src/ast/contract/function/expression/operator.rs
@@ -13,9 +13,11 @@ use solx_mlir::ods::sol::AddOperation;
 use solx_mlir::ods::sol::AndOperation;
 use solx_mlir::ods::sol::CAddOperation;
 use solx_mlir::ods::sol::CDivOperation;
+use solx_mlir::ods::sol::CExpOperation;
 use solx_mlir::ods::sol::CMulOperation;
 use solx_mlir::ods::sol::CSubOperation;
 use solx_mlir::ods::sol::DivOperation;
+use solx_mlir::ods::sol::ExpOperation;
 use solx_mlir::ods::sol::ModOperation;
 use solx_mlir::ods::sol::MulOperation;
 use solx_mlir::ods::sol::OrOperation;
@@ -38,6 +40,8 @@ pub enum Operator {
     Divide,
     /// `%`
     Remainder,
+    /// `**`
+    Exponentiation,
 
     // ---- Arithmetic assignment ----
     /// `+=`
@@ -120,7 +124,7 @@ impl Operator {
     /// Builds a Sol dialect binary operation via ODS-generated builders.
     ///
     /// When `checked` is true, uses checked variants (`sol.cadd`, `sol.csub`,
-    /// `sol.cmul`, `sol.cdiv`) for arithmetic operators. Modulo, bitwise,
+    /// `sol.cmul`, `sol.cdiv`, `sol.cexp`) for arithmetic operators. Modulo, bitwise,
     /// and shift operators are always unchecked. Result type is inferred
     /// from `lhs` (`SameOperandsAndResultType`).
     ///
@@ -179,6 +183,16 @@ impl Operator {
                 .build()
                 .into(),
             Self::Remainder => ModOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Exponentiation if checked => CExpOperation::builder(context, location)
+                .lhs(lhs)
+                .rhs(rhs)
+                .build()
+                .into(),
+            Self::Exponentiation => ExpOperation::builder(context, location)
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()
@@ -242,6 +256,7 @@ impl FromStr for Operator {
             "*" => Ok(Self::Multiply),
             "/" => Ok(Self::Divide),
             "%" => Ok(Self::Remainder),
+            "**" => Ok(Self::Exponentiation),
             "+=" => Ok(Self::AddAssign),
             "-=" => Ok(Self::SubtractAssign),
             "*=" => Ok(Self::MultiplyAssign),


### PR DESCRIPTION
Add checked exponentiation support by routing `ExponentiationExpression` through `emit_binary_op` and the `Operator` enum.

In checked mode, exponentiation now emits `sol.cexp`; in unchecked blocks it emits `sol.exp`.

Newly passing tests (12 cases across 4 files):

- `tests/solidity/simple/operator/arithmetic/exponentiation_u8.sol`
- `tests/solidity/simple/operator/arithmetic/exponentiation_u8_const.sol`
- `tests/solidity/simple/operator/arithmetic/exponentiation_i8.sol`
- `tests/solidity/simple/operator/arithmetic/exponentiation_i128_const.sol`