### PR TITLE
feat(slang): add assert built-in

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -34,6 +34,7 @@ use crate::context::builder::type_factory::TypeFactory;
 use crate::ods::sol::AddrOfOperation;
 use crate::ods::sol::AddressCastOperation;
 use crate::ods::sol::AllocaOperation;
+use crate::ods::sol::AssertOperation;
 use crate::ods::sol::BreakOperation;
 use crate::ods::sol::CallOperation;
 use crate::ods::sol::CastOperation;
@@ -299,6 +300,24 @@ impl<'context> Builder<'context> {
             RevertOperation::builder(self.context, self.unknown_location)
                 .signature(StringAttribute::new(self.context, ""))
                 .args(&[])
+                .build()
+                .into(),
+        );
+    }
+
+    /// Emits a `sol.assert` panic if the condition is false.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MLIR operation cannot be constructed, indicating a bug in the builder.
+    pub fn emit_sol_assert<'block, B>(&self, condition: Value<'context, 'block>, block: &B)
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block.append_operation(
+            AssertOperation::builder(self.context, self.unknown_location)
+                .cond(condition)
                 .build()
                 .into(),
         );

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -33,6 +33,9 @@ pub struct CallEmitter<'emitter, 'state, 'context, 'block> {
 }
 
 impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context, 'block> {
+    /// Solidity built-in `assert()` function name.
+    const ASSERT: &'static str = "assert";
+
     /// Solidity built-in `require()` function name.
     const REQUIRE: &'static str = "require";
 
@@ -105,6 +108,16 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 .next()
                 .expect("length checked above");
             let block = self.emit_require(&first, block)?;
+            return Ok((None, block));
+        }
+
+        // Handle assert() built-in.
+        if callee_name == Self::ASSERT && positional_arguments.len() == 1 {
+            let first = positional_arguments
+                .iter()
+                .next()
+                .expect("length checked above");
+            let block = self.emit_assert(&first, block)?;
             return Ok((None, block));
         }
 
@@ -210,6 +223,23 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             .expect("intrinsic always produces one result")
             .into();
         Ok((value, block))
+    }
+
+    /// Emits an `assert(condition)` built-in via `sol.assert`.
+    fn emit_assert(
+        &self,
+        condition: &Expression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<BlockRef<'context, 'block>> {
+        let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
+        let condition_boolean = self
+            .expression_emitter
+            .emit_is_nonzero(condition_value, &block);
+        self.expression_emitter
+            .state
+            .builder
+            .emit_sol_assert(condition_boolean, &block);
+        Ok(block)
     }
 
     /// Emits a `require(condition)` built-in via `sol.require`.


### PR DESCRIPTION
Wire up `assert(condition)` as a built-in function dispatch in `CallEmitter`.

Previously, `assert()` calls fell through to `resolve_function` and failed with "undefined function: assert".

Newly passing tests:

- `tests/solidity/simple/fuzzed/boolean_assert.sol`
- `tests/solidity/simple/fuzzed/boolean_assert1.sol`