### PR TITLE
fix(mlir): update CallOp builder for $results -> $outs rename

### DIFF
--- a/solx-mlir/src/context/builder.rs
+++ b/solx-mlir/src/context/builder.rs
@@ -890,7 +890,7 @@ impl<'context> Builder<'context> {
             CallOperation::builder(self.context, self.unknown_location)
                 .callee(FlatSymbolRefAttribute::new(self.context, callee))
                 .operands(operands)
-                .results(result_types)
+                .outs(result_types)
                 .build()
                 .into(),
         );


### PR DESCRIPTION
Update `CallOperation` builder call from `.results()` to `.outs()` to match the upstream Sol dialect rename of `$results` to `$outs` (solx-llvm commit 51eee2bce35f).