### PR TITLE
ci(sfw): install SFW CA in container path

### DIFF
--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -1,8 +1,11 @@
 name: Setup Socket Firewall (SFW)
 description: >
   Installs and configures Socket Firewall to monitor package installations.
-  On bare-metal Linux runners, installs via socketdev/action with MITM proxy
-  and CA cert trust. Inside containers, installs the sfw CLI via npm.
+  On bare-metal Linux runners, installs via socketdev/action with MITM
+  proxy. Inside containers, installs the sfw CLI via npm. In both cases,
+  discovers SFW's generated CA and exports a merged bundle via
+  CARGO_HTTP_CAINFO/GIT_SSL_CAINFO/SSL_CERT_FILE so cargo, git, and
+  rustls consumers trust the MITM cert.
   Skips on macOS/Windows where the MITM proxy is incompatible.
 
 inputs:
@@ -54,9 +57,15 @@ runs:
       with:
         mode: ${{ inputs.mode }}
 
+    # Runs for both the bare-metal (`action`) and container (`npm`) paths.
+    # In both cases the actual proxy is the sfw-free binary, which exposes
+    # its generated CA via NODE_EXTRA_CA_CERTS when it wraps a child process.
+    # Without this step, containers have no trust path for the MITM cert,
+    # so cargo git-dep clones (libgit2) fail with "unable to get local
+    # issuer certificate" whenever sfw-free intercepts github.com TLS.
     - name: Configure cargo TLS trust for SFW
       id: ca-cert
-      if: steps.detect.outputs.method == 'action'
+      if: steps.detect.outputs.method != 'none'
       shell: bash
       run: |
         # Trigger SFW cert generation (may be lazy)


### PR DESCRIPTION
## Summary

Durable fix for the SSL failure that #355 pins around.

The `Configure cargo TLS trust for SFW` step in `setup-sfw/action.yml` was gated to the bare-metal `action` install method, so container jobs (every job that uses `ghcr.io/nomicfoundation/solx-ci-runner`) had no trust path for SFW's MITM cert. That was tolerable while sfw-free passed `github.com` git traffic through, but sfw-free **v1.7.2** (2026-04-21 06:40 UTC) started intercepting it, and libgit2 now rejects the cert when cargo clones git dependencies (e.g. `NomicFoundation/inkwell`), breaking every container-based cargo job with `unable to get local issuer certificate`.

Example failure: https://github.com/NomicFoundation/solx/actions/runs/24712293319/job/72279723658.

## Change

Relax the step gate from `method == 'action'` to `method != 'none'` so the same `NODE_EXTRA_CA_CERTS` discovery + merged CA bundle + `CARGO_HTTP_CAINFO` / `GIT_SSL_CAINFO` / `SSL_CERT_FILE` export also runs in the container path. The actual proxy is the `sfw-free` binary in both cases, and it exposes its generated CA via `NODE_EXTRA_CA_CERTS` when it wraps a child process, so the existing discovery logic works unchanged.

If the CA can't be discovered in a container (sfw binary missing, `sfw node` script fails, etc.), the existing `ca-failed=true` fallback still short-circuits and disables SFW rather than producing opaque TLS errors.

## Relationship to #355

#355 is the quick-unblock: pin `sfw-free` to v1.6.1 in the container path so Socket's next release can't regress us again while we debug. This PR is the durable fix — if CI here passes, we can drop the pin.

## Test plan

- [x] `cargo-checks` (container) goes green — `cargo fetch --locked` succeeds against the inkwell git dep
- [x] `build-and-test` Linux x86 gnu (container) and Linux ARM64 gnu (container) go green
- [x] Bare-metal Linux path unchanged in behavior (same script runs, same env vars exported)
- [x] macOS / Windows unchanged — still hit the `method == 'none'` early-return in detect