### PR TITLE
fix(slang): use arith.constant for i1 booleans

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -282,6 +282,35 @@ impl<'context> Builder<'context> {
         self.emit_sol_constant_from_hex_str(&all_ones_hex, integer_type, block)
     }
 
+    /// Emits an `arith.constant` for a signless `i1` boolean value.
+    ///
+    /// Boolean (`i1`) is signless in MLIR, so it uses `arith.constant`
+    /// instead of `sol.constant` (which is for signed/unsigned int types).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MLIR operation cannot be constructed.
+    pub fn emit_arith_constant_bool<'block, B>(
+        &self,
+        value: bool,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        let i1_type = IntegerType::new(self.context, solx_utils::BIT_LENGTH_BOOLEAN as u32).into();
+        block
+            .append_operation(melior::dialect::arith::constant(
+                self.context,
+                IntegerAttribute::new(i1_type, i64::from(value)).into(),
+                self.unknown_location,
+            ))
+            .result(0)
+            .expect("arith.constant always produces one result")
+            .into()
+    }
+
     // ==== Terminators ====
 
     /// Emits a `sol.revert` with an empty signature (no error data).

--- a/solx-slang/src/ast/contract/function/expression/logical.rs
+++ b/solx-slang/src/ast/contract/function/expression/logical.rs
@@ -67,12 +67,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
         let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
-        // TODO: solc uses `arith.constant false` here; consider switching to
-        // arith dialect for i1 constants to match solc output exactly.
-        let false_val = self.state.builder.emit_sol_constant(0, i1_type, &block);
+        let false_value = self.state.builder.emit_arith_constant_bool(false, &block);
         self.state
             .builder
-            .emit_sol_store(false_val, result_ptr, &block);
+            .emit_sol_store(false_value, result_ptr, &block);
 
         let (then_block, else_block) = self.state.builder.emit_sol_if(lhs_bool, &block);
 
@@ -113,10 +111,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
         let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
-        let true_val = self.state.builder.emit_sol_constant(1, i1_type, &block);
+        let true_value = self.state.builder.emit_arith_constant_bool(true, &block);
         self.state
             .builder
-            .emit_sol_store(true_val, result_ptr, &block);
+            .emit_sol_store(true_value, result_ptr, &block);
 
         let (then_block, else_block) = self.state.builder.emit_sol_if(lhs_bool, &block);
 

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -127,13 +127,11 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 Ok((Some(value), block))
             }
             Expression::TrueKeyword => {
-                let i1_type = self.state.builder.types.i1;
-                let value = self.state.builder.emit_sol_constant(1, i1_type, &block);
+                let value = self.state.builder.emit_arith_constant_bool(true, &block);
                 Ok((Some(value), block))
             }
             Expression::FalseKeyword => {
-                let i1_type = self.state.builder.types.i1;
-                let value = self.state.builder.emit_sol_constant(0, i1_type, &block);
+                let value = self.state.builder.emit_arith_constant_bool(false, &block);
                 Ok((Some(value), block))
             }
             Expression::Identifier(identifier) => {

--- a/solx-slang/src/ast/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/ast/contract/function/statement/control_flow.rs
@@ -134,14 +134,13 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                     .emit_sol_condition(condition_boolean, &condition_end);
             }
             ForStatementCondition::Semicolon => {
-                let i1_type = self.state.builder.types.i1;
-                let true_val = self
+                let true_value = self
                     .state
                     .builder
-                    .emit_sol_constant(1, i1_type, &condition_block);
+                    .emit_arith_constant_bool(true, &condition_block);
                 self.state
                     .builder
-                    .emit_sol_condition(true_val, &condition_block);
+                    .emit_sol_condition(true_value, &condition_block);
             }
         }
 


### PR DESCRIPTION
Boolean (`i1`) is signless in MLIR, so it uses `arith.constant` instead of `sol.constant` (which is for signed/unsigned int types). This matches solc's `bExt.genBool()` in `Util.h:69-74` which emits `arith::ConstantOp`.

Adds `emit_arith_constant_bool` to the builder and replaces 5 call sites that were incorrectly using `sol.constant` for `i1` values:
- `TrueKeyword` / `FalseKeyword` literal emission
- `&&` / `||` short-circuit default values
- For-loop implicit `true` condition (infinite loop)