### PR TITLE
fix(slang): use declared type for state variable storage operations

### DIFF
--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -192,12 +192,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .storage_layout
                     .get(&state_variable.node_id())
                     .ok_or_else(|| anyhow::anyhow!("unregistered state variable: {name}"))?;
-                let old = self.emit_storage_load(slot, block)?;
-                // TODO: use declared element type once state variable types are tracked.
-                // Currently hardcodes ui256, so `uint8 x = 255; x++` won't revert
-                // in checked mode because overflow is checked at 256-bit width.
-                let ui256 = self.state.builder.types.ui256;
-                let one = self.state.builder.emit_sol_constant(1, ui256, block);
+                let element_type = TypeConversion::resolve_state_variable_type(
+                    &state_variable,
+                    &self.state.builder,
+                )?;
+                let old = self.emit_storage_load(slot, element_type, block)?;
+                let one = self.state.builder.emit_sol_constant(1, element_type, block);
                 let new_value = block
                     .append_operation(operator.emit_sol_binary_operation(
                         self.checked,

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -19,8 +19,8 @@ use crate::ast::contract::function::expression::operator::Operator;
 enum AssignmentTarget<'context, 'block> {
     /// Local variable — alloca'd pointer and its declared element type.
     Local(Value<'context, 'block>, Type<'context>),
-    /// State variable — storage slot.
-    Storage(u64),
+    /// State variable — storage slot and declared element type.
+    Storage(u64, Type<'context>),
 }
 
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
@@ -42,7 +42,11 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .storage_layout
                     .get(&state_variable.node_id())
                     .ok_or_else(|| anyhow::anyhow!("unregistered state variable: {name}"))?;
-                AssignmentTarget::Storage(*slot)
+                let element_type = TypeConversion::resolve_state_variable_type(
+                    &state_variable,
+                    &self.state.builder,
+                )?;
+                AssignmentTarget::Storage(*slot, element_type)
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {
                 let (pointer, element_type) = self
@@ -69,9 +73,9 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                         .emit_sol_load(pointer, element_type, &block)?;
                     (old, element_type)
                 }
-                AssignmentTarget::Storage(slot) => {
-                    let old = self.emit_storage_load(slot, &block)?;
-                    (old, self.state.builder.types.ui256)
+                AssignmentTarget::Storage(slot, element_type) => {
+                    let old = self.emit_storage_load(slot, element_type, &block)?;
+                    (old, element_type)
                 }
             };
             let (rhs, block) = self.emit_value(&right, block)?;
@@ -112,11 +116,14 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .emit_sol_store(stored_value, pointer, &block);
                 stored_value
             }
-            AssignmentTarget::Storage(slot) => {
-                let ui256 = self.state.builder.types.ui256;
-                let stored_value = self.state.builder.emit_sol_cast(value, ui256, &block);
+            AssignmentTarget::Storage(slot, element_type) => {
+                let stored_value = TypeConversion::from_target_type(
+                    element_type,
+                    &self.state.builder,
+                )
+                .emit(value, &self.state.builder, &block);
                 self.emit_storage_store(slot, stored_value, &block);
-                value
+                stored_value
             }
         };
         Ok((result, block))

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -5,6 +5,7 @@
 use melior::ir::Type;
 use melior::ir::ValueLike;
 use melior::ir::r#type::IntegerType;
+use slang_solidity::backend::ir::ast::StateVariableDefinition;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 
 /// Classification of Solidity type conversions.
@@ -24,20 +25,19 @@ impl<'context> TypeConversion<'context> {
     /// Maps a Slang semantic type to an MLIR type.
     pub fn resolve_slang_type(
         slang_type: &SlangType,
-        context: &'context melior::Context,
         builder: &solx_mlir::Builder<'context>,
     ) -> Type<'context> {
         match slang_type {
             SlangType::Integer(integer_type) => {
                 let bits = integer_type.bits();
                 if integer_type.signed() {
-                    Type::from(IntegerType::signed(context, bits))
+                    Type::from(IntegerType::signed(builder.context, bits))
                 } else {
-                    Type::from(IntegerType::unsigned(context, bits))
+                    Type::from(IntegerType::unsigned(builder.context, bits))
                 }
             }
             SlangType::Boolean(_) => Type::from(IntegerType::new(
-                context,
+                builder.context,
                 solx_utils::BIT_LENGTH_BOOLEAN as u32,
             )),
             SlangType::Address(_) => builder.types.sol_address,
@@ -58,6 +58,18 @@ impl<'context> TypeConversion<'context> {
         } else {
             Self::Cast(target_type)
         }
+    }
+
+    /// Resolves the declared Solidity type of a state variable to an MLIR type.
+    pub fn resolve_state_variable_type(
+        state_variable: &StateVariableDefinition,
+        builder: &solx_mlir::Builder<'context>,
+    ) -> anyhow::Result<Type<'context>> {
+        let name = state_variable.name().name();
+        let slang_type = state_variable
+            .get_type()
+            .ok_or_else(|| anyhow::anyhow!("unresolved type for state variable: {name}"))?;
+        Ok(Self::resolve_slang_type(&slang_type, builder))
     }
 
     /// Emits the conversion, returning the cast value.

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -146,7 +146,11 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                             .ok_or_else(|| {
                                 anyhow::anyhow!("unregistered state variable: {name}")
                             })?;
-                        let value = self.emit_storage_load(*slot, &block)?;
+                        let element_type = TypeConversion::resolve_state_variable_type(
+                            &state_variable,
+                            &self.state.builder,
+                        )?;
+                        let value = self.emit_storage_load(*slot, element_type, &block)?;
                         Ok((Some(value), block))
                     }
                     Some(Definition::Variable(_) | Definition::Parameter(_)) => {
@@ -340,7 +344,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let slang_type = self.semantic.get_type_from_node_id(node_id)?;
         Some(TypeConversion::resolve_slang_type(
             &slang_type,
-            self.state.builder.context,
             &self.state.builder,
         ))
     }

--- a/solx-slang/src/ast/contract/function/expression/storage.rs
+++ b/solx-slang/src/ast/contract/function/expression/storage.rs
@@ -3,6 +3,7 @@
 //!
 
 use melior::ir::BlockRef;
+use melior::ir::Type;
 use melior::ir::Value;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
@@ -12,11 +13,13 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     pub fn emit_storage_load(
         &self,
         slot: u64,
+        element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) -> anyhow::Result<Value<'context, 'block>> {
         let pointer = self.emit_storage_addr_of(slot, block);
-        let ui256 = self.state.builder.types.ui256;
-        self.state.builder.emit_sol_load(pointer, ui256, block)
+        self.state
+            .builder
+            .emit_sol_load(pointer, element_type, block)
     }
 
     /// Emits a storage store via `sol.addr_of` + `sol.store`.

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -79,7 +79,6 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
             .map(|param| {
                 TypeConversion::resolve_slang_type(
                     &param.get_type().expect("parameter type binding resolved"),
-                    self.state.builder.context,
                     &self.state.builder,
                 )
             })
@@ -92,7 +91,6 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
                     .map(|param| {
                         TypeConversion::resolve_slang_type(
                             &param.get_type().expect("return type binding resolved"),
-                            self.state.builder.context,
                             &self.state.builder,
                         )
                     })

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -180,13 +180,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         let name = declaration.name().name();
         let declared_type = declaration
             .get_type()
-            .map(|slang_type| {
-                TypeConversion::resolve_slang_type(
-                    &slang_type,
-                    self.state.builder.context,
-                    &self.state.builder,
-                )
-            })
+            .map(|slang_type| TypeConversion::resolve_slang_type(&slang_type, &self.state.builder))
             .unwrap_or_else(|| self.state.builder.types.ui256);
 
         let emitter = ExpressionEmitter::new(

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -116,7 +116,6 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
                         .map(|param| {
                             TypeConversion::resolve_slang_type(
                                 &param.get_type().expect("return type binding resolved"),
-                                self.state.builder.context,
                                 &self.state.builder,
                             )
                         })


### PR DESCRIPTION
State variable loads, stores, increments, and compound assignments hardcoded ui256 instead of resolving the declared type from Slang's `StateVariableDefinition::get_type()`. This caused incorrect overflow behavior for smaller types — e.g. `uint8 x = 255; x++` would not revert in checked mode because the checked add operated at 256-bit width. The fix threads the resolved element type through `emit_storage_load` and `AssignmentTarget::Storage`, matching how local variables already work.