### PR TITLE
feat(slang): encode require string literal message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "metaslang_bindings"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a01bc76b742173941cea1aff0b3b68a9006b38b8#a01bc76b742173941cea1aff0b3b68a9006b38b8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -2589,9 +2589,9 @@ dependencies = [
 [[package]]
 name = "metaslang_cst"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a01bc76b742173941cea1aff0b3b68a9006b38b8#a01bc76b742173941cea1aff0b3b68a9006b38b8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
 dependencies = [
- "nom",
+ "nom 8.0.0",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "metaslang_graph_builder"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a01bc76b742173941cea1aff0b3b68a9006b38b8#a01bc76b742173941cea1aff0b3b68a9006b38b8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -2613,14 +2613,14 @@ dependencies = [
 [[package]]
 name = "metaslang_stack_graphs"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a01bc76b742173941cea1aff0b3b68a9006b38b8#a01bc76b742173941cea1aff0b3b68a9006b38b8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
 dependencies = [
  "bitvec",
  "controlled-option",
  "either",
  "enumset",
  "fxhash",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "libc",
  "lsp-positions",
  "smallvec",
@@ -2697,6 +2697,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4273,7 +4282,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a01bc76b742173941cea1aff0b3b68a9006b38b8#a01bc76b742173941cea1aff0b3b68a9006b38b8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
 dependencies = [
  "indexmap 2.14.0",
  "metaslang_bindings",
@@ -4283,9 +4292,8 @@ dependencies = [
  "paste",
  "semver 1.0.28",
  "serde",
- "sha3 0.10.8",
+ "sha3 0.11.0",
  "strum",
- "strum_macros",
  "thiserror 2.0.18",
 ]
 
@@ -4601,20 +4609,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.117",
 ]
 

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -69,4 +69,11 @@ MlirType solxCreateContractType(MlirContext ctx, const char *name_ptr,
     return wrap(mlir::sol::ContractType::get(context, name, payable));
 }
 
+MlirType solxCreateStringType(MlirContext ctx, uint32_t dataLocation) {
+    if (dataLocation > 5) abort();
+    auto *context = unwrap(ctx);
+    auto location = static_cast<mlir::sol::DataLocation>(dataLocation);
+    return wrap(mlir::sol::StringType::get(context, location));
+}
+
 } /* extern "C" */

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -53,6 +53,7 @@ use crate::ods::sol::ReturnOperation;
 use crate::ods::sol::RevertOperation;
 use crate::ods::sol::StateVarOperation;
 use crate::ods::sol::StoreOperation;
+use crate::ods::sol::StringLitOperation;
 use crate::ods::sol::WhileOperation;
 use crate::ods::sol::YieldOperation;
 
@@ -311,6 +312,31 @@ impl<'context> Builder<'context> {
             .into()
     }
 
+    // ==== String literals ====
+
+    /// Emits a `sol.string_lit` constant with a `!sol.string<Memory>` result.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MLIR operation cannot be constructed, indicating a bug in the builder.
+    pub fn emit_sol_string_lit<'block, B>(&self, value: &str, block: &B) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block
+            .append_operation(
+                StringLitOperation::builder(self.context, self.unknown_location)
+                    .value(StringAttribute::new(self.context, value))
+                    .addr(self.types.sol_string_memory)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.string_lit always produces one result")
+            .into()
+    }
+
     // ==== Terminators ====
 
     /// Emits a `sol.revert` with an empty signature (no error data).
@@ -352,27 +378,31 @@ impl<'context> Builder<'context> {
         );
     }
 
-    /// Emits a `sol.require` conditional revert with an empty signature.
+    /// Emits a `sol.require` conditional revert with an optional message.
     ///
-    /// Reverts if `condition` is false. Not a terminator — execution continues
-    /// after this op when the condition is true.
+    /// Reverts if `condition` is false. When `msg` is `Some`, the revert
+    /// includes the string as a revert reason. Not a terminator — execution
+    /// continues after this op when the condition is true.
     ///
     /// # Panics
     ///
     /// Panics if the MLIR operation cannot be constructed, indicating a bug in the builder.
-    pub fn emit_sol_require<'block, B>(&self, condition: Value<'context, 'block>, block: &B)
-    where
+    pub fn emit_sol_require<'block, B>(
+        &self,
+        condition: Value<'context, 'block>,
+        msg: Option<&str>,
+        block: &B,
+    ) where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        block.append_operation(
-            RequireOperation::builder(self.context, self.unknown_location)
-                .cond(condition)
-                .msg(StringAttribute::new(self.context, ""))
-                .args(&[])
-                .build()
-                .into(),
-        );
+        let mut builder = RequireOperation::builder(self.context, self.unknown_location)
+            .cond(condition)
+            .args(&[]);
+        if let Some(msg) = msg {
+            builder = builder.msg(StringAttribute::new(self.context, msg));
+        }
+        block.append_operation(builder.build().into());
     }
 
     /// Emits a `sol.return` terminator.

--- a/solx-mlir/src/context/builder/type_factory.rs
+++ b/solx-mlir/src/context/builder/type_factory.rs
@@ -26,6 +26,8 @@ pub struct TypeFactory<'context> {
     pub sol_address: Type<'context>,
     /// Sol storage pointer type (`!sol.ptr<ui256, Storage>`).
     pub sol_ptr_storage: Type<'context>,
+    /// Sol memory string type (`!sol.string<Memory>`).
+    pub sol_string_memory: Type<'context>,
 }
 
 impl<'context> TypeFactory<'context> {
@@ -59,6 +61,14 @@ impl<'context> TypeFactory<'context> {
                 solx_utils::DataLocation::Storage as u32,
             ))
         };
+        // SAFETY: `solxCreateStringType` returns a valid MlirType from
+        // the C++ Sol dialect. The context pointer is valid.
+        let sol_string_memory = unsafe {
+            Type::from_raw(crate::ffi::solxCreateStringType(
+                context.to_raw(),
+                solx_utils::DataLocation::Memory as u32,
+            ))
+        };
         Self {
             context,
             i1,
@@ -66,6 +76,7 @@ impl<'context> TypeFactory<'context> {
             ui256,
             sol_address,
             sol_ptr_storage,
+            sol_string_memory,
         }
     }
 

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -104,6 +104,12 @@ unsafe extern "C" {
         payable: bool,
     ) -> mlir_sys::MlirType;
 
+    /// Creates a `sol::StringType` with the given data location.
+    ///
+    /// `data_location` maps to `mlir::sol::DataLocation` (0=Storage, 1=CallData,
+    /// 2=Memory, 3=Stack, 4=Immutable, 5=Transient).
+    pub fn solxCreateStringType(context: MlirContext, data_location: u32) -> mlir_sys::MlirType;
+
     // ---- MLIR core (not in mlir-sys) ----
 
     /// Returns the region that owns the given block.

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -16,7 +16,7 @@ semver.workspace = true
 # `__private_testing_utils` is required by `__private_backend_api` internals
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 # TODO: pin to a release tag instead of branch = "main"
-slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "a01bc76b742173941cea1aff0b3b68a9006b38b8", features = ["__private_backend_api", "__private_testing_utils"] }
+slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "6f892dff8e2d6d275cfe9737c3cb364486c41410", features = ["__private_backend_api", "__private_testing_utils"] }
 melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -132,7 +132,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .state
                     .builder
                     .emit_sol_cmp(value, zero, CmpPredicate::Eq, &block);
-                let result_type = target_type.unwrap_or_else(|| self.state.builder.types.ui256);
+                let result_type = target_type.unwrap_or(self.state.builder.types.ui256);
                 let result = TypeConversion::from_target_type(result_type, &self.state.builder)
                     .emit(cmp, &self.state.builder, &block);
                 Ok((result, block))

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -102,12 +102,18 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             && (positional_arguments.len() == 1
                 || positional_arguments.len() == Self::MAX_REQUIRE_ARGUMENTS)
         {
-            // TODO: encode revert reason from second argument
-            let first = positional_arguments
-                .iter()
-                .next()
-                .expect("length checked above");
-            let block = self.emit_require(&first, block)?;
+            let mut args = positional_arguments.iter();
+            let condition = args.next().expect("length checked above");
+            let message_arg = args.next();
+            let message = match &message_arg {
+                Some(Expression::StringExpression(string_expression)) => {
+                    let bytes = string_expression.value();
+                    Some(String::from_utf8(bytes).expect("require message is valid UTF-8"))
+                }
+                Some(_) => anyhow::bail!("require message must be a string literal"),
+                None => None,
+            };
+            let block = self.emit_require(&condition, message.as_deref(), block)?;
             return Ok((None, block));
         }
 
@@ -242,10 +248,12 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         Ok(block)
     }
 
-    /// Emits a `require(condition)` built-in via `sol.require`.
+    /// Emits a `require(condition)` or `require(condition, "message")` built-in
+    /// via `sol.require`.
     fn emit_require(
         &self,
         condition: &Expression,
+        message: Option<&str>,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<BlockRef<'context, 'block>> {
         let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
@@ -256,7 +264,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         self.expression_emitter
             .state
             .builder
-            .emit_sol_require(condition_boolean, &block);
+            .emit_sol_require(condition_boolean, message, &block);
 
         Ok(block)
     }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -154,6 +154,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .into();
                 Ok((Some(value), block))
             }
+            Expression::StringExpression(string_expression) => {
+                let bytes = string_expression.value();
+                let text = std::str::from_utf8(&bytes).expect("string literal is valid UTF-8");
+                let value = self.state.builder.emit_sol_string_lit(text, &block);
+                Ok((Some(value), block))
+            }
             Expression::Identifier(identifier) => {
                 let name = identifier.name();
                 match identifier.resolve_to_definition() {
@@ -302,7 +308,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             Expression::ConditionalExpression(conditional) => {
                 let result_type = self
                     .resolve_expression_type(conditional.node_id())
-                    .unwrap_or_else(|| self.state.builder.types.ui256);
+                    .unwrap_or(self.state.builder.types.ui256);
                 let condition = conditional.operand();
                 let (condition_value, block) = self.emit_value(&condition, block)?;
                 let condition_boolean = self.emit_is_nonzero(condition_value, &block);

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -265,7 +265,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 .return_types
                 .first()
                 .copied()
-                .unwrap_or_else(|| self.state.builder.types.ui256);
+                .unwrap_or(self.state.builder.types.ui256);
             let return_value = self.state.builder.emit_sol_cast(value, return_type, &block);
             self.state.builder.emit_sol_return(&[return_value], &block);
         } else {


### PR DESCRIPTION
Extract the string literal from the second argument of `require(cond, "msg")` and pass it into `sol.require`'s `msg` attribute. Previously the message was always hardcoded to an empty string, causing require reverts to lose the error reason.

Newly passing tests:

- `tests/solidity/simple/conditional/require.sol` (all)