### PR TITLE
feat(mlir): add lit tests

### DIFF
--- a/solx-mlir/tests/lit/.gitignore
+++ b/solx-mlir/tests/lit/.gitignore
@@ -1,0 +1,2 @@
+Output/
+.lit_test_times.txt

--- a/solx-mlir/tests/lit/address_cast.sol
+++ b/solx-mlir/tests/lit/address_cast.sol
@@ -1,0 +1,11 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"to_address(uint256)"
+// CHECK:   sol.cast %{{.*}} : ui256 to ui160
+// CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
+
+contract C {
+    function to_address(uint256 x) public pure returns (address) {
+        return address(uint160(x));
+    }
+}

--- a/solx-mlir/tests/lit/arithmetic.sol
+++ b/solx-mlir/tests/lit/arithmetic.sol
@@ -1,0 +1,110 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"checked_add(uint256,uint256)"
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"checked_sub(uint256,uint256)"
+// CHECK:   sol.csub %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"checked_mul(uint256,uint256)"
+// CHECK:   sol.cmul %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"checked_div(uint256,uint256)"
+// CHECK:   sol.cdiv %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"checked_mod(uint256,uint256)"
+// CHECK:   sol.mod %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"checked_exp(uint256,uint256)"
+// CHECK:   sol.cexp %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unchecked_add(uint256,uint256)"
+// CHECK:   sol.add %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unchecked_sub(uint256,uint256)"
+// CHECK:   sol.sub %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unchecked_mul(uint256,uint256)"
+// CHECK:   sol.mul %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unchecked_div(uint256,uint256)"
+// CHECK:   sol.div %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unchecked_exp(uint256,uint256)"
+// CHECK:   sol.exp %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"unary_neg(int256)"
+// CHECK:   %{{.*}} = sol.sub %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @"signed_add(int256,int256)"
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @"signed_div(int256,int256)"
+// CHECK:   sol.cdiv %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @"signed_shr(int256,uint256)"
+// CHECK:   sol.shr %{{.*}}, %{{.*}} : si256
+
+contract C {
+    function checked_add(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+
+    function checked_sub(uint256 a, uint256 b) public pure returns (uint256) {
+        return a - b;
+    }
+
+    function checked_mul(uint256 a, uint256 b) public pure returns (uint256) {
+        return a * b;
+    }
+
+    function checked_div(uint256 a, uint256 b) public pure returns (uint256) {
+        return a / b;
+    }
+
+    function checked_mod(uint256 a, uint256 b) public pure returns (uint256) {
+        return a % b;
+    }
+
+    function checked_exp(uint256 a, uint256 b) public pure returns (uint256) {
+        return a ** b;
+    }
+
+    function unchecked_add(uint256 a, uint256 b) public pure returns (uint256) {
+        unchecked { return a + b; }
+    }
+
+    function unchecked_sub(uint256 a, uint256 b) public pure returns (uint256) {
+        unchecked { return a - b; }
+    }
+
+    function unchecked_mul(uint256 a, uint256 b) public pure returns (uint256) {
+        unchecked { return a * b; }
+    }
+
+    function unchecked_div(uint256 a, uint256 b) public pure returns (uint256) {
+        unchecked { return a / b; }
+    }
+
+    function unchecked_exp(uint256 a, uint256 b) public pure returns (uint256) {
+        unchecked { return a ** b; }
+    }
+
+    function unary_neg(int256 a) public pure returns (int256) {
+        unchecked {
+            return -a;
+        }
+    }
+
+    function signed_add(int256 a, int256 b) public pure returns (int256) {
+        return a + b;
+    }
+
+    function signed_div(int256 a, int256 b) public pure returns (int256) {
+        return a / b;
+    }
+
+    function signed_shr(int256 a, uint256 b) public pure returns (int256) {
+        return a >> b;
+    }
+}

--- a/solx-mlir/tests/lit/assert.sol
+++ b/solx-mlir/tests/lit/assert.sol
@@ -1,0 +1,12 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"check(uint256)"
+// CHECK:   %[[COND:.*]] = sol.cmp gt
+// CHECK:   sol.assert %[[COND]]
+
+contract C {
+    function check(uint256 x) public pure returns (uint256) {
+        assert(x > 0);
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/bitwise.sol
+++ b/solx-mlir/tests/lit/bitwise.sol
@@ -1,0 +1,45 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"bit_and(uint256,uint256)"
+// CHECK:   sol.and %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"bit_or(uint256,uint256)"
+// CHECK:   sol.or %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"bit_xor(uint256,uint256)"
+// CHECK:   sol.xor %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"bit_not(uint256)"
+// CHECK:   sol.xor %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"shift_left(uint256,uint256)"
+// CHECK:   sol.shl %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"shift_right(uint256,uint256)"
+// CHECK:   sol.shr %{{.*}}, %{{.*}} : ui256
+
+contract C {
+    function bit_and(uint256 a, uint256 b) public pure returns (uint256) {
+        return a & b;
+    }
+
+    function bit_or(uint256 a, uint256 b) public pure returns (uint256) {
+        return a | b;
+    }
+
+    function bit_xor(uint256 a, uint256 b) public pure returns (uint256) {
+        return a ^ b;
+    }
+
+    function bit_not(uint256 a) public pure returns (uint256) {
+        return ~a;
+    }
+
+    function shift_left(uint256 a, uint256 b) public pure returns (uint256) {
+        return a << b;
+    }
+
+    function shift_right(uint256 a, uint256 b) public pure returns (uint256) {
+        return a >> b;
+    }
+}

--- a/solx-mlir/tests/lit/comparison.sol
+++ b/solx-mlir/tests/lit/comparison.sol
@@ -1,0 +1,45 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"eq(uint256,uint256)"
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"ne(uint256,uint256)"
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"lt(uint256,uint256)"
+// CHECK:   sol.cmp lt, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"le(uint256,uint256)"
+// CHECK:   sol.cmp le, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"gt(uint256,uint256)"
+// CHECK:   sol.cmp gt, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @"ge(uint256,uint256)"
+// CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : ui256
+
+contract C {
+    function eq(uint256 a, uint256 b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function ne(uint256 a, uint256 b) public pure returns (bool) {
+        return a != b;
+    }
+
+    function lt(uint256 a, uint256 b) public pure returns (bool) {
+        return a < b;
+    }
+
+    function le(uint256 a, uint256 b) public pure returns (bool) {
+        return a <= b;
+    }
+
+    function gt(uint256 a, uint256 b) public pure returns (bool) {
+        return a > b;
+    }
+
+    function ge(uint256 a, uint256 b) public pure returns (bool) {
+        return a >= b;
+    }
+}

--- a/solx-mlir/tests/lit/compound_assignment.sol
+++ b/solx-mlir/tests/lit/compound_assignment.sol
@@ -1,0 +1,103 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"add_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.cadd %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"sub_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.csub %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"mul_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.cmul %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"div_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.cdiv %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"mod_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.mod %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"and_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.and %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"or_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.or %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"xor_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.xor %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"shl_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.shl %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+// CHECK: sol.func @"shr_assign(uint256,uint256)"
+// CHECK:   %[[X:.*]] = sol.load %[[PTR:.*]] :
+// CHECK:   sol.shr %[[X]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+
+contract C {
+    function add_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x += y;
+        return x;
+    }
+
+    function sub_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x -= y;
+        return x;
+    }
+
+    function mul_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x *= y;
+        return x;
+    }
+
+    function div_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x /= y;
+        return x;
+    }
+
+    function mod_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x %= y;
+        return x;
+    }
+
+    function and_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x &= y;
+        return x;
+    }
+
+    function or_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x |= y;
+        return x;
+    }
+
+    function xor_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x ^= y;
+        return x;
+    }
+
+    function shl_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x <<= y;
+        return x;
+    }
+
+    function shr_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x >>= y;
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/control_flow.sol
+++ b/solx-mlir/tests/lit/control_flow.sol
@@ -1,0 +1,119 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"if_else(uint256)"
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.return
+// CHECK:   } else {
+// CHECK:     sol.return
+
+// CHECK: sol.func @"while_loop(uint256)"
+// CHECK:   sol.while {
+// CHECK:     sol.condition %{{.*}}
+// CHECK:   } do {
+// CHECK:     sol.yield
+
+// For-loop step uses unchecked add (sol.add not sol.cadd)
+// CHECK: sol.func @"for_loop(uint256)"
+// CHECK:   sol.for cond {
+// CHECK:     sol.condition %{{.*}}
+// CHECK:   } body {
+// CHECK:     sol.yield
+// CHECK:   } step {
+// CHECK:     sol.add %
+// CHECK:     sol.yield
+
+// CHECK: sol.func @"do_while(uint256)"
+// CHECK:   sol.do {
+// CHECK:     sol.yield
+// CHECK:   } while {
+// CHECK:     sol.condition %{{.*}}
+
+// CHECK: sol.func @"infinite_for()"
+// CHECK:   sol.for cond {
+// CHECK:     %[[TRUE:.*]] = arith.constant true
+// CHECK:     sol.condition %[[TRUE]]
+// CHECK:   } body {
+
+// CHECK: sol.func @"with_break(uint256)"
+// CHECK:   sol.while {
+// CHECK:     sol.condition
+// CHECK:   } do {
+// CHECK:     sol.if
+// CHECK:       sol.break
+
+// CHECK: sol.func @"with_continue(uint256)"
+// CHECK:   sol.while {
+// CHECK:     sol.condition
+// CHECK:   } do {
+// CHECK:     sol.if
+// CHECK:       sol.continue
+
+contract C {
+    function if_else(uint256 x) public pure returns (uint256) {
+        if (x > 10) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    function while_loop(uint256 n) public pure returns (uint256) {
+        uint256 sum = 0;
+        uint256 i = 0;
+        while (i < n) {
+            sum = sum + i;
+            i = i + 1;
+        }
+        return sum;
+    }
+
+    function for_loop(uint256 n) public pure returns (uint256) {
+        uint256 sum = 0;
+        for (uint256 i = 0; i < n; i++) {
+            sum = sum + i;
+        }
+        return sum;
+    }
+
+    function do_while(uint256 n) public pure returns (uint256) {
+        uint256 i = 0;
+        do {
+            i = i + 1;
+        } while (i < n);
+        return i;
+    }
+
+    function infinite_for() public pure returns (uint256) {
+        uint256 i = 0;
+        for (;;) {
+            i = i + 1;
+            if (i == 10) {
+                return i;
+            }
+        }
+    }
+
+    function with_break(uint256 n) public pure returns (uint256) {
+        uint256 i = 0;
+        while (i < n) {
+            if (i == 5) {
+                break;
+            }
+            i = i + 1;
+        }
+        return i;
+    }
+
+    function with_continue(uint256 n) public pure returns (uint256) {
+        uint256 sum = 0;
+        uint256 i = 0;
+        while (i < n) {
+            i = i + 1;
+            if (i == 3) {
+                continue;
+            }
+            sum = sum + i;
+        }
+        return sum;
+    }
+}

--- a/solx-mlir/tests/lit/evm_context.sol
+++ b/solx-mlir/tests/lit/evm_context.sol
@@ -1,0 +1,73 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"get_sender()"
+// CHECK:   sol.caller : !sol.address
+
+// CHECK: sol.func @"get_value()"
+// CHECK:   sol.callvalue : ui256
+
+// CHECK: sol.func @"get_origin()"
+// CHECK:   sol.origin : !sol.address
+
+// CHECK: sol.func @"get_gasprice()"
+// CHECK:   sol.gasprice : ui256
+
+// CHECK: sol.func @"get_timestamp()"
+// CHECK:   sol.timestamp : ui256
+
+// CHECK: sol.func @"get_number()"
+// CHECK:   sol.blocknumber : ui256
+
+// CHECK: sol.func @"get_coinbase()"
+// CHECK:   sol.coinbase : !sol.address
+
+// CHECK: sol.func @"get_chainid()"
+// CHECK:   sol.chainid : ui256
+
+// CHECK: sol.func @"get_basefee()"
+// CHECK:   sol.basefee : ui256
+
+// CHECK: sol.func @"get_gaslimit()"
+// CHECK:   sol.gaslimit : ui256
+
+contract C {
+    function get_sender() public view returns (address) {
+        return msg.sender;
+    }
+
+    function get_value() public payable returns (uint256) {
+        return msg.value;
+    }
+
+    function get_origin() public view returns (address) {
+        return tx.origin;
+    }
+
+    function get_gasprice() public view returns (uint256) {
+        return tx.gasprice;
+    }
+
+    function get_timestamp() public view returns (uint256) {
+        return block.timestamp;
+    }
+
+    function get_number() public view returns (uint256) {
+        return block.number;
+    }
+
+    function get_coinbase() public view returns (address) {
+        return block.coinbase;
+    }
+
+    function get_chainid() public view returns (uint256) {
+        return block.chainid;
+    }
+
+    function get_basefee() public view returns (uint256) {
+        return block.basefee;
+    }
+
+    function get_gaslimit() public view returns (uint256) {
+        return block.gaslimit;
+    }
+}

--- a/solx-mlir/tests/lit/function_calls.sol
+++ b/solx-mlir/tests/lit/function_calls.sol
@@ -1,0 +1,25 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"add(uint256,uint256)"(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+// CHECK:   sol.cadd
+
+// CHECK: sol.func @"double
+// CHECK:   sol.call @"add(uint256,uint256)"(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @"chain
+// CHECK:   sol.call @"double(uint256)"
+// CHECK:   sol.call @"add(uint256,uint256)"
+
+contract C {
+    function add(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+
+    function double(uint256 x) public pure returns (uint256) {
+        return add(x, x);
+    }
+
+    function chain(uint256 x) public pure returns (uint256) {
+        return add(double(x), x);
+    }
+}

--- a/solx-mlir/tests/lit/hex_literal.sol
+++ b/solx-mlir/tests/lit/hex_literal.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"hex_val()"
+// CHECK:   sol.constant 255 : ui8
+
+contract C {
+    function hex_val() public pure returns (uint256) {
+        return 0xff;
+    }
+}

--- a/solx-mlir/tests/lit/increment_decrement.sol
+++ b/solx-mlir/tests/lit/increment_decrement.sol
@@ -1,0 +1,43 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"prefix_inc(uint256)"
+// CHECK:   %[[OLD:.*]] = sol.load
+// CHECK:   %[[NEW:.*]] = sol.cadd %[[OLD]]
+// CHECK:   sol.store %[[NEW]]
+// CHECK:   sol.return %[[NEW]]
+
+// CHECK: sol.func @"postfix_inc(uint256)"
+// CHECK:   %[[OLD:.*]] = sol.load
+// CHECK:   %[[NEW:.*]] = sol.cadd %[[OLD]]
+// CHECK:   sol.store %[[NEW]]
+// CHECK:   sol.return %[[OLD]]
+
+// CHECK: sol.func @"prefix_dec(uint256)"
+// CHECK:   %[[OLD:.*]] = sol.load
+// CHECK:   %[[NEW:.*]] = sol.csub %[[OLD]]
+// CHECK:   sol.store %[[NEW]]
+// CHECK:   sol.return %[[NEW]]
+
+// CHECK: sol.func @"postfix_dec(uint256)"
+// CHECK:   %[[OLD:.*]] = sol.load
+// CHECK:   %[[NEW:.*]] = sol.csub %[[OLD]]
+// CHECK:   sol.store %[[NEW]]
+// CHECK:   sol.return %[[OLD]]
+
+contract C {
+    function prefix_inc(uint256 x) public pure returns (uint256) {
+        return ++x;
+    }
+
+    function postfix_inc(uint256 x) public pure returns (uint256) {
+        return x++;
+    }
+
+    function prefix_dec(uint256 x) public pure returns (uint256) {
+        return --x;
+    }
+
+    function postfix_dec(uint256 x) public pure returns (uint256) {
+        return x--;
+    }
+}

--- a/solx-mlir/tests/lit/int_types.sol
+++ b/solx-mlir/tests/lit/int_types.sol
@@ -1,0 +1,38 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"uint8_arith(uint8,uint8)"(%{{.*}}: ui8, %{{.*}}: ui8) -> ui8
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : ui8
+
+// CHECK: sol.func @"uint128_arith(uint128,uint128)"(%{{.*}}: ui128, %{{.*}}: ui128) -> ui128
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : ui128
+
+// CHECK: sol.func @"int256_arith(int256,int256)"(%{{.*}}: si256, %{{.*}}: si256) -> si256
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @"bool_return
+// CHECK:   %true = arith.constant true
+
+// CHECK: sol.func @"bool_false
+// CHECK:   %false = arith.constant false
+
+contract C {
+    function uint8_arith(uint8 a, uint8 b) public pure returns (uint8) {
+        return a + b;
+    }
+
+    function uint128_arith(uint128 a, uint128 b) public pure returns (uint128) {
+        return a + b;
+    }
+
+    function int256_arith(int256 a, int256 b) public pure returns (int256) {
+        return a + b;
+    }
+
+    function bool_return() public pure returns (bool) {
+        return true;
+    }
+
+    function bool_false() public pure returns (bool) {
+        return false;
+    }
+}

--- a/solx-mlir/tests/lit/lit.cfg.py
+++ b/solx-mlir/tests/lit/lit.cfg.py
@@ -1,0 +1,15 @@
+import os
+import lit.formats
+
+config.name = "solx-mlir"
+config.test_format = lit.formats.ShTest(True)
+config.suffixes = [".sol"]
+
+config_dir = os.path.dirname(os.path.abspath(__file__))
+solx_root = os.path.join(config_dir, "..", "..", "..")
+solx_bin_dir = os.path.join(solx_root, "target-slang", "debug")
+
+config.environment["PATH"] = solx_bin_dir + os.pathsep + os.environ.get("PATH", "")
+
+config.test_source_root = config_dir
+config.test_exec_root = os.path.join(config_dir, "Output")

--- a/solx-mlir/tests/lit/local_variables.sol
+++ b/solx-mlir/tests/lit/local_variables.sol
@@ -1,0 +1,45 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// Default init: alloca, store zero, load back.
+// CHECK: sol.func @"default_init()"
+// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui256
+// CHECK:   sol.store %[[ZERO]], %[[PTR]] : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   %[[VAL:.*]] = sol.load %[[PTR]] : !sol.ptr<ui256, Stack>, ui256
+// CHECK:   sol.return %[[VAL]] : ui256
+
+// Explicit init: alloca, store initializer, load back.
+// CHECK: sol.func @"explicit_init()"
+// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   sol.store %{{.*}}, %[[PTR]] : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   %[[VAL:.*]] = sol.load %[[PTR]] : !sol.ptr<ui256, Stack>, ui256
+// CHECK:   sol.return %[[VAL]] : ui256
+
+// Reassign: load, compute, store back to same alloca.
+// CHECK: sol.func @"reassign(uint256)"
+// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   sol.store %arg0, %[[PTR]]
+// CHECK:   %[[V1:.*]] = sol.load %[[PTR]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   %[[V2:.*]] = sol.load %[[PTR]]
+// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   %[[RET:.*]] = sol.load %[[PTR]]
+// CHECK:   sol.return %[[RET]]
+
+contract C {
+    function default_init() public pure returns (uint256) {
+        uint256 x;
+        return x;
+    }
+
+    function explicit_init() public pure returns (uint256) {
+        uint256 x = 42;
+        return x;
+    }
+
+    function reassign(uint256 x) public pure returns (uint256) {
+        x = x + 1;
+        x = x * 2;
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/logical.sol
+++ b/solx-mlir/tests/lit/logical.sol
@@ -1,0 +1,44 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// Short-circuit &&: result defaults to false, then-branch stores b.
+// CHECK: sol.func @"logical_and(bool,bool)"
+// CHECK:   %[[FALSE:.*]] = arith.constant false
+// CHECK:   sol.store %[[FALSE]], %[[RES:.*]] :
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.store %{{.*}}, %[[RES]]
+// CHECK:     sol.yield
+// CHECK:   } else {
+// CHECK:     sol.yield
+// CHECK:   }
+// CHECK:   %[[RET:.*]] = sol.load %[[RES]]
+// CHECK:   sol.return %[[RET]]
+
+// Short-circuit ||: result defaults to true, else-branch stores b.
+// CHECK: sol.func @"logical_or(bool,bool)"
+// CHECK:   %[[TRUE:.*]] = arith.constant true
+// CHECK:   sol.store %[[TRUE]], %[[RES:.*]] :
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.yield
+// CHECK:   } else {
+// CHECK:     sol.store %{{.*}}, %[[RES]]
+// CHECK:     sol.yield
+// CHECK:   }
+// CHECK:   %[[RET:.*]] = sol.load %[[RES]]
+// CHECK:   sol.return %[[RET]]
+
+// CHECK: sol.func @"logical_not(bool)"
+// CHECK:   %[[COND:.*]] = sol.cmp eq, %{{.*}}, %{{.*}} : i1
+
+contract C {
+    function logical_and(bool a, bool b) public pure returns (bool) {
+        return a && b;
+    }
+
+    function logical_or(bool a, bool b) public pure returns (bool) {
+        return a || b;
+    }
+
+    function logical_not(bool a) public pure returns (bool) {
+        return !a;
+    }
+}

--- a/solx-mlir/tests/lit/mutability.sol
+++ b/solx-mlir/tests/lit/mutability.sol
@@ -1,0 +1,26 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"pure_fn(uint256)"{{.*}} state_mutability = #{{.*}}Pure
+// CHECK: sol.func @"view_fn()"{{.*}} state_mutability = #{{.*}}View
+// CHECK: sol.func @"payable_fn()"{{.*}} state_mutability = #{{.*}}Payable
+// CHECK: sol.func @"nonpayable_fn(uint256)"{{.*}} state_mutability = #{{.*}}NonPayable
+
+contract C {
+    uint256 x;
+
+    function pure_fn(uint256 a) public pure returns (uint256) {
+        return a;
+    }
+
+    function view_fn() public view returns (uint256) {
+        return x;
+    }
+
+    function payable_fn() public payable returns (uint256) {
+        return msg.value;
+    }
+
+    function nonpayable_fn(uint256 val) public {
+        x = val;
+    }
+}

--- a/solx-mlir/tests/lit/require.sol
+++ b/solx-mlir/tests/lit/require.sol
@@ -1,0 +1,21 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"check(uint256)"
+// CHECK:   %[[COND:.*]] = sol.cmp gt
+// CHECK:   sol.require %[[COND]]
+
+// CHECK: sol.func @"check_msg(uint256)"
+// CHECK:   %[[COND:.*]] = sol.cmp gt
+// CHECK:   sol.require %[[COND]]
+
+contract C {
+    function check(uint256 x) public pure returns (uint256) {
+        require(x > 0);
+        return x;
+    }
+
+    function check_msg(uint256 x) public pure returns (uint256) {
+        require(x > 0, "must be positive");
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/return_constant.sol
+++ b/solx-mlir/tests/lit/return_constant.sol
@@ -1,0 +1,19 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// Comprehensive test - checks the full Sol dialect module structure.
+
+// CHECK:      module attributes {llvm.data_layout = "E-p:256:256-i256:256:256-S256-a:256:256", llvm.target_triple = "evm-unknown-unknown"
+// CHECK:        sol.contract @C {
+// CHECK-NEXT:     sol.func @"f()"() -> ui256
+// CHECK:            %c42_ui8 = sol.constant 42 : ui8
+// CHECK-NEXT:       %0 = sol.cast %c42_ui8 : ui8 to ui256
+// CHECK-NEXT:       sol.return %0 : ui256
+// CHECK:          sol.func @"constructor()"() attributes {kind = #Constructor
+// CHECK:            sol.return
+// CHECK:        } {kind = #Contract}
+
+contract C {
+    function f() public pure returns (uint256) {
+        return 42;
+    }
+}

--- a/solx-mlir/tests/lit/scoping.sol
+++ b/solx-mlir/tests/lit/scoping.sol
@@ -1,0 +1,25 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"nested_scope()"
+// CHECK:   sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   sol.alloca : !sol.ptr<ui256, Stack>
+
+// CHECK: sol.func @"default_return()"
+// CHECK:   sol.constant 42
+// CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui256
+// CHECK:   sol.return %[[ZERO]] : ui256
+
+contract C {
+    function nested_scope() public pure returns (uint256) {
+        uint256 x = 1;
+        {
+            uint256 y = 2;
+            x = x + y;
+        }
+        return x;
+    }
+
+    function default_return() public pure returns (uint256) {
+        uint256 x = 42;
+    }
+}

--- a/solx-mlir/tests/lit/special_functions.sol
+++ b/solx-mlir/tests/lit/special_functions.sol
@@ -1,0 +1,21 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"receive()"() attributes {kind = #{{.*}}Receive, state_mutability = #{{.*}}Payable}
+// CHECK: sol.func @"fallback()"() attributes {kind = #{{.*}}Fallback, state_mutability = #{{.*}}Payable}
+// CHECK: sol.func @"constructor()"() attributes {kind = #{{.*}}Constructor
+
+contract C {
+    uint256 x;
+
+    constructor(uint256 val) {
+        x = val;
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+
+    function get() public view returns (uint256) {
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/state_variables.sol
+++ b/solx-mlir/tests/lit/state_variables.sol
@@ -1,0 +1,49 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK-DAG: sol.state_var @slot_0 slot 0 offset 0 : ui256
+// CHECK-DAG: sol.state_var @slot_1 slot 1 offset 0 : ui256
+
+// Read: addr_of -> load -> return
+// CHECK: sol.func @"get_x()"
+// CHECK:   %[[PTR:.*]] = sol.addr_of @slot_0 : !sol.ptr<ui256, Storage>
+// CHECK:   %[[VAL:.*]] = sol.load %[[PTR]] : !sol.ptr<ui256, Storage>, ui256
+// CHECK:   sol.return %[[VAL]]
+
+// Write: addr_of -> store
+// CHECK: sol.func @"set_x(uint256)"
+// CHECK:   %[[PTR:.*]] = sol.addr_of @slot_0 : !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %[[PTR]] : ui256, !sol.ptr<ui256, Storage>
+
+// Swap: load both, store crossed
+// CHECK: sol.func @"swap()"
+// CHECK:   %[[P0:.*]] = sol.addr_of @slot_0
+// CHECK:   sol.load %[[P0]]
+// CHECK:   %[[P1:.*]] = sol.addr_of @slot_1
+// CHECK:   sol.load %[[P1]]
+// CHECK:   sol.addr_of @slot_0
+// CHECK:   sol.store
+// CHECK:   sol.addr_of @slot_1
+// CHECK:   sol.store
+
+contract C {
+    uint256 x;
+    uint256 y;
+
+    function get_x() public view returns (uint256) {
+        return x;
+    }
+
+    function set_x(uint256 val) public {
+        x = val;
+    }
+
+    function get_y() public view returns (uint256) {
+        return y;
+    }
+
+    function swap() public {
+        uint256 tmp = x;
+        x = y;
+        y = tmp;
+    }
+}

--- a/solx-mlir/tests/lit/type_casts.sol
+++ b/solx-mlir/tests/lit/type_casts.sol
@@ -1,0 +1,31 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"uint8_to_uint256(uint8)"
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+
+// CHECK: sol.func @"uint256_to_uint8(uint256)"
+// CHECK:   sol.cast %{{.*}} : ui256 to ui8
+
+// CHECK: sol.func @"int_to_uint(int256)"
+// CHECK:   sol.cast %{{.*}} : si256 to ui256
+
+// CHECK: sol.func @"uint_to_bool(uint256)"
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : ui256
+
+contract C {
+    function uint8_to_uint256(uint8 x) public pure returns (uint256) {
+        return uint256(x);
+    }
+
+    function uint256_to_uint8(uint256 x) public pure returns (uint8) {
+        return uint8(x);
+    }
+
+    function int_to_uint(int256 x) public pure returns (uint256) {
+        return uint256(x);
+    }
+
+    function uint_to_bool(uint256 x) public pure returns (bool) {
+        return x != 0;
+    }
+}


### PR DESCRIPTION
## Summary

- Add lit/FileCheck tests for the Slang MLIR frontend (20 tests)
- Add `--emit-mlir=sol`/`--emit-mlir=llvm` to filter output by dialect
- Fix non-deterministic state_var emission order

## Test plan

- `lit solx-mlir/tests/lit/` - 20/20 pass