### PR TITLE
build: bump rustls-webpki to 0.103.13 for RUSTSEC-2026-0104

### DIFF
--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -1,3 +1,3 @@
 [[allow.exact]]
 crate = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,9 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Fixes a reachable panic in CRL parsing (empty BIT STRING in IssuingDistributionPoint::onlySomeReasons). The fix was published 2026-04-21, so the cargo-cooldown allowlist exception is moved from 0.103.12 to 0.103.13 to cover the 7-day cooldown window.