### PR TITLE
ci(sfw): pin sfw-free to v1.6.1 in container path

### DIFF
--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -43,10 +43,42 @@ runs:
 
         echo "method=action" >> "$GITHUB_OUTPUT"
 
+    # Temporary pin: the `sfw` npm wrapper (2.0.4) hardcodes GitHub
+    # `releases/latest` for its binary download and has no pin env var.
+    # sfw-free v1.7.2 (2026-04-21) started MITM'ing git-over-HTTPS, but the
+    # container path below doesn't install SFW's CA, so `cargo fetch` fails
+    # on git dependencies with `unable to get local issuer certificate`.
+    # Installing the v1.6.1 binary directly as `/usr/local/bin/sfw` keeps
+    # SFW_PREFIX=sfw working unchanged. Unpin once the container path
+    # installs the SFW CA (see companion PR) or Socket addresses the
+    # regression upstream.
     - name: Install SFW (container)
       if: steps.detect.outputs.method == 'npm'
       shell: bash
-      run: npm install -g sfw@2.0.4
+      run: |
+        set -euo pipefail
+        SFW_TAG="v1.6.1"
+        case "$(uname -m)" in
+          x86_64)
+            ASSET="sfw-free-linux-x86_64"
+            SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff"
+            ;;
+          aarch64|arm64)
+            ASSET="sfw-free-linux-arm64"
+            SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1"
+            ;;
+          *)
+            echo "::error::Unsupported arch for pinned sfw-free: $(uname -m)"
+            exit 1
+            ;;
+        esac
+        URL="https://github.com/SocketDev/sfw-free/releases/download/${SFW_TAG}/${ASSET}"
+        TMP="$(mktemp)"
+        curl --proto '=https' --tlsv1.2 -fsSL -o "$TMP" "$URL"
+        echo "${SHA256}  ${TMP}" | sha256sum -c -
+        install -m 0755 "$TMP" /usr/local/bin/sfw
+        rm -f "$TMP"
+        echo "Pinned sfw-free ${SFW_TAG} (${ASSET}) installed at /usr/local/bin/sfw"
 
     - name: Install SFW
       if: steps.detect.outputs.method == 'action'


### PR DESCRIPTION
Proper fix now ready, and actually easier in the end: https://github.com/NomicFoundation/solx/pull/357

## Summary

Unblock the merge queue: `cargo fetch --locked` in the `cargo-checks` job (and other container-based jobs that wrap cargo with `sfw`) is failing with `SSL peer certificate ... unable to get local issuer certificate` when cargo clones git dependencies (`NomicFoundation/inkwell`). Example failure: https://github.com/NomicFoundation/solx/actions/runs/24712293319/job/72279723658.

## Root cause

The `sfw@2.0.4` npm wrapper hardcodes `https://api.github.com/repos/SocketDev/sfw-free/releases/latest` for its binary download (see `SocketDev/sfw-installer` `src/github.ts`) and has no pin env var. Container jobs silently picked up **sfw-free v1.7.2** (published 2026-04-21 06:40 UTC), which started MITM'ing git-over-HTTPS.

The container branch of `setup-sfw/action.yml` doesn't install SFW's CA (the `Configure cargo TLS trust for SFW` step is gated to `method == 'action'`, i.e. bare-metal Linux only). So libgit2 rejects the intercepted TLS for `github.com` git clones.

Timeline:
- 2026-04-21 04:02 UTC — last green `cargo-checks` run; sfw-free **v1.6.1** (2026-03-02) in cache.
- 2026-04-21 06:40 UTC — Socket publishes **sfw-free v1.7.2**.
- 2026-04-21 07:21 UTC+ — merge-queue runs start failing on the same code.

## Change

Replace `npm install -g sfw@2.0.4` in the container path with a direct, sha256-verified download of `sfw-free-linux-{x86_64,arm64}` from `v1.6.1`, installed as `/usr/local/bin/sfw` so `SFW_PREFIX=sfw` works unchanged. No call sites need to change.

## Follow-up (separate PR)

The durable fix is to install SFW's CA into the system trust store inside the container path of `setup-sfw` (and/or set `CARGO_HTTP_CAINFO`/`GIT_SSL_CAINFO`/`SSL_CERT_FILE` to a merged bundle). Once that lands, this pin can be removed.

## Test plan

- [x] `cargo-checks` job goes green (cargo fetch + cargo-deny + cargo check + udeps)
- [x] `build-and-test` Linux x86 and Linux ARM64 gnu jobs go green
- [x] Bare-metal Linux path (non-container jobs) is unaffected — still uses `socketdev/action@…` + CA trust step
- [x] macOS / Windows paths unchanged (setup-sfw skips them)