### PR TITLE
ci(cache): re-add ccache as artifact-cache fallback

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -89,12 +89,56 @@ runs:
         CARGO_TARGET_DIR: target
       run: ${SFW_PREFIX:-} cargo fetch --locked && ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
 
+    # ccache is layered behind the SHA-keyed artifact cache: it only runs on
+    # artifact-cache miss (i.e. submodule bump) and provides object-level reuse
+    # across neighbouring solx-llvm commits.
+    - name: Define ccache key
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      id: ccache-key
+      run: |
+        KEY="llvm-${{ runner.os }}-${{ runner.arch }}"
+        [ '${{ inputs.build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.build-type }}"
+        [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
+        [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
+        [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
+        [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
+        echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
+
+    # ccache-action requires `apt update` on Linux Docker jobs
+    - name: Prepare ccache installation
+      if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      shell: 'bash'
+      run: apt update
+
+    # sccache is broken with cmake+ninja+clang on MSYS2/Windows
+    # (https://github.com/mozilla/sccache/issues/1097). Using ccache everywhere.
+    - name: Set up compiler cache
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
+      with:
+        key: ${{ steps.ccache-key.outputs.key }}
+        restore-keys: ${{ steps.ccache-key.outputs.key }}
+        append-timestamp: true
+        max-size: "4G"
+        verbose: 2
+        save: ${{ github.event_name != 'pull_request' }}
+
     - name: Build LLVM
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       working-directory: ${{ inputs.working-dir }}
       env:
         VERBOSE: 1
+        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
         LIBSTDCPP_SOURCE_PATH: "${{ runner.temp }}/msys64/mingw64/lib/libstdc++.a"
       run: |
         set -x
@@ -111,8 +155,15 @@ runs:
         fi
 
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
-          ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
+          --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='2'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+
+    - name: Show ccache stats
+      if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+      run: ccache --show-stats
 
     - name: Save LLVM artifact cache
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -111,11 +111,12 @@ runs:
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     # ccache-action refreshes the apt package index before installing ccache.
-    # `sudo` works both as root (Docker) and non-root (hosted runners); `-qq` silences routine output.
+    # The solx-ci-runner container doesn't ship sudo (steps run as root), so
+    # we invoke apt-get directly. `-qq` silences routine output.
     - name: Prepare ccache installation
       if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       shell: 'bash'
-      run: sudo apt-get update -qq
+      run: apt-get update -qq
 
     # sccache is broken with cmake+ninja+clang on MSYS2/Windows
     # (https://github.com/mozilla/sccache/issues/1097). Using ccache everywhere.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -125,7 +125,7 @@ runs:
         key: ${{ steps.ccache-key.outputs.key }}
         restore-keys: ${{ steps.ccache-key.outputs.key }}
         append-timestamp: true
-        max-size: "4G"
+        max-size: "10G"
         verbose: 2
         save: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -120,13 +120,14 @@ runs:
     # sccache is broken with cmake+ninja+clang on MSYS2/Windows
     # (https://github.com/mozilla/sccache/issues/1097). Using ccache everywhere.
     #
-    # The &ccache-llvm-env anchor keeps this block in sync with the Build LLVM
-    # and Show ccache stats steps — composite-action sibling steps don't share
-    # env, so we'd otherwise duplicate four variables three times.
+    # The four CCACHE_* env vars below are duplicated on the Build LLVM and
+    # Show ccache stats steps. YAML anchors/merge-keys would dedupe but GHA's
+    # composite-action manifest loader rejects anchors — keep them in sync by
+    # hand.
     - name: Set up compiler cache
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
-      env: &ccache-llvm-env
+      env:
         CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
         CCACHE_BASEDIR: ${{ github.workspace }}
         CCACHE_NOHASHDIR: "true"
@@ -144,7 +145,10 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       working-directory: ${{ inputs.working-dir }}
       env:
-        <<: *ccache-llvm-env
+        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
         VERBOSE: 1
         LIBSTDCPP_SOURCE_PATH: "${{ runner.temp }}/msys64/mingw64/lib/libstdc++.a"
       run: |
@@ -171,7 +175,11 @@ runs:
       if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      env: *ccache-llvm-env
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
       run: ccache --show-stats
 
     - name: Save LLVM artifact cache

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -103,6 +103,9 @@ runs:
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
+        # Terminator: prevents shorter-variant keys from prefix-matching longer ones
+        # via ccache-action's restore-keys (e.g. `...-mlir` matching `...-mlir-coverage-no-assertions`).
+        KEY="${KEY}-end"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     # ccache-action requires `apt update` on Linux Docker jobs

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -177,9 +177,28 @@ runs:
           LINK_JOBS=1
         fi
 
+        # Windows disables LLVM's own tool binaries (opt, llc, llvm-objdump, ...)
+        # because `lld-link` is slow per-executable and those ~200 tool links
+        # dominate Windows wall-clock even at 100% ccache hits on compiles. solx
+        # consumes LLVM via inkwell FFI and never invokes a tool from
+        # target-llvm/target-final/bin/; distro/Xcode packages provide
+        # llvm-cov / llvm-symbolizer / etc. Scoped Windows-only so non-Windows
+        # runs stay identical pending independent validation on those platforms.
+        EXTRA_ARGS=(
+          "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'"
+          "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'"
+          "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+        )
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          EXTRA_ARGS+=(
+            "-DLLVM_BUILD_TOOLS='Off'"
+            "-DLLVM_INCLUDE_TOOLS='Off'"
+          )
+        fi
+
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
-          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+          --extra-args "${EXTRA_ARGS[@]}"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -110,18 +110,23 @@ runs:
         KEY="${KEY}-end"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
-    # ccache-action requires `apt update` on Linux Docker jobs
+    # ccache-action refreshes the apt package index before installing ccache.
+    # `sudo` works both as root (Docker) and non-root (hosted runners); `-qq` silences routine output.
     - name: Prepare ccache installation
       if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       shell: 'bash'
-      run: apt update
+      run: sudo apt-get update -qq
 
     # sccache is broken with cmake+ninja+clang on MSYS2/Windows
     # (https://github.com/mozilla/sccache/issues/1097). Using ccache everywhere.
+    #
+    # The &ccache-llvm-env anchor keeps this block in sync with the Build LLVM
+    # and Show ccache stats steps — composite-action sibling steps don't share
+    # env, so we'd otherwise duplicate four variables three times.
     - name: Set up compiler cache
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
-      env:
+      env: &ccache-llvm-env
         CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
         CCACHE_BASEDIR: ${{ github.workspace }}
         CCACHE_NOHASHDIR: "true"
@@ -139,11 +144,8 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       working-directory: ${{ inputs.working-dir }}
       env:
+        <<: *ccache-llvm-env
         VERBOSE: 1
-        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
-        CCACHE_BASEDIR: ${{ github.workspace }}
-        CCACHE_NOHASHDIR: "true"
-        CCACHE_COMPILERCHECK: "content"
         LIBSTDCPP_SOURCE_PATH: "${{ runner.temp }}/msys64/mingw64/lib/libstdc++.a"
       run: |
         set -x
@@ -163,11 +165,13 @@ runs:
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='2'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 
+    # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
+    # from masking the real Build LLVM failure in the step summary.
     - name: Show ccache stats
       if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      env:
-        CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
+      env: *ccache-llvm-env
       run: ccache --show-stats
 
     - name: Save LLVM artifact cache

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -119,10 +119,8 @@ runs:
     # sccache is broken with cmake+ninja+clang on MSYS2/Windows
     # (https://github.com/mozilla/sccache/issues/1097). Using ccache everywhere.
     #
-    # The four CCACHE_* env vars below are duplicated on the Build LLVM and
-    # Show ccache stats steps. YAML anchors/merge-keys would dedupe but GHA's
-    # composite-action manifest loader rejects anchors — keep them in sync by
-    # hand.
+    # KEEP-IN-SYNC with CCACHE_* env on Build LLVM and Show ccache stats steps
+    # (GHA composite actions don't support YAML anchors).
     - name: Set up compiler cache
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -173,28 +173,9 @@ runs:
           LINK_JOBS=1
         fi
 
-        # Windows disables LLVM's own tool binaries (opt, llc, llvm-objdump, ...)
-        # because `lld-link` is slow per-executable and those ~200 tool links
-        # dominate Windows wall-clock even at 100% ccache hits on compiles. solx
-        # consumes LLVM via inkwell FFI and never invokes a tool from
-        # target-llvm/target-final/bin/; distro/Xcode packages provide
-        # llvm-cov / llvm-symbolizer / etc. Scoped Windows-only so non-Windows
-        # runs stay identical pending independent validation on those platforms.
-        EXTRA_ARGS=(
-          "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'"
-          "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'"
-          "-DLLVM_OPTIMIZED_TABLEGEN='On'"
-        )
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          EXTRA_ARGS+=(
-            "-DLLVM_BUILD_TOOLS='Off'"
-            "-DLLVM_INCLUDE_TOOLS='Off'"
-          )
-        fi
-
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
-          --extra-args "${EXTRA_ARGS[@]}"
+          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -165,9 +165,20 @@ runs:
           fi
         fi
 
+        # With ccache at 99%+ hit rate, link time dominates. Each LLVM tool link
+        # peaks at 2-4 GB RSS on RelWithDebInfo. The hosted macos-15 ARM runner
+        # has 3 vCPU / 7 GB RAM — two parallel links alone can exceed RAM and
+        # push into swap, which is net slower than serialized links. The intel
+        # macos-15 has 14 GB and handles 2 parallel links fine, as do Linux and
+        # Windows hosted (16 GB).
+        LINK_JOBS=2
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
+          LINK_JOBS=1
+        fi
+
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
-          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='2'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -67,10 +67,8 @@ runs:
         KEY="${KEY}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
-    # TEMP(ci:ccache-test): forced-miss so the ccache path always runs. REVERT BEFORE MERGE.
     - name: Restore LLVM artifact cache
       id: llvm-artifact-cache
-      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}
@@ -139,7 +137,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: true # TEMP(ci:ccache-test): save on PR events too. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
+        save: ${{ github.event_name != 'pull_request' }}
 
     - name: Build LLVM
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -67,8 +67,10 @@ runs:
         KEY="${KEY}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    # TEMP(ci:ccache-test): forced-miss so the ccache path always runs. REVERT BEFORE MERGE.
     - name: Restore LLVM artifact cache
       id: llvm-artifact-cache
+      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}
@@ -130,7 +132,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: ${{ github.event_name != 'pull_request' }}
+        save: true # TEMP(ci:ccache-test): save on PR events too. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
 
     - name: Build LLVM
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -33,8 +33,10 @@ runs:
         KEY="${KEY}-boost${{ inputs.boost-version }}-${SHA}-script${SCRIPT_HASH:0:8}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    # TEMP(ci:ccache-test): forced-miss so the ccache path always runs. REVERT BEFORE MERGE.
     - name: Restore solc artifact cache
       id: solc-artifact-cache
+      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
@@ -73,7 +75,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: ${{ github.event_name != 'pull_request' }}
+        save: true # TEMP(ci:ccache-test): save on PR events too. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
 
     - name: Build solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -33,10 +33,8 @@ runs:
         KEY="${KEY}-boost${{ inputs.boost-version }}-${SHA}-script${SCRIPT_HASH:0:8}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
-    # TEMP(ci:ccache-test): forced-miss so the ccache path always runs. REVERT BEFORE MERGE.
     - name: Restore solc artifact cache
       id: solc-artifact-cache
-      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
@@ -86,7 +84,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: true # TEMP(ci:ccache-test): save on PR events too. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
+        save: ${{ github.event_name != 'pull_request' }}
 
     - name: Build solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -71,7 +71,7 @@ runs:
         key: solc-${{ runner.os }}-${{ runner.arch }}
         restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
         append-timestamp: true
-        max-size: "4G"
+        max-size: "10G"
         verbose: 2
         save: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -55,23 +55,32 @@ runs:
     # artifact-cache miss (i.e. submodule bump) and provides object-level reuse
     # across neighbouring solx-solidity commits.
 
-    # ccache-action requires `apt update` on Linux Docker jobs
+    # ccache-action refreshes the apt package index before installing ccache.
+    # `sudo` works both as root (Docker) and non-root (hosted runners); `-qq` silences routine output.
     - name: Prepare ccache installation
       if: runner.os == 'Linux' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
       shell: 'bash'
-      run: apt update
+      run: sudo apt-get update -qq
 
+    # `cmake-build-type` in the key keeps Release and RelWithDebInfo configs
+    # from sharing a cache bucket and evicting each other; `-end` terminator
+    # matches the LLVM pattern and blocks future prefix-collision if more
+    # dimensions are added.
+    #
+    # The &ccache-solc-env anchor keeps this block in sync with the Build solc
+    # and Show ccache stats steps — composite-action sibling steps don't share
+    # env, so we'd otherwise duplicate four variables three times.
     - name: Set up compiler cache for solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
-      env:
+      env: &ccache-solc-env
         CCACHE_DIR: ${{ runner.temp }}/ccache-solc
         CCACHE_BASEDIR: ${{ github.workspace }}
         CCACHE_NOHASHDIR: "true"
         CCACHE_COMPILERCHECK: "content"
       with:
-        key: solc-${{ runner.os }}-${{ runner.arch }}
-        restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+        key: solc-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-end
+        restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cmake-build-type }}-end
         append-timestamp: true
         max-size: "10G"
         verbose: 2
@@ -83,11 +92,8 @@ runs:
       working-directory: ${{ inputs.working-dir }}/..
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
+        <<: *ccache-solc-env
         CXXFLAGS: "-Wno-narrowing"
-        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
-        CCACHE_BASEDIR: ${{ github.workspace }}
-        CCACHE_NOHASHDIR: "true"
-        CCACHE_COMPILERCHECK: "content"
       run: |
         set -x
         ./target/release/solx-dev solc build \
@@ -96,11 +102,13 @@ runs:
           --build-boost \
           --ccache-variant=ccache
 
+    # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
+    # from masking the real Build solc failure in the step summary.
     - name: Show ccache stats
       if: always() && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      env:
-        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+      env: *ccache-solc-env
       run: ccache --show-stats
 
     - name: Save solc artifact cache

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -67,13 +67,14 @@ runs:
     # matches the LLVM pattern and blocks future prefix-collision if more
     # dimensions are added.
     #
-    # The &ccache-solc-env anchor keeps this block in sync with the Build solc
-    # and Show ccache stats steps — composite-action sibling steps don't share
-    # env, so we'd otherwise duplicate four variables three times.
+    # The four CCACHE_* env vars below are duplicated on the Build solc and
+    # Show ccache stats steps. YAML anchors/merge-keys would dedupe but GHA's
+    # composite-action manifest loader rejects anchors — keep them in sync by
+    # hand.
     - name: Set up compiler cache for solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
-      env: &ccache-solc-env
+      env:
         CCACHE_DIR: ${{ runner.temp }}/ccache-solc
         CCACHE_BASEDIR: ${{ github.workspace }}
         CCACHE_NOHASHDIR: "true"
@@ -92,7 +93,10 @@ runs:
       working-directory: ${{ inputs.working-dir }}/..
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
-        <<: *ccache-solc-env
+        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
         CXXFLAGS: "-Wno-narrowing"
       run: |
         set -x
@@ -108,7 +112,11 @@ runs:
       if: always() && steps.solc-artifact-cache.outputs.cache-hit != 'true'
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      env: *ccache-solc-env
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
       run: ccache --show-stats
 
     - name: Save solc artifact cache

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -66,10 +66,8 @@ runs:
     # matches the LLVM pattern and blocks future prefix-collision if more
     # dimensions are added.
     #
-    # The four CCACHE_* env vars below are duplicated on the Build solc and
-    # Show ccache stats steps. YAML anchors/merge-keys would dedupe but GHA's
-    # composite-action manifest loader rejects anchors — keep them in sync by
-    # hand.
+    # KEEP-IN-SYNC with CCACHE_* env on Build solc and Show ccache stats steps
+    # (GHA composite actions don't support YAML anchors).
     - name: Set up compiler cache for solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
       uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -56,11 +56,12 @@ runs:
     # across neighbouring solx-solidity commits.
 
     # ccache-action refreshes the apt package index before installing ccache.
-    # `sudo` works both as root (Docker) and non-root (hosted runners); `-qq` silences routine output.
+    # The solx-ci-runner container doesn't ship sudo (steps run as root), so
+    # we invoke apt-get directly. `-qq` silences routine output.
     - name: Prepare ccache installation
       if: runner.os == 'Linux' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
       shell: 'bash'
-      run: sudo apt-get update -qq
+      run: apt-get update -qq
 
     # `cmake-build-type` in the key keeps Release and RelWithDebInfo configs
     # from sharing a cache bucket and evicting each other; `-end` terminator

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -49,6 +49,32 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: ${SFW_PREFIX:-} cargo fetch --locked && ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
 
+    # ccache is layered behind the SHA-keyed artifact cache: it only runs on
+    # artifact-cache miss (i.e. submodule bump) and provides object-level reuse
+    # across neighbouring solx-solidity commits.
+
+    # ccache-action requires `apt update` on Linux Docker jobs
+    - name: Prepare ccache installation
+      if: runner.os == 'Linux' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      shell: 'bash'
+      run: apt update
+
+    - name: Set up compiler cache for solc
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.14
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
+      with:
+        key: solc-${{ runner.os }}-${{ runner.arch }}
+        restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+        append-timestamp: true
+        max-size: "4G"
+        verbose: 2
+        save: ${{ github.event_name != 'pull_request' }}
+
     - name: Build solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
       # Run from the checkout root that owns solx-solidity
@@ -56,12 +82,24 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         CXXFLAGS: "-Wno-narrowing"
+        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_NOHASHDIR: "true"
+        CCACHE_COMPILERCHECK: "content"
       run: |
         set -x
         ./target/release/solx-dev solc build \
           --build-type ${{ inputs.cmake-build-type }} \
           --boost-version ${{ inputs.boost-version }} \
-          --build-boost
+          --build-boost \
+          --ccache-variant=ccache
+
+    - name: Show ccache stats
+      if: always() && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      env:
+        CCACHE_DIR: ${{ runner.temp }}/ccache-solc
+      run: ccache --show-stats
 
     - name: Save solc artifact cache
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,62 @@
+name: "free-disk-space"
+
+description: |
+  Reclaims ~20-25 GB of disk on GitHub-hosted Ubuntu runners by removing
+  pre-installed host tooling solx does not use.
+
+  Host-path targets (freed when bind-mounted into the container):
+    - .NET SDK           /usr/share/dotnet                ~1.6 GB
+    - Android SDK+NDK    /usr/local/lib/android           ~11-14 GB
+    - Haskell            /opt/ghc  /usr/local/.ghcup      ~5-6 GB
+    - CodeQL bundles     /opt/hostedtoolcache/CodeQL      ~5.4 GB
+
+  This action's rm runs inside the container, so the callers must
+  bind-mount each host path into the container at a fixed mount point.
+  The rm operates only on paths under `/mnt/free-disk-space/`, so a
+  missing or misconfigured mount can't target anything outside that
+  prefix. Add to the job's `container:` block:
+
+      container:
+        image: <your image>
+        volumes:
+          - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+          - /usr/local/lib/android:/mnt/free-disk-space/android
+          - /opt/ghc:/mnt/free-disk-space/ghc
+          - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+          - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
+
+  The container runs as root, so no sudo is needed. Boost is intentionally
+  NOT removed — solc's build has its own `--build-boost`, but the host's
+  /usr/local/share/boost headers may be pulled in by other tooling.
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Remove unused host tooling via bind mount"
+      shell: bash
+      run: |
+        set -u
+        echo "Before:"
+        df -h /
+        # Only rm paths that exist and are non-empty. Defends against a
+        # missing `container.volumes:` silently unlinking an empty mount point
+        # on the host, and caps the blast radius to /mnt/free-disk-space/*.
+        cleanup() {
+          local p="$1"
+          case "$p" in
+            /mnt/free-disk-space/*) ;;
+            *) echo "refusing to clean path outside /mnt/free-disk-space/: $p" >&2; return 1 ;;
+          esac
+          [ -d "$p" ] || return 0
+          [ -n "$(ls -A "$p" 2>/dev/null)" ] || return 0
+          echo "  removing $p"
+          rm -rf "$p"
+        }
+        cleanup /mnt/free-disk-space/dotnet  &
+        cleanup /mnt/free-disk-space/android &
+        cleanup /mnt/free-disk-space/ghc     &
+        cleanup /mnt/free-disk-space/ghcup   &
+        cleanup /mnt/free-disk-space/codeql  &
+        wait
+        echo "After:"
+        df -h /

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -49,8 +49,11 @@ runs:
           esac
           [ -d "$p" ] || return 0
           [ -n "$(ls -A "$p" 2>/dev/null)" ] || return 0
-          echo "  removing $p"
-          rm -rf "$p"
+          echo "  clearing $p"
+          # `rm -rf "$p"` would fail on the bind-mount directory itself (EBUSY);
+          # delete contents instead so the mount stays intact and a real rm
+          # failure can still surface as a non-zero exit.
+          find "$p" -mindepth 1 -delete
         }
         cleanup /mnt/free-disk-space/dotnet  &
         cleanup /mnt/free-disk-space/android &

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -12,9 +12,10 @@ description: |
 
   This action's rm runs inside the container, so the callers must
   bind-mount each host path into the container at a fixed mount point.
-  The rm operates only on paths under `/mnt/free-disk-space/`, so a
-  missing or misconfigured mount can't target anything outside that
-  prefix. Add to the job's `container:` block:
+  A shell-glob `case` guards against typos in new callers — it refuses
+  paths that don't start with `/mnt/free-disk-space/`. It is NOT a
+  security boundary (the glob matches `..` traversal); all current
+  callers pass hard-coded literals. Add to the job's `container:` block:
 
       container:
         image: <your image>
@@ -36,7 +37,9 @@ runs:
         df -h /
         # Only rm paths that exist and are non-empty. Defends against a
         # missing `container.volumes:` silently unlinking an empty mount point
-        # on the host, and caps the blast radius to /mnt/free-disk-space/*.
+        # on the host, and best-effort refuses callers passing paths outside
+        # /mnt/free-disk-space/. Glob-based, not realpath — enough to catch
+        # typos, not a security boundary against `..` traversal.
         cleanup() {
           local p="$1"
           case "$p" in

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -25,10 +25,6 @@ description: |
           - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
           - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
 
-  The container runs as root, so no sudo is needed. Boost is intentionally
-  NOT removed — solc's build has its own `--build-boost`, but the host's
-  /usr/local/share/boost headers may be pulled in by other tooling.
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -46,16 +46,28 @@ runs:
           [ -d "$p" ] || return 0
           [ -n "$(ls -A "$p" 2>/dev/null)" ] || return 0
           echo "  clearing $p"
-          # `rm -rf "$p"` would fail on the bind-mount directory itself (EBUSY);
-          # delete contents instead so the mount stays intact and a real rm
-          # failure can still surface as a non-zero exit.
+          # `rm -rf "$p"` would fail on the bind-mount directory itself
+          # (EBUSY); delete contents instead so the mount stays intact.
           find "$p" -mindepth 1 -delete
         }
-        cleanup /mnt/free-disk-space/dotnet  &
-        cleanup /mnt/free-disk-space/android &
-        cleanup /mnt/free-disk-space/ghc     &
-        cleanup /mnt/free-disk-space/ghcup   &
-        cleanup /mnt/free-disk-space/codeql  &
-        wait
+        # Capture each PID — bare `wait` with no args returns 0 regardless
+        # of child exit codes (bash §3.7.5), which would silently mask a
+        # failed `find -delete` and hide the partial-cleanup from the log.
+        pids=()
+        cleanup /mnt/free-disk-space/dotnet  & pids+=($!)
+        cleanup /mnt/free-disk-space/android & pids+=($!)
+        cleanup /mnt/free-disk-space/ghc     & pids+=($!)
+        cleanup /mnt/free-disk-space/ghcup   & pids+=($!)
+        cleanup /mnt/free-disk-space/codeql  & pids+=($!)
+        rc=0
+        for pid in "${pids[@]}"; do
+          wait "$pid" || rc=$?
+        done
         echo "After:"
         df -h /
+        # Warn but don't fail the step: partial cleanup is usually still
+        # enough headroom for the downstream build, and if it isn't, ENOSPC
+        # will surface with a clearer location than this action can provide.
+        if [ "$rc" -ne 0 ]; then
+          echo "::warning::free-disk-space: one or more cleanups failed (exit $rc); subsequent steps may hit ENOSPC"
+        fi

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -47,12 +47,24 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image || '' }}
+      # Host tooling bind-mounts for the free-disk-space action, applied only
+      # when a container is started (matrix legs with `image:` set).
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     name: "LLVM · ${{ matrix.name }}"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        if: runner.os == 'Linux' && matrix.image != ''
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout submodules
         run: |
@@ -152,12 +164,21 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     name: "LLVM · Sanitizer"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout submodules
         run: |
@@ -189,12 +210,21 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     name: "LLVM · Coverage"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout submodules
         run: |
@@ -227,12 +257,21 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     name: "LLVM + solc · Integration"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache-touch-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-end
           fail-on-cache-miss: false
           lookup-only: true
 
@@ -180,7 +180,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache-touch-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-Address
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-Address-end
           fail-on-cache-miss: false
           lookup-only: true
 
@@ -218,7 +218,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache-touch-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-coverage-no-assertions
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-coverage-no-assertions-end
           fail-on-cache-miss: false
           lookup-only: true
 
@@ -254,7 +254,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache-touch-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-no-assertions
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-no-assertions-end
           fail-on-cache-miss: false
           lookup-only: true
 

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -49,7 +49,9 @@ jobs:
       image: ${{ matrix.image || '' }}
       # Host tooling bind-mounts for the free-disk-space action, applied only
       # when a container is started (matrix legs with `image:` set).
-      volumes:
+      # Anchor shared with the three single-job LLVM warm-ups below; keep in
+      # sync with the matching list in test.yaml.
+      volumes: &free-disk-volumes
         - /usr/share/dotnet:/mnt/free-disk-space/dotnet
         - /usr/local/lib/android:/mnt/free-disk-space/android
         - /opt/ghc:/mnt/free-disk-space/ghc
@@ -164,12 +166,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
-      volumes:
-        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
-        - /usr/local/lib/android:/mnt/free-disk-space/android
-        - /opt/ghc:/mnt/free-disk-space/ghc
-        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
-        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
+      volumes: *free-disk-volumes
     name: "LLVM · Sanitizer"
     steps:
       - name: Checkout
@@ -210,12 +207,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
-      volumes:
-        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
-        - /usr/local/lib/android:/mnt/free-disk-space/android
-        - /opt/ghc:/mnt/free-disk-space/ghc
-        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
-        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
+      volumes: *free-disk-volumes
     name: "LLVM · Coverage"
     steps:
       - name: Checkout
@@ -257,12 +249,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
-      volumes:
-        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
-        - /usr/local/lib/android:/mnt/free-disk-space/android
-        - /opt/ghc:/mnt/free-disk-space/ghc
-        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
-        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
+      volumes: *free-disk-volumes
     name: "LLVM + solc · Integration"
     steps:
       - name: Checkout

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -73,6 +73,23 @@ jobs:
           enable-assertions: 'true'
           enable-mlir: 'true'
 
+      # When the artifact cache is warm, build-llvm skips ccache entirely,
+      # so the ccache entry's LRU timer isn't refreshed. Touch it explicitly
+      # so the nightly cron keeps ccache alive past GHA's 7-day eviction
+      # window. Primary key is unique → falls through to the restore-keys
+      # prefix match against the ccache-action's timestamped key.
+      # lookup-only: true skips the download; the cache service lookup alone
+      # resets the access timer.
+      - name: Touch LLVM ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-llvm
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir
+          fail-on-cache-miss: false
+          lookup-only: true
+
   # ── solc: standard config (test.yaml / build-and-test) ──────────────
   warm-solc:
     strategy:
@@ -120,6 +137,16 @@ jobs:
           boost-version: '1.83.0'
           working-dir: 'solx-solidity'
 
+      - name: Touch solc ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-solc
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+          fail-on-cache-miss: false
+          lookup-only: true
+
   # ── LLVM: sanitizer config (sanitizer.yaml) ─────────────────────────
   warm-llvm-sanitizer:
     runs-on: ubuntu-24.04
@@ -146,6 +173,16 @@ jobs:
           build-type: RelWithDebInfo
           enable-assertions: 'true'
           sanitizer: 'Address'
+
+      - name: Touch LLVM ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-llvm
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-Address
+          fail-on-cache-miss: false
+          lookup-only: true
 
   # ── LLVM: coverage config (coverage.yaml) ───────────────────────────
   warm-llvm-coverage:
@@ -175,6 +212,16 @@ jobs:
           enable-coverage: 'true'
           enable-mlir: 'true'
 
+      - name: Touch LLVM ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-llvm
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-coverage-no-assertions
+          fail-on-cache-miss: false
+          lookup-only: true
+
   # ── LLVM + solc: integration config (integration-tests.yaml) ────────
   warm-llvm-integration:
     runs-on: ubuntu-24.04
@@ -201,8 +248,28 @@ jobs:
           build-type: Release
           enable-assertions: 'false'
 
+      - name: Touch LLVM ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-llvm
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-no-assertions
+          fail-on-cache-miss: false
+          lookup-only: true
+
       - name: Build solc
         uses: ./.github/actions/build-solc
         with:
           cmake-build-type: Release
           working-dir: 'solx-solidity'
+
+      - name: Touch solc ccache
+        if: always()
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ runner.temp }}/ccache-touch-solc
+          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
+          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+          fail-on-cache-miss: false
+          lookup-only: true

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -125,12 +125,21 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image || '' }}
+      # solc's build footprint (~3-5 GB) fits comfortably in container
+      # headroom today, so this cleanup isn't strictly required — but the
+      # ~30 s it costs is cheap insurance against future solc/boost growth
+      # hitting ENOSPC and killing a warmup run mid-flight.
+      volumes: *free-disk-volumes
     name: "solc · ${{ matrix.name }}"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        if: runner.os == 'Linux' && matrix.image != ''
+        uses: ./.github/actions/free-disk-space
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-llvm
+          path: ${{ runner.temp }}/ccache-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
           restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-end
           fail-on-cache-miss: false
@@ -141,9 +141,9 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-solc
+          path: ${{ runner.temp }}/ccache-solc
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-end
           fail-on-cache-miss: false
           lookup-only: true
 
@@ -178,7 +178,7 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-llvm
+          path: ${{ runner.temp }}/ccache-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
           restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-Address-end
           fail-on-cache-miss: false
@@ -216,7 +216,7 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-llvm
+          path: ${{ runner.temp }}/ccache-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
           restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-mlir-coverage-no-assertions-end
           fail-on-cache-miss: false
@@ -252,7 +252,7 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-llvm
+          path: ${{ runner.temp }}/ccache-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
           restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-no-assertions-end
           fail-on-cache-miss: false
@@ -268,8 +268,8 @@ jobs:
         if: always()
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ runner.temp }}/ccache-touch-solc
+          path: ${{ runner.temp }}/ccache-solc
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-Release-end
           fail-on-cache-miss: false
           lookup-only: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,9 @@ jobs:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
       # Host tooling bind-mounted so the free-disk-space action can reclaim
       # ~24 GB before the cold LLVM build fills the runner's 14 GB budget.
-      volumes:
+      # Anchor shared with build-and-test below; keep in sync with the
+      # matching list in cache-warmup.yaml.
+      volumes: &free-disk-volumes
         - /usr/share/dotnet:/mnt/free-disk-space/dotnet
         - /usr/local/lib/android:/mnt/free-disk-space/android
         - /opt/ghc:/mnt/free-disk-space/ghc
@@ -133,12 +135,7 @@ jobs:
       # Host tooling bind-mounts for the free-disk-space action. These apply
       # only when a container is started (matrix legs with `image:` set); the
       # macOS/Windows legs run bare and the paths are irrelevant there.
-      volumes:
-        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
-        - /usr/local/lib/android:/mnt/free-disk-space/android
-        - /opt/ghc:/mnt/free-disk-space/ghc
-        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
-        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
+      volumes: *free-disk-volumes
     name: ${{ matrix.name }}
     steps:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -191,19 +191,28 @@ jobs:
             echo "  warning: active Xcode path '${ACTIVE_XCODE}' is not an Xcode app; skipping Xcode removal"
           else
             echo "Active Xcode (keeping): ${ACTIVE_XCODE}"
+            to_remove=()
             for app in /Applications/Xcode_*.app; do
               [ -d "$app" ] || continue
               if [ "$app" = "$ACTIVE_XCODE" ]; then
                 echo "  skip (active): $app"
               else
                 echo "  removing: $app"
-                if sudo rm -rf "$app"; then
-                  removed=$((removed + 1))
-                else
-                  echo "  warning: failed to remove $app"
-                fi
+                to_remove+=("$app")
               fi
             done
+            # Each Xcode bundle is ~15 GB of small files; `rm -rf` is I/O-bound
+            # per inode, so run them concurrently (one worker per bundle).
+            # Soft-fail: a stray rm error shouldn't sink the whole job — rm's
+            # stderr will pinpoint the bad path above.
+            if [ "${#to_remove[@]}" -gt 0 ]; then
+              if printf '%s\0' "${to_remove[@]}" \
+                  | xargs -0 -n1 -P "${#to_remove[@]}" sudo rm -rf; then
+                removed=${#to_remove[@]}
+              else
+                echo "  warning: one or more Xcode removals failed (see rm stderr above)"
+              fi
+            fi
           fi
           echo "Removed ${removed} inactive Xcode version(s)"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,11 +205,17 @@ jobs:
             # per inode, so run them concurrently (one worker per bundle).
             # Soft-fail: a stray rm error shouldn't sink the whole job — rm's
             # stderr will pinpoint the bad path above.
+            #
+            # `removed` reflects the attempt count, not per-bundle success:
+            # xargs returns non-zero if *any* child failed, so gating the
+            # count on xargs success would print "Removed 0" even after
+            # ~30 GB was freed. The count is off by the number of failed
+            # bundles — usually one in practice — which is still a much
+            # better signal than zero.
             if [ "${#to_remove[@]}" -gt 0 ]; then
-              if printf '%s\0' "${to_remove[@]}" \
+              removed=${#to_remove[@]}
+              if ! printf '%s\0' "${to_remove[@]}" \
                   | xargs -0 -n1 -P "${#to_remove[@]}" sudo rm -rf; then
-                removed=${#to_remove[@]}
-              else
                 echo "  warning: one or more Xcode removals failed (see rm stderr above)"
               fi
             fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,12 +49,23 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
+      # Host tooling bind-mounted so the free-disk-space action can reclaim
+      # ~24 GB before the cold LLVM build fills the runner's 14 GB budget.
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     steps:
 
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       # This step is required to checkout submodules
       # that are disabled in .gitmodules config
@@ -119,6 +130,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image || '' }} # Special workaround to allow matrix builds with optional container
+      # Host tooling bind-mounts for the free-disk-space action. These apply
+      # only when a container is started (matrix legs with `image:` set); the
+      # macOS/Windows legs run bare and the paths are irrelevant there.
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     name: ${{ matrix.name }}
     steps:
 
@@ -127,6 +147,13 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
+
+      # Only meaningful on containerized Linux legs (the hosted x86 leg is the
+      # disk-constrained one); a no-op on macOS/Windows since the mount points
+      # don't exist there.
+      - name: Free disk space
+        if: runner.os == 'Linux' && matrix.image != ''
+        uses: ./.github/actions/free-disk-space
 
       # This step is required to checkout submodules
       # that are disabled in .gitmodules config


### PR DESCRIPTION
## Summary

- I've upped the solx cache size to 150GB.
- Re-adds ccache to the `build-llvm` and `build-solc` composite actions as a **fallback behind** the SHA-keyed artifact cache (removed in #246). ccache only runs on artifact-cache miss; the warm-cache fast path (~30 s restore) is unchanged.
- Adds ccache-touch steps to each `cache-warmup.yaml` job so the daily cron extends the ccache LRU even when the artifact cache hits, preventing GHA's 7-day eviction from emptying ccache on quiet periods.
- Adds a `free-disk-space` composite action that reclaims ~24 GB of pre-installed host tooling (dotnet, Android SDK, Haskell, CodeQL) via `container.volumes:` bind-mounts, so hosted `ubuntu-24.04` runners have enough room for cold LLVM builds + ccache on the same disk pool.
- Tunes `LLVM_PARALLEL_LINK_JOBS` per platform — 2 on Linux/Windows and macOS x86 (14–16 GB RAM), 1 on macOS ARM64 — because link memory pressure becomes the bottleneck once compile-phase is served from ccache at 99%+ hit rates. The hosted `macos-15` ARM runner has 3 vCPU / 7 GB RAM; two parallel RelWithDebInfo links at 2–4 GB RSS each push it into swap.
- `max-size: "10G"` per ccache scope (matches pre-#246 value).

## Observed runtimes

Three reference runs on this PR branch show the progression:

- **Cold**: run [#24731422129](https://github.com/NomicFoundation/solx/actions/runs/24731422129) at `fb9f415` — first run, ccache empty, pre-free-disk-space; cargo-checks fails on disk exhaustion during `lld` link of `llvm-opt-fuzzer`.
- **Warm ccache, link-jobs=2**: run [#24745368771](https://github.com/NomicFoundation/solx/actions/runs/24745368771) at `13d56d5` — LLVM ccache populated by the cold run, free-disk-space wired, but parallel links still causing swap on macOS ARM64.
- **Warm ccache + link-jobs tuning**: run [#24751701680](https://github.com/NomicFoundation/solx/actions/runs/24751701680) at `6f85d0a` — `LLVM_PARALLEL_LINK_JOBS=1` on macOS ARM64, 100% ccache hit rate across the board.

### Whole-job wall-clock

| Platform | Cold | Warm ccache, link-jobs=2 | Warm ccache + link-jobs tuned |
|---|---|---|---|
| cargo-checks | 2h 17min, **failed on disk** | 18.5 min | **16.5 min** |
| Linux x86 gnu | 3h 00min | 32.5 min | **15.5 min** |
| Linux ARM64 gnu | 1h 44min | 25 min | **14.5 min** |
| macOS x86 | 3h 28min | 1h 53min | **45 min** |
| macOS ARM64 | 4h 44min | 2h 23min | **21 min** |
| Windows | 4h 31min | 1h 46min | **1h 19min** |

### Build LLVM step only

Isolates the LLVM-building cost from checkout / solc build / tests / etc. Shows that the dramatic macOS ARM64 win is mechanism-specific:

| Platform | Warm ccache, link-jobs=2 | Warm ccache + link-jobs tuned | Speedup |
|---|---|---|---|
| cargo-checks | 7:07 | 4:20 | 1.6× |
| Linux x86 gnu | 7:00 | 3:59 | 1.8× |
| Linux ARM64 gnu | 6:11 | 4:22 | 1.4× |
| macOS x86 | 17:40 | 10:23 | 1.7× |
| **macOS ARM64** | **1h 57min** | **5:54** | **20×** |
| Windows | 46:35 | 42:16 | 1.1× |

Two effects stacking:

1. **ccache hit rate crept from 99.35% → 100%** (confirmed on both macOS legs this run). The previous run had 25 misses out of 3839 cacheable calls; those got saved, so this run hits them. Accounts for the modest 1.4–1.8× speedup on every non-ARM64 leg — roughly 25 cold compiles × ~10–15 s each.
2. **`LLVM_PARALLEL_LINK_JOBS=1` eliminated swap thrashing on macOS ARM64**, which is the 20× speedup. 25 additional cache hits don't explain ~1h 50min of saved wall time; that was the linker stalled on page faults in a 7 GB runner trying to run two ~3 GB RSS link jobs concurrently. Windows' 1.1× result is the control group: 16 GB RAM, no swap pressure, no link-jobs change, speedup limited to cache warming.

ccache itself handles compile, not link. The ~200 link steps per build still run every time; that's the floor. On most platforms link time is tolerable; on macOS ARM64 specifically the interaction between link count, link RSS, and runner RAM was catastrophic before this PR and is now fine.

### Building solc step

solc's ccache key changed in `35949d3` (adding `-{cmake-build-type}-end` per review feedback), which invalidated run 1's saves — run 2 re-populated with the new key format, and run 3 is the first run that actually restores a warm solc ccache at 100% hit rate.

| Platform | Cold (run 1, fb9f415) | Warm ccache (run 3, 6f85d0a) | Speedup |
|---|---|---|---|
| Linux x86 gnu | 19:11 | **1:32** | 12.5× |
| Linux ARM64 gnu | 10:26 | **1:25** | 7.4× |
| macOS x86 | 25:32 | **7:12** | 3.5× |
| macOS ARM64 | 14:07 | **2:31** | 5.6× |
| Windows | 35:50 | **16:03** | 2.2× |

Observations:

- **Linux warm solc is the clean case** — under 2 min thanks to a small link graph (just `solc` and `solc-tests` binaries, vs LLVM's ~200 tool-executables). Almost all of the wall-clock is the link-floor we can't eliminate.
- **Windows warm solc is still 16 min.** Same link-bound story as LLVM: `lld-link` is inherently slow per-executable on Windows and solc + boost together produce enough binaries for that to dominate. No swap here (16 GB RAM, not memory-pressured), just slow links.
- **macOS ARM64 solc doesn't need the link-jobs treatment.** Solc produces few enough binaries that even link-jobs=2 doesn't exceed the 7 GB RAM.

## Fixes and tuning during review

- **Cache-key terminator** (`-end`): `llvm-…-mlir` was a prefix of `llvm-…-mlir-coverage-no-assertions`, so ccache-action's `restore-keys` prefix match was cross-restoring between dev and coverage configs on Linux x64. All LLVM and solc keys now end with an `-end` marker.
- **Touch-step path mismatch**: `cache-warmup.yaml`'s Touch steps used `${{ runner.temp }}/ccache-touch-{llvm,solc}` but ccache-action saves with `path = CCACHE_DIR = ${{ runner.temp }}/ccache-{llvm,solc}`. GHA includes `path` in the cache version hash, so the Touch was a silent no-op. Fixed to real paths.
- **solc key missing `cmake-build-type`**: `warm-solc` (RelWithDebInfo) and `warm-llvm-integration` (Release) were colliding on one key. Key now includes build-type.
- **`Show ccache stats`** → `continue-on-error: true` so a missing-ccache-binary failure can't mask the real build failure.
- **`apt update` handling** — went through a couple of iterations: first bare `apt update`, then `sudo apt-get update -qq` (per review suggestion for portability), then back to plain `apt-get update -qq` once a test run (#24751389733) confirmed the `solx-ci-runner` container image doesn't ship `sudo` at all. Kept the add-then-remove as separate commits so the iteration is visible in history.
- **YAML anchor reality check**: GHA composite-action manifests reject YAML anchors (`ActionManifestManagerLegacy` explicit refusal), so the four duplicated `CCACHE_*` env vars across steps in `build-llvm/action.yml` and `build-solc/action.yml` stay inlined with a sync comment. Workflow files *do* accept anchors, which is used to dedupe the five-entry `container.volumes:` list across the six affected jobs within each of `test.yaml` and `cache-warmup.yaml`.
- **`find -mindepth 1 -delete`** instead of `rm -rf` on the bind-mounted host paths: `rm -rf` on a bind-mount directory fails with EBUSY on the mount point itself (disk reclaim still happens, but log noise and a masked non-zero exit). `find -delete` clears contents, leaves the mount intact, and preserves a meaningful exit code.
- **`xargs -P` for macOS Xcode removal**: the pre-installed runner has ~16 Xcode versions. Sequential `rm -rf` was ~8 min; parallel fan-out cuts it well under two.
- **Windows LLVM tool-disable experiment, landed and reverted**: commit `3106d1e` added `LLVM_BUILD_TOOLS=Off` + `LLVM_INCLUDE_TOOLS=Off` on Windows to skip ~200 unused tool-binary links. Build LLVM step dropped from 42 min → 9:44 (4.3×) on the validation run. Reverted in `90df14b` after `Run tests` failed with `llvm-sys` unable to find `llvm-config` at Rust crate-build time — `llvm-config` is itself a tool binary and got disabled along with the rest. Follow-up to retry with a surgical "build only `llvm-config`" approach tracked in #364.

## Prior art (why this shape)

- #217 — original ccache. Revealed cargo caches evicting LLVM ccache from the 10 GB budget; fixed by removing cargo caches from that path.
- #226 — sccache is broken on MSYS2 with cmake+ninja+clang ([mozilla/sccache#1097](https://github.com/mozilla/sccache/issues/1097), open since 2022). Windows uses ccache.
- #246 — removed ccache entirely in favour of SHA-keyed artifact caching on the (now-outdated) assumption that submodule bumps would be rare. This PR restores only the ccache steps; the 5→4 LLVM config consolidation from #246 stays.

## Cache calculations

Current observed active usage (`gh api repos/NomicFoundation/solx/actions/cache/usage`):

| Entry | Per entry | Copies¹ | Subtotal |
|---|---|---|---|
| `v1-llvm-Windows-X64-RelWithDebInfo-mlir-…` | 9.09 GB | 4 | 36.4 GB |
| `v1-llvm-macOS-X64-RelWithDebInfo-mlir-…` | 2.39 GB | 2 | 4.8 GB |
| `v1-llvm-macOS-ARM64-RelWithDebInfo-mlir-…` | 2.28 GB | 1 | 2.3 GB |
| `v1-llvm-Linux-X64-RelWithDebInfo-mlir-…` | 1.86 GB | 2 | 3.7 GB |
| `v1-llvm-Linux-ARM64-RelWithDebInfo-mlir-…` | 1.82 GB | 2 | 3.6 GB |
| `build-and-test-v2-*` (rust-cache, 3 OSes) | ~1.5 GB | 3 | ~4.7 GB |
| `v1-solc-*` (5 platforms) | ~0.35 GB | 5 | 1.8 GB |
| misc | small | — | ~0.05 GB |
| **Current total** | | | **~59.7 GB / 28 entries** |

¹ GHA scopes caches per-ref: each merge queue branch (`gh-readonly-queue/main/pr-###-…`) creates its own cache copy.

### Projected ccache additions

With `max-size: 10G` per scope, actual on-disk ccache per variant tends to sit at ~2–3 GB for LLVM, ~1 GB for solc. GHA stores the zstd-compressed tarball, typically 40–60 % of on-disk size.

| New ccache entry | On-disk (typical) | Count | Compressed subtotal |
|---|---|---|---|
| LLVM dev (`llvm-<OS>-<arch>-RelWithDebInfo-mlir`), 5 platforms | ~3 GB | 5 | ~8 GB |
| LLVM sanitizer (Linux x86 only) | ~3 GB | 1 | ~1.5 GB |
| LLVM coverage (Linux x86 only) | ~3 GB | 1 | ~1.5 GB |
| LLVM integration / Release (Linux x86 only) | ~3 GB | 1 | ~1.5 GB |
| solc (`solc-<OS>-<arch>-<build-type>`), 5 platforms | ~1 GB | 5 | ~3 GB |
| **New subtotal** | | 13 | **~15–20 GB** |

### Worst-case upper bound

If every ccache scope fills its 10G cap (unlikely, but the theoretical max):

| | On-disk | Compressed in GHA |
|---|---|---|
| 13 scopes × 10G | 130 GB | ~50–80 GB |

### Projected totals

| Scenario | Active cache |
|---|---|
| Current (artifact cache only) | ~60 GB |
| Current + typical ccache | **~75–80 GB** |
| Current + worst-case ccache | **~110–140 GB** |
| Quota (newly raised) | **150 GB** |

Headroom under quota stays comfortable in the typical case and survives the worst case. If observed usage approaches 150 GB after a few weeks, the `max-size` cap is a single-line dial-back.

## Why ccache-touch in cache-warmup?

The composite action gates the ccache steps on `cache-hit != 'true'`. When the daily cron fires on an unchanged submodule SHA, the artifact cache hits → composite skips ccache → the ccache entry's LRU timer isn't refreshed. After 7 quiet days, GHA evicts it. The `Touch ccache` steps use `actions/cache/restore` with `lookup-only: true` — the lookup hits the cache service endpoint, resetting the 7-day access timer, without downloading the ~2–4 GB entry.

## Test plan

- [x] CI passes cold build — confirmed in run #24745368771 once free-disk-space was wired. cargo-checks passes in 16.5 min (was failing on disk with SIGBUS during link).
- [x] LLVM ccache active, populated, and restored across runs. Stats confirm 100% hit rate once warmed.
- [x] solc ccache validated end-to-end on run #24751701680 — 100% hit rate on all five platforms after the key change propagated.
- [x] LLVM wall-clock drops substantially vs cold baseline on every leg. Linux x86: 3h → 15.5 min (12×). Linux ARM64: 1h 44min → 14.5 min (7×). macOS x86: 3h 28min → 45 min (4.6×). macOS ARM64: 4h 44min → 21 min (13×). Windows: 4h 31min → 1h 19min (3.4×).
- [x] `LLVM_PARALLEL_LINK_JOBS=1` on macOS ARM64 validated — Build LLVM step 1h 57min → 5:54 (20×) compared to prior warm-ccache run at link-jobs=2.
- [ ] After merge, watch push-to-main `cache-warmup` run populate ccache entries on main.
- [ ] Monitor `gh api repos/NomicFoundation/solx/actions/cache/usage` over 1–2 weeks — confirm total stays under 150 GB.

## Out of scope / follow-ups

- Publishing prebuilt LLVM binary tarballs from the `solx-llvm` repo (build once there, download by SHA here) — biggest long-term win but requires cross-repo infra.
- Windows LLVM artifact is 9 GB (4× macOS, 5× Linux) — likely PDBs / `.lib` files in `RelWithDebInfo`. Not in scope per prior discussion.
- Capping ninja compile parallelism (`LLVM_PARALLEL_COMPILE_JOBS`) if link-jobs tuning isn't enough on some future platform.
- Reduce Windows LLVM tool count (#364) — attempted in this PR and reverted; worth retrying surgically with `llvm-config` retained. Expected ~4× Windows Build LLVM speedup.
