### PR TITLE
feat(slang): cast function call arguments to match parameter types

### DIFF
--- a/solx-mlir/src/context/function.rs
+++ b/solx-mlir/src/context/function.rs
@@ -9,8 +9,8 @@ use melior::ir::Type;
 pub struct Function<'context> {
     /// The mangled MLIR function name.
     pub mlir_name: String,
-    /// Number of parameters.
-    pub parameter_count: usize,
+    /// Parameter types (MLIR-interned, exact types from the function signature).
+    pub parameter_types: Vec<Type<'context>>,
     /// Return types (MLIR-interned, exact types from the function signature).
     pub return_types: Vec<Type<'context>>,
 }
@@ -19,12 +19,12 @@ impl<'context> Function<'context> {
     /// Creates a new function metadata entry.
     pub fn new(
         mlir_name: String,
-        parameter_count: usize,
+        parameter_types: Vec<Type<'context>>,
         return_types: Vec<Type<'context>>,
     ) -> Self {
         Self {
             mlir_name,
-            parameter_count,
+            parameter_types,
             return_types,
         }
     }

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -171,52 +171,47 @@ impl<'context> Context<'context> {
     /// Registers a function signature for call resolution.
     pub fn register_function_signature(
         &mut self,
-        bare_name: &str,
+        base_name: &str,
         mlir_name: String,
-        parameter_count: usize,
+        parameter_types: Vec<Type<'context>>,
         return_types: Vec<Type<'context>>,
     ) {
         self.function_signatures
-            .entry(bare_name.to_owned())
+            .entry(base_name.to_owned())
             .or_default()
-            .push(Function::new(mlir_name, parameter_count, return_types));
+            .push(Function::new(mlir_name, parameter_types, return_types));
     }
 
     /// Resolves a function call by bare name and argument count.
     ///
-    /// Returns the mangled MLIR name and the declared return types.
+    /// Returns the mangled MLIR name, declared parameter types, and return
+    /// types.
     ///
     /// # Errors
     ///
     /// Returns an error if the function is undefined or the call is ambiguous.
     pub fn resolve_function(
         &self,
-        bare_name: &str,
-        argument_count: usize,
-    ) -> anyhow::Result<(&str, &[Type<'context>])> {
+        base_name: &str,
+        argument_types: &[Type<'context>],
+    ) -> anyhow::Result<(&str, &[Type<'context>], &[Type<'context>])> {
         let signatures = self
             .function_signatures
-            .get(bare_name)
-            .ok_or_else(|| anyhow::anyhow!("undefined function: {bare_name}"))?;
-        // TODO: resolve overloads by parameter types, not just arity
-        let matches: Vec<_> = signatures
+            .get(base_name)
+            .ok_or_else(|| anyhow::anyhow!("undefined function: {base_name}"))?;
+        let matched = signatures
             .iter()
-            .filter(|signature| signature.parameter_count == argument_count)
-            .collect();
-        match matches.len() {
-            0 => anyhow::bail!("no overload of '{bare_name}' takes {argument_count} arguments"),
-            1 => Ok((matches[0].mlir_name.as_str(), &matches[0].return_types)),
-            _ => {
-                let overloads: Vec<&str> = matches
-                    .iter()
-                    .map(|signature| signature.mlir_name.as_str())
-                    .collect();
-                anyhow::bail!(
-                    "ambiguous call to '{bare_name}' with {argument_count} arguments: {}",
-                    overloads.join(", ")
+            .find(|signature| signature.parameter_types == argument_types)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no matching overload of '{base_name}' for the given argument types"
                 )
-            }
-        }
+            })?;
+        Ok((
+            matched.mlir_name.as_str(),
+            &matched.parameter_types,
+            &matched.return_types,
+        ))
     }
 
     // ==== Phase 3: Sol pass pipeline ====

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -7,6 +7,7 @@ pub mod type_conversion;
 
 use melior::ir::BlockRef;
 use melior::ir::Value;
+use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::FunctionCallExpression;
@@ -93,10 +94,19 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             current_block = next_block;
         }
 
-        let (mlir_name, return_types) = self
+        let argument_types: Vec<melior::ir::Type<'context>> =
+            argument_values.iter().map(|value| value.r#type()).collect();
+        let (mlir_name, parameter_types, return_types) = self
             .expression_emitter
             .state
-            .resolve_function(&callee_name, argument_values.len())?;
+            .resolve_function(&callee_name, &argument_types)?;
+
+        // Cast arguments to match the callee's declared parameter types.
+        let builder = &self.expression_emitter.state.builder;
+        for (value, &param_type) in argument_values.iter_mut().zip(parameter_types) {
+            let conversion = TypeConversion::from_target_type(param_type, builder);
+            *value = conversion.emit(*value, builder, &current_block);
+        }
 
         if return_types.is_empty() {
             self.expression_emitter.state.builder.emit_sol_call(

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -5,7 +5,9 @@
 use melior::ir::Type;
 use melior::ir::ValueLike;
 use melior::ir::r#type::IntegerType;
+use slang_solidity::backend::ir::ast::FunctionDefinition;
 use slang_solidity::backend::ir::ast::LiteralKind;
+use slang_solidity::backend::ir::ast::Parameter;
 use slang_solidity::backend::ir::ast::StateVariableDefinition;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 
@@ -99,6 +101,27 @@ impl<'context> TypeConversion<'context> {
             .get_type()
             .ok_or_else(|| anyhow::anyhow!("unresolved type for state variable: {name}"))?;
         Ok(Self::resolve_slang_type(&slang_type, builder))
+    }
+
+    /// Resolves a function's parameter and return types from Slang AST to MLIR.
+    pub fn resolve_function_types(
+        function: &FunctionDefinition,
+        builder: &solx_mlir::Builder<'context>,
+    ) -> (Vec<Type<'context>>, Vec<Type<'context>>) {
+        let resolve = |parameter: Parameter| {
+            Self::resolve_slang_type(
+                &parameter
+                    .get_type()
+                    .expect("parameter type resolved by semantic analysis"),
+                builder,
+            )
+        };
+        let parameter_types = function.parameters().iter().map(&resolve).collect();
+        let return_types = function
+            .returns()
+            .map(|returns| returns.iter().map(&resolve).collect())
+            .unwrap_or_default();
+        (parameter_types, return_types)
     }
 
     /// Emits the conversion, returning the cast value.

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -74,29 +74,8 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
         let parameters = function.parameters();
         let mlir_name = Self::mlir_function_name(function);
 
-        let mlir_parameter_types: Vec<Type<'context>> = parameters
-            .iter()
-            .map(|param| {
-                TypeConversion::resolve_slang_type(
-                    &param.get_type().expect("parameter type binding resolved"),
-                    &self.state.builder,
-                )
-            })
-            .collect();
-        let result_types: Vec<Type<'context>> = function
-            .returns()
-            .map(|returns| {
-                returns
-                    .iter()
-                    .map(|param| {
-                        TypeConversion::resolve_slang_type(
-                            &param.get_type().expect("return type binding resolved"),
-                            &self.state.builder,
-                        )
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let (mlir_parameter_types, result_types) =
+            TypeConversion::resolve_function_types(function, &self.state.builder);
 
         let selector = function.compute_selector();
 

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -117,24 +117,11 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
             }
             let name = FunctionEmitter::mlir_base_name(&function);
             let mlir_name = FunctionEmitter::mlir_function_name(&function);
-            let parameter_count = function.parameters().len();
-            let return_types: Vec<melior::ir::Type<'_>> = function
-                .returns()
-                .map(|returns| {
-                    returns
-                        .iter()
-                        .map(|param| {
-                            TypeConversion::resolve_slang_type(
-                                &param.get_type().expect("return type binding resolved"),
-                                &self.state.builder,
-                            )
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
+            let (parameter_types, return_types) =
+                TypeConversion::resolve_function_types(&function, &self.state.builder);
 
             self.state
-                .register_function_signature(&name, mlir_name, parameter_count, return_types);
+                .register_function_signature(&name, mlir_name, parameter_types, return_types);
         }
     }
 


### PR DESCRIPTION
Store declared parameter types in function signatures and emit `sol.cast` for each argument whose type differs from the callee's declared parameter type. This matches the C++ reference behavior where `genRValExpr` receives a target type and casts accordingly.

Also cleans up inline `melior::` fully-qualified paths across solx-slang by adding proper `use` imports for `Context`, `BlockRef`, `Value`, `Block`, `Region`, and `IntegerType`.