### PR TITLE
feat(slang): lower revert statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Build the `solx-dev` tool first, then use it to build LLVM and solc:
 cargo build --release --bin solx-dev
 
 # Build LLVM (outputs to target-llvm/target-final/)
-./target/release/solx-dev llvm build --enable-mlir
+./target/release/solx-dev llvm build --enable-mlir --enable-tests --build-type RelWithDebInfo
 
 # Build solc libraries (outputs to solx-solidity/build/)
 ./target/release/solx-dev solc build

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -339,12 +339,15 @@ impl<'context> Builder<'context> {
 
     // ==== Terminators ====
 
-    /// Emits a `sol.revert` with an optional error signature and arguments.
+    /// Emits a `sol.revert` carrying an optional payload.
     ///
-    /// For custom errors (`revert MyError(x, y)`), pass the canonical
-    /// signature (e.g. `"MyError(uint256,address)"`) and the evaluated
-    /// argument values. For plain reverts, pass an empty signature and no
-    /// args.
+    /// `signature` doubles as the payload string: for custom errors
+    /// (`revert MyError(x, y)`) it is the canonical signature
+    /// (`"MyError(uint256,address)"`) and the evaluated arguments are passed
+    /// in `args` with `is_custom_error = true`. For string-message reverts
+    /// (`revert("message")`) it is the literal message, with no `args` and
+    /// `is_custom_error = false`. For plain `revert()` it is empty, with no
+    /// `args` and `is_custom_error = false`.
     // TODO(sol-dialect): mark `sol.revert` as `IsTerminator` like `sol.return`
     // so callers don't need to append `llvm.unreachable` after it.
     ///

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -339,25 +339,35 @@ impl<'context> Builder<'context> {
 
     // ==== Terminators ====
 
-    /// Emits a `sol.revert` with an empty signature (no error data).
+    /// Emits a `sol.revert` with an optional error signature and arguments.
+    ///
+    /// For custom errors (`revert MyError(x, y)`), pass the canonical
+    /// signature (e.g. `"MyError(uint256,address)"`) and the evaluated
+    /// argument values. For plain reverts, pass an empty signature and no
+    /// args.
     // TODO(sol-dialect): mark `sol.revert` as `IsTerminator` like `sol.return`
     // so callers don't need to append `llvm.unreachable` after it.
     ///
     /// # Panics
     ///
     /// Panics if the MLIR operation cannot be constructed, indicating a bug in the builder.
-    pub fn emit_sol_revert<'block, B>(&self, block: &B)
-    where
+    pub fn emit_sol_revert<'block, B>(
+        &self,
+        signature: &str,
+        args: &[Value<'context, 'block>],
+        is_custom_error: bool,
+        block: &B,
+    ) where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        block.append_operation(
-            RevertOperation::builder(self.context, self.unknown_location)
-                .signature(StringAttribute::new(self.context, ""))
-                .args(&[])
-                .build()
-                .into(),
-        );
+        let mut builder = RevertOperation::builder(self.context, self.unknown_location)
+            .signature(StringAttribute::new(self.context, signature))
+            .args(args);
+        if is_custom_error {
+            builder = builder.call(Attribute::unit(self.context));
+        }
+        block.append_operation(builder.build().into());
     }
 
     /// Emits a `sol.assert` panic if the condition is false.

--- a/solx-mlir/tests/lit/revert.sol
+++ b/solx-mlir/tests/lit/revert.sol
@@ -1,0 +1,35 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"plain_revert()"
+// CHECK:   sol.revert ""
+
+// CHECK: sol.func @"message_revert()"
+// CHECK:   sol.revert "oops"
+
+// CHECK: sol.func @"custom_error(uint256)"
+// CHECK:   sol.revert "TooLow(uint256,uint256)" %{{.*}}, %{{.*}} : ui256, {{.*}} {call}
+
+// CHECK: sol.func @"custom_error_named(uint256)"
+// CHECK:   %[[X:.*]] = sol.load
+// CHECK:   %[[C:.*]] = sol.constant 100
+// CHECK:   sol.revert "TooLow(uint256,uint256)" %[[X]], %[[C]] : ui256, {{.*}} {call}
+
+contract C {
+    error TooLow(uint256 supplied, uint256 minimum);
+
+    function plain_revert() public pure {
+        revert();
+    }
+
+    function message_revert() public pure {
+        revert("oops");
+    }
+
+    function custom_error(uint256 x) public pure {
+        revert TooLow(x, 100);
+    }
+
+    function custom_error_named(uint256 x) public pure {
+        revert TooLow({minimum: 100, supplied: x});
+    }
+}

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -106,7 +106,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 let expression = expression_statement.expression();
                 if let Expression::FunctionCallExpression(call) = &expression
                     && let Expression::Identifier(identifier) = call.operand()
-                    && identifier.name() == "revert"
+                    && identifier.name() == revert::IDENTIFIER
                 {
                     return self.emit_revert_call(call, block);
                 }

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -3,15 +3,16 @@
 //!
 
 pub mod control_flow;
+pub mod revert;
 
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Region;
 use melior::ir::Type;
 use slang_solidity::backend::SemanticAnalysis;
+use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::Statement;
 use slang_solidity::backend::ir::ast::Statements;
 use slang_solidity::cst::NodeId;
@@ -103,6 +104,12 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             }
             Statement::ExpressionStatement(expression_statement) => {
                 let expression = expression_statement.expression();
+                if let Expression::FunctionCallExpression(call) = &expression
+                    && let Expression::Identifier(identifier) = call.operand()
+                    && identifier.name() == "revert"
+                {
+                    return self.emit_revert_call(call, block);
+                }
                 let emitter = ExpressionEmitter::new(
                     &self.semantic,
                     self.state,
@@ -130,15 +137,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 self.checked = saved_checked;
                 result
             }
-            Statement::RevertStatement(_revert) => {
-                // TODO: encode custom error data from revert arguments
-                self.state.builder.emit_sol_revert(&block);
-                // TODO(sol-dialect): remove once sol.revert is marked IsTerminator
-                block.append_operation(melior::dialect::llvm::unreachable(
-                    self.state.builder.unknown_location,
-                ));
-                Ok(None)
-            }
+            Statement::RevertStatement(revert) => self.emit_revert(revert, block),
             _ => anyhow::bail!(
                 "unsupported statement: {:?}",
                 std::mem::discriminant(statement)

--- a/solx-slang/src/ast/contract/function/statement/revert.rs
+++ b/solx-slang/src/ast/contract/function/statement/revert.rs
@@ -17,6 +17,9 @@ use slang_solidity::backend::ir::ast::RevertStatement;
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::statement::StatementEmitter;
 
+/// Identifier the parser uses to recognize the Solidity `revert` built-in.
+pub const IDENTIFIER: &str = "revert";
+
 /// Revert arguments evaluated in ABI order.
 struct EvaluatedRevertArguments<'context, 'block> {
     /// Evaluated argument values.

--- a/solx-slang/src/ast/contract/function/statement/revert.rs
+++ b/solx-slang/src/ast/contract/function/statement/revert.rs
@@ -1,0 +1,214 @@
+//! Revert statement lowering.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use melior::ir::BlockLike;
+use melior::ir::BlockRef;
+use melior::ir::Value;
+use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
+use slang_solidity::backend::ir::ast::Definition;
+use slang_solidity::backend::ir::ast::Expression;
+use slang_solidity::backend::ir::ast::FunctionCallExpression;
+use slang_solidity::backend::ir::ast::NamedArguments;
+use slang_solidity::backend::ir::ast::Parameters;
+use slang_solidity::backend::ir::ast::RevertStatement;
+
+use crate::ast::contract::function::expression::ExpressionEmitter;
+use crate::ast::contract::function::statement::StatementEmitter;
+
+/// Revert arguments evaluated in ABI order.
+struct EvaluatedRevertArguments<'context, 'block> {
+    /// Evaluated argument values.
+    values: Vec<Value<'context, 'block>>,
+    /// Current block after evaluating all arguments.
+    block: BlockRef<'context, 'block>,
+}
+
+impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
+    /// Emits a `sol.revert` for a `revert ErrorName(args);` statement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the error path resolves to a non-Error definition,
+    /// the canonical signature cannot be computed, named arguments cannot be
+    /// matched to error parameters, or any argument expression cannot be
+    /// lowered.
+    ///
+    /// # Returns None
+    ///
+    /// Always returns `None` because `sol.revert` terminates control flow.
+    pub fn emit_revert(
+        &self,
+        revert: &RevertStatement,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
+        let error = match revert.error().resolve_to_definition() {
+            None => {
+                self.state.builder.emit_sol_revert("", &[], false, &block);
+                // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
+                block.append_operation(melior::dialect::llvm::unreachable(
+                    self.state.builder.unknown_location,
+                ));
+                return Ok(None);
+            }
+            Some(Definition::Error(error)) => error,
+            Some(_) => anyhow::bail!("revert target does not resolve to an error definition"),
+        };
+        let signature = error.compute_canonical_signature().ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot compute canonical signature for error `{}`",
+                error.name().name()
+            )
+        })?;
+        let parameters = error.parameters();
+        let evaluated = match revert.arguments() {
+            ArgumentsDeclaration::PositionalArguments(positional) => {
+                self.emit_revert_argument_values(positional.iter(), block)?
+            }
+            ArgumentsDeclaration::NamedArguments(named) => {
+                let ordered = Self::order_named_revert_arguments(&named, &parameters)?;
+                self.emit_revert_argument_values(ordered, block)?
+            }
+        };
+        self.state
+            .builder
+            .emit_sol_revert(&signature, &evaluated.values, true, &evaluated.block);
+        // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
+        evaluated
+            .block
+            .append_operation(melior::dialect::llvm::unreachable(
+                self.state.builder.unknown_location,
+            ));
+        Ok(None)
+    }
+
+    /// Emits a `sol.revert` for the call form `revert()` or `revert("message")`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the arguments are not positional, more than one
+    /// argument is supplied, the message argument is not a string literal, or
+    /// the message is empty (which would emit ambiguous bytecode under the
+    /// current Sol dialect; `revert()` is the no-data form).
+    ///
+    /// # Returns None
+    ///
+    /// Always returns `None` because `sol.revert` terminates control flow.
+    pub fn emit_revert_call(
+        &self,
+        call: &FunctionCallExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
+        let ArgumentsDeclaration::PositionalArguments(positional_arguments) = &call.arguments()
+        else {
+            anyhow::bail!("only positional arguments supported");
+        };
+        let mut arguments = positional_arguments.iter();
+        let message_argument = arguments.next();
+        anyhow::ensure!(
+            arguments.next().is_none(),
+            "revert accepts at most one argument"
+        );
+        let signature: String = match message_argument {
+            None => String::new(),
+            Some(Expression::StringExpression(string_expression)) => {
+                let message = String::from_utf8(string_expression.value())
+                    .expect("revert message is valid UTF-8");
+                anyhow::ensure!(
+                    !message.is_empty(),
+                    "revert(\"\") would emit ambiguous bytecode under the current Sol dialect; use revert() for no-data revert"
+                );
+                message
+            }
+            Some(_) => anyhow::bail!("revert message must be a string literal"),
+        };
+        self.state
+            .builder
+            .emit_sol_revert(&signature, &[], false, &block);
+        // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
+        block.append_operation(melior::dialect::llvm::unreachable(
+            self.state.builder.unknown_location,
+        ));
+        Ok(None)
+    }
+
+    /// Orders named revert arguments by the custom error's parameter declaration order.
+    fn order_named_revert_arguments(
+        named_arguments: &NamedArguments,
+        error_parameters: &Parameters,
+    ) -> anyhow::Result<Vec<Expression>> {
+        let mut arguments = HashMap::new();
+        for argument in named_arguments.iter() {
+            match arguments.entry(argument.name().name()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(argument.value());
+                }
+                Entry::Occupied(entry) => {
+                    anyhow::bail!("duplicate named revert argument `{}`", entry.key());
+                }
+            }
+        }
+
+        let mut ordered_arguments = Vec::new();
+        for parameter in error_parameters.iter() {
+            let parameter_name = parameter
+                .name()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("cannot match named revert argument to unnamed error parameter")
+                })?
+                .name();
+            let argument = arguments.remove(&parameter_name).ok_or_else(|| {
+                anyhow::anyhow!("missing named revert argument `{parameter_name}`")
+            })?;
+            ordered_arguments.push(argument);
+        }
+
+        anyhow::ensure!(
+            arguments.is_empty(),
+            "unknown named revert argument(s): {}",
+            arguments
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        Ok(ordered_arguments)
+    }
+
+    /// Evaluates revert argument expressions left-to-right, threading the
+    /// current MLIR block through each evaluation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any argument expression cannot be lowered.
+    fn emit_revert_argument_values<Arguments>(
+        &self,
+        arguments: Arguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<EvaluatedRevertArguments<'context, 'block>>
+    where
+        Arguments: IntoIterator<Item = Expression>,
+    {
+        let emitter = ExpressionEmitter::new(
+            &self.semantic,
+            self.state,
+            self.environment,
+            self.storage_layout,
+            self.checked,
+        );
+        let mut values = Vec::new();
+        let mut current_block = block;
+        for argument in arguments {
+            let (value, next_block) = emitter.emit_value(&argument, current_block)?;
+            values.push(value);
+            current_block = next_block;
+        }
+
+        Ok(EvaluatedRevertArguments {
+            values,
+            block: current_block,
+        })
+    }
+}


### PR DESCRIPTION
Lowers `revert ErrorName(args);`, `revert();`, and `revert("message");` to `sol.revert` followed by a transitional `llvm.unreachable` (until the dialect marks `sol.revert` `IsTerminator`). The custom-error form resolves the error definition, computes the canonical signature, and supports both positional and named arguments — reordering named ones to declaration order. The call form bails on `revert("")` because the empty signature collides with the plain-revert encoding under the current Sol dialect; use `revert()` for the no-data form.

## Newly passing tests

- `tests/solidity/simple/error/default.sol` (the `new_error` case migrates from FAILED to PASSED; the other 5 cases were already passing)
- `tests/solidity/simple/error/revert1.sol` (both cases migrate from INVALID to PASSED)

## Suite stats (`tests/solidity/simple`)

|         | Before | After |
|---------|-------:|------:|
| Passing |   1529 |  1532 |
| Failed  |     16 |    15 |
| Invalid |    418 |   417 |

## Other revert tests still not passing

- `error/revert2.sol` (uses `require(cond, runtimeStringVar)` — non-literal require message; not supported by the C++ MLIR reference either)
- `error/revert3.sol`, `revert4.sol`, `revert5.sol` (use `require(cond, f1())` returning `string memory` — hit the `type_conversion.rs:45` `unsupported Slang type` panic for `String`)
- `yul_instructions/revert.sol` (Yul `revert(...)` inline-assembly statement — assembly lowering is a separate track)
- `solidity_by_example/simple/error.sol` (uses `address(this).balance` — `unsupported member access: balance`)
- `solidity_by_example/simple/error_account.sol` (relies on the auto-generated public state-var getter `balance` — separate gap)
- `try_catch/error_as_bytes.sol`, `try_catch/revert_long_data.sol` (try/catch lowering not supported)