### PR TITLE
ci(llvm): disable Windows LLVM tools via install-distribution (#364)

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -52,15 +52,10 @@ runs:
   using: "composite"
   steps:
 
-    # Compute the cmake --extra-args list once, then (a) persist to a file for
-    # the Build LLVM step to re-use verbatim, and (b) hash into the artifact
-    # cache key so flag changes invalidate stale entries. Without hashing,
-    # changing output-affecting flags (e.g. LLVM_BUILD_TOOLS) while reusing
-    # the old cache key would let a pre-change entry satisfy a post-change
-    # restore — confusing or wrong installs. Non-output-affecting flag tweaks
-    # also rotate the key here; the one-time cache miss is cheap with ccache
-    # as fallback and the alternative (remembering to update the key when
-    # adding an output-affecting flag) doesn't hold up to reviewer discipline.
+    # Build the cmake --extra-args list once and hash it into the artifact
+    # cache key, so any output-affecting flag change invalidates stale
+    # entries automatically. Non-output-affecting tweaks rotate the key
+    # too — one-time cold build, cheap behind ccache.
     - name: Compute LLVM build config
       id: build-config
       shell: bash
@@ -78,9 +73,11 @@ runs:
           "-DLLVM_OPTIMIZED_TABLEGEN='On'"
         )
 
-        # Windows: skip LLVM tool binaries to cut lld-link wall-clock, but keep
-        # llvm-config (llvm-sys needs it at Rust build time) via the per-tool
-        # LLVM_TOOL_<name>_BUILD override. See #364 for background.
+        # Windows: skip ~200 LLVM tool binaries to cut lld-link wall-clock.
+        # llvm-config is still needed by llvm-sys at Rust build time — the
+        # Build LLVM step below force-builds and installs it manually.
+        # LLVM_TOOL_LLVM_CONFIG_BUILD is set defensively; LLVM's current
+        # cmake doesn't honour it for install rules (see #364).
         if [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_ARGS+=(
             "-DLLVM_BUILD_TOOLS='Off'"
@@ -89,8 +86,8 @@ runs:
           )
         fi
 
-        # Step outputs can't round-trip bash array semantics cleanly with
-        # special chars; write to a file instead.
+        # Persist to a file — step outputs don't round-trip bash array
+        # semantics with the embedded quotes.
         printf '%s\n' "${EXTRA_ARGS[@]}" > "${RUNNER_TEMP}/llvm-extra-args"
         ARGS_HASH=$(sha256sum "${RUNNER_TEMP}/llvm-extra-args" | head -c 8)
         echo "args-hash=${ARGS_HASH}" | tee -a "${GITHUB_OUTPUT}"
@@ -110,11 +107,8 @@ runs:
         KEY="${KEY}-args${{ steps.build-config.outputs.args-hash }}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
-    # TEMP(ci:windows-tools): forced-miss so Build LLVM always runs and the
-    # Windows tool-disable change is actually exercised. REVERT BEFORE MERGE.
     - name: Restore LLVM artifact cache
       id: llvm-artifact-cache
-      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}
@@ -181,7 +175,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: true # TEMP(ci:windows-tools): populate ccache on PR events so a follow-up push to this branch can measure warm-ccache + tool-disable. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
+        save: ${{ github.event_name != 'pull_request' }}
 
     - name: Build LLVM
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
@@ -208,10 +202,8 @@ runs:
           fi
         fi
 
-        # Load the cmake --extra-args computed in the Compute LLVM build config
-        # step (also hashed into the cache key). `while read` instead of
-        # `readarray` for macOS compatibility — macOS ships bash 3.2 by default
-        # and readarray is bash 4+.
+        # Read the --extra-args written by "Compute LLVM build config".
+        # `while read` rather than `readarray` — macOS ships bash 3.2.
         EXTRA_ARGS=()
         while IFS= read -r line; do
           EXTRA_ARGS+=("$line")
@@ -221,16 +213,10 @@ runs:
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "${EXTRA_ARGS[@]}"
 
-        # With LLVM_BUILD_TOOLS=Off, LLVM's cmake marks every tool (including
-        # llvm-config) EXCLUDE_FROM_ALL and — critically — registers no install
-        # rule for them (`install(TARGETS ...)` is hard-gated on
-        # LLVM_BUILD_TOOLS=On in `llvm_add_tool`). But `llvm-sys` (pulled in by
-        # inkwell) needs `${LLVM_SYS_211_PREFIX}/bin/llvm-config.exe` at Rust
-        # crate-build time. Force-build the target (overrides EXCLUDE_FROM_ALL)
-        # and copy the binary into the install prefix by hand. The `LLVM_TOOL_
-        # LLVM_CONFIG_BUILD=On` flag is still set in EXTRA_ARGS for symmetry /
-        # future-proofing if LLVM's cmake grows an honoured hook, but it's the
-        # manual ninja+cp below that actually does the work today.
+        # LLVM_BUILD_TOOLS=Off marks every tool EXCLUDE_FROM_ALL and skips
+        # its install rule (`install(TARGETS ...)` in `llvm_add_tool` is
+        # gated on it). llvm-sys needs llvm-config.exe in the install
+        # prefix at Rust build time, so force-build and copy it by hand.
         if [ "${{ runner.os }}" = "Windows" ]; then
           ninja -C target-llvm/build-final llvm-config
           mkdir -p target-llvm/target-final/bin

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -209,8 +209,13 @@ runs:
         fi
 
         # Load the cmake --extra-args computed in the Compute LLVM build config
-        # step (also hashed into the cache key).
-        readarray -t EXTRA_ARGS < "${RUNNER_TEMP}/llvm-extra-args"
+        # step (also hashed into the cache key). `while read` instead of
+        # `readarray` for macOS compatibility — macOS ships bash 3.2 by default
+        # and readarray is bash 4+.
+        EXTRA_ARGS=()
+        while IFS= read -r line; do
+          EXTRA_ARGS+=("$line")
+        done < "${RUNNER_TEMP}/llvm-extra-args"
 
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -221,6 +221,22 @@ runs:
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "${EXTRA_ARGS[@]}"
 
+        # With LLVM_BUILD_TOOLS=Off, LLVM's cmake marks every tool (including
+        # llvm-config) EXCLUDE_FROM_ALL and — critically — registers no install
+        # rule for them (`install(TARGETS ...)` is hard-gated on
+        # LLVM_BUILD_TOOLS=On in `llvm_add_tool`). But `llvm-sys` (pulled in by
+        # inkwell) needs `${LLVM_SYS_211_PREFIX}/bin/llvm-config.exe` at Rust
+        # crate-build time. Force-build the target (overrides EXCLUDE_FROM_ALL)
+        # and copy the binary into the install prefix by hand. The `LLVM_TOOL_
+        # LLVM_CONFIG_BUILD=On` flag is still set in EXTRA_ARGS for symmetry /
+        # future-proofing if LLVM's cmake grows an honoured hook, but it's the
+        # manual ninja+cp below that actually does the work today.
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          ninja -C target-llvm/build-final llvm-config
+          mkdir -p target-llvm/target-final/bin
+          cp target-llvm/build-final/bin/llvm-config.exe target-llvm/target-final/bin/
+        fi
+
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.
     - name: Show ccache stats

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -52,59 +52,23 @@ runs:
   using: "composite"
   steps:
 
-    # Build the cmake --extra-args list once and hash it into the artifact
-    # cache key, so any output-affecting flag change invalidates stale
-    # entries automatically. Non-output-affecting tweaks rotate the key
-    # too — one-time cold build, cheap behind ccache.
-    - name: Compute LLVM build config
-      id: build-config
-      shell: bash
-      run: |
-        # macos-15 ARM runner is 3 vCPU / 7 GB RAM; two parallel RelWithDebInfo
-        # links exceed RAM and push into swap. 2 fits 14-16 GB runners fine.
-        LINK_JOBS=2
-        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
-          LINK_JOBS=1
-        fi
-
-        EXTRA_ARGS=(
-          "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'"
-          "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'"
-          "-DLLVM_OPTIMIZED_TABLEGEN='On'"
-        )
-
-        # Windows: skip ~200 LLVM tool binaries to cut lld-link wall-clock.
-        # llvm-config is still needed by llvm-sys at Rust build time — the
-        # Build LLVM step below force-builds and installs it manually.
-        # LLVM_TOOL_LLVM_CONFIG_BUILD is set defensively; LLVM's current
-        # cmake doesn't honour it for install rules (see #364).
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          EXTRA_ARGS+=(
-            "-DLLVM_BUILD_TOOLS='Off'"
-            "-DLLVM_INCLUDE_TOOLS='On'"
-            "-DLLVM_TOOL_LLVM_CONFIG_BUILD='On'"
-          )
-        fi
-
-        # Persist to a file — step outputs don't round-trip bash array
-        # semantics with the embedded quotes.
-        printf '%s\n' "${EXTRA_ARGS[@]}" > "${RUNNER_TEMP}/llvm-extra-args"
-        ARGS_HASH=$(sha256sum "${RUNNER_TEMP}/llvm-extra-args" | head -c 8)
-        echo "args-hash=${ARGS_HASH}" | tee -a "${GITHUB_OUTPUT}"
-
     - name: Compute LLVM cache key
       id: llvm-cache
       shell: bash
       working-directory: ${{ inputs.working-dir }}
       run: |
         SHA=$(git -C solx-llvm rev-parse HEAD)
+        # solx-dev owns LLVM-build cmake args (shared.rs + platforms/*.rs).
+        # Hash that tree into the key so Rust-side flag changes invalidate
+        # stale artifact-cache entries automatically. Truncate for readability.
+        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir)) }}' | head -c 8)
         KEY="v1-llvm-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
-        KEY="${KEY}-args${{ steps.build-config.outputs.args-hash }}-${SHA}"
+        KEY="${KEY}-dev${DEV_HASH}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Restore LLVM artifact cache
@@ -202,26 +166,18 @@ runs:
           fi
         fi
 
-        # Read the --extra-args written by "Compute LLVM build config".
-        # `while read` rather than `readarray` — macOS ships bash 3.2.
-        EXTRA_ARGS=()
-        while IFS= read -r line; do
-          EXTRA_ARGS+=("$line")
-        done < "${RUNNER_TEMP}/llvm-extra-args"
+        # macos-15 ARM runner is 3 vCPU / 7 GB RAM; two parallel RelWithDebInfo
+        # links exceed RAM and push into swap. 2 fits 14-16 GB runners fine.
+        LINK_JOBS=2
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
+          LINK_JOBS=1
+        fi
 
+        # Windows tool-disable + install-distribution live in solx-dev
+        # (see solx-dev/src/llvm/platforms/{shared,x86_64_windows_gnu}.rs).
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
-          --extra-args "${EXTRA_ARGS[@]}"
-
-        # LLVM_BUILD_TOOLS=Off marks every tool EXCLUDE_FROM_ALL and skips
-        # its install rule (`install(TARGETS ...)` in `llvm_add_tool` is
-        # gated on it). llvm-sys needs llvm-config.exe in the install
-        # prefix at Rust build time, so force-build and copy it by hand.
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          ninja -C target-llvm/build-final llvm-config
-          mkdir -p target-llvm/target-final/bin
-          cp target-llvm/build-final/bin/llvm-config.exe target-llvm/target-final/bin/
-        fi
+          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -52,6 +52,49 @@ runs:
   using: "composite"
   steps:
 
+    # Compute the cmake --extra-args list once, then (a) persist to a file for
+    # the Build LLVM step to re-use verbatim, and (b) hash into the artifact
+    # cache key so flag changes invalidate stale entries. Without hashing,
+    # changing output-affecting flags (e.g. LLVM_BUILD_TOOLS) while reusing
+    # the old cache key would let a pre-change entry satisfy a post-change
+    # restore — confusing or wrong installs. Non-output-affecting flag tweaks
+    # also rotate the key here; the one-time cache miss is cheap with ccache
+    # as fallback and the alternative (remembering to update the key when
+    # adding an output-affecting flag) doesn't hold up to reviewer discipline.
+    - name: Compute LLVM build config
+      id: build-config
+      shell: bash
+      run: |
+        # macos-15 ARM runner is 3 vCPU / 7 GB RAM; two parallel RelWithDebInfo
+        # links exceed RAM and push into swap. 2 fits 14-16 GB runners fine.
+        LINK_JOBS=2
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
+          LINK_JOBS=1
+        fi
+
+        EXTRA_ARGS=(
+          "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'"
+          "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'"
+          "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+        )
+
+        # Windows: skip LLVM tool binaries to cut lld-link wall-clock, but keep
+        # llvm-config (llvm-sys needs it at Rust build time) via the per-tool
+        # LLVM_TOOL_<name>_BUILD override. See #364 for background.
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          EXTRA_ARGS+=(
+            "-DLLVM_BUILD_TOOLS='Off'"
+            "-DLLVM_INCLUDE_TOOLS='On'"
+            "-DLLVM_TOOL_LLVM_CONFIG_BUILD='On'"
+          )
+        fi
+
+        # Step outputs can't round-trip bash array semantics cleanly with
+        # special chars; write to a file instead.
+        printf '%s\n' "${EXTRA_ARGS[@]}" > "${RUNNER_TEMP}/llvm-extra-args"
+        ARGS_HASH=$(sha256sum "${RUNNER_TEMP}/llvm-extra-args" | head -c 8)
+        echo "args-hash=${ARGS_HASH}" | tee -a "${GITHUB_OUTPUT}"
+
     - name: Compute LLVM cache key
       id: llvm-cache
       shell: bash
@@ -64,7 +107,7 @@ runs:
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
-        KEY="${KEY}-${SHA}"
+        KEY="${KEY}-args${{ steps.build-config.outputs.args-hash }}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Restore LLVM artifact cache
@@ -162,20 +205,13 @@ runs:
           fi
         fi
 
-        # With ccache at 99%+ hit rate, link time dominates. Each LLVM tool link
-        # peaks at 2-4 GB RSS on RelWithDebInfo. The hosted macos-15 ARM runner
-        # has 3 vCPU / 7 GB RAM — two parallel links alone can exceed RAM and
-        # push into swap, which is net slower than serialized links. The intel
-        # macos-15 has 14 GB and handles 2 parallel links fine, as do Linux and
-        # Windows hosted (16 GB).
-        LINK_JOBS=2
-        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
-          LINK_JOBS=1
-        fi
+        # Load the cmake --extra-args computed in the Compute LLVM build config
+        # step (also hashed into the cache key).
+        readarray -t EXTRA_ARGS < "${RUNNER_TEMP}/llvm-extra-args"
 
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
           --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
-          --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
+          --extra-args "${EXTRA_ARGS[@]}"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -110,8 +110,11 @@ runs:
         KEY="${KEY}-args${{ steps.build-config.outputs.args-hash }}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    # TEMP(ci:windows-tools): forced-miss so Build LLVM always runs and the
+    # Windows tool-disable change is actually exercised. REVERT BEFORE MERGE.
     - name: Restore LLVM artifact cache
       id: llvm-artifact-cache
+      if: false
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}
@@ -178,7 +181,7 @@ runs:
         append-timestamp: true
         max-size: "10G"
         verbose: 2
-        save: ${{ github.event_name != 'pull_request' }}
+        save: true # TEMP(ci:windows-tools): populate ccache on PR events so a follow-up push to this branch can measure warm-ccache + tool-disable. REVERT BEFORE MERGE to `${{ github.event_name != 'pull_request' }}`.
 
     - name: Build LLVM
       if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'

--- a/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
@@ -76,6 +76,6 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install")?;
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/aarch64_macos.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_macos.rs
@@ -66,7 +66,7 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install")?;
 
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -172,21 +172,25 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
 /// never invokes any LLVM tool at runtime (it consumes LLVM as a library via
 /// inkwell), so linking them is pure waste. `LLVM_BUILD_TOOLS=Off` marks every
 /// tool `EXCLUDE_FROM_ALL`; `LLVM_INCLUDE_TOOLS=On` keeps `tools/` in the
-/// configure pass so the umbrella targets (`llvm-libraries`, `llvm-config`) are
-/// defined. `LLVM_DISTRIBUTION_COMPONENTS` whitelists the install set, which
+/// configure pass so the umbrella targets (`llvm-libraries` etc.) are defined.
+/// `LLVM_DISTRIBUTION_COMPONENTS` whitelists the install set, which
 /// `install-distribution` then honours — see #364.
 ///
-/// `llvm-config` is included because `llvm-sys` shells out to it at Rust build
-/// time to discover include paths and link flags. `lld-*` is always included
-/// because `shared_build_opts_projects` always enables `lld`. `mlir-*` is
-/// included only when `enable_mlir` is true.
+/// `llvm-config` is deliberately **not** in the distribution list: with
+/// `LLVM_BUILD_TOOLS=Off`, `llvm_add_tool` never creates the `install-llvm-config`
+/// cmake target (both `install(TARGETS)` and `add_llvm_install_targets` are
+/// gated on `LLVM_BUILD_TOOLS`), so referencing it here errors at configure
+/// time. `llvm-sys` still needs `llvm-config` at Rust build time — the Windows
+/// builder builds it via direct `ninja llvm-config` and copies the binary into
+/// the install prefix after `install-distribution` completes.
+/// `lld-*` is always included because `shared_build_opts_projects` always
+/// enables `lld`. `mlir-*` is included only when `enable_mlir` is true.
 ///
 pub fn windows_build_opts_distribution(enable_mlir: bool) -> Vec<String> {
     let mut components = vec![
         "llvm-libraries",
         "llvm-headers",
         "cmake-exports",
-        "llvm-config",
         "lld-libraries",
         "lld-headers",
         "lld-cmake-exports",

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -165,6 +165,43 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
 }
 
 ///
+/// Windows-only: configure an `install-distribution` that ships only what solx
+/// needs, skipping the ~200 LLVM tool binaries (`opt.exe`, `llc.exe`, ...).
+///
+/// `lld-link` dominates LLVM build wall-clock on the hosted Windows runner; solx
+/// never invokes any LLVM tool at runtime (it consumes LLVM as a library via
+/// inkwell), so linking them is pure waste. `LLVM_BUILD_TOOLS=Off` marks every
+/// tool `EXCLUDE_FROM_ALL`; `LLVM_INCLUDE_TOOLS=On` keeps `tools/` in the
+/// configure pass so the umbrella targets (`llvm-libraries`, `llvm-config`) are
+/// defined. `LLVM_DISTRIBUTION_COMPONENTS` whitelists the install set, which
+/// `install-distribution` then honours — see #364.
+///
+/// `llvm-config` is included because `llvm-sys` shells out to it at Rust build
+/// time to discover include paths and link flags. `lld-*` is always included
+/// because `shared_build_opts_projects` always enables `lld`. `mlir-*` is
+/// included only when `enable_mlir` is true.
+///
+pub fn windows_build_opts_distribution(enable_mlir: bool) -> Vec<String> {
+    let mut components = vec![
+        "llvm-libraries",
+        "llvm-headers",
+        "cmake-exports",
+        "llvm-config",
+        "lld-libraries",
+        "lld-headers",
+        "lld-cmake-exports",
+    ];
+    if enable_mlir {
+        components.extend(["mlir-libraries", "mlir-headers", "mlir-cmake-exports"]);
+    }
+    vec![
+        "-DLLVM_BUILD_TOOLS='Off'".to_owned(),
+        "-DLLVM_INCLUDE_TOOLS='On'".to_owned(),
+        format!("-DLLVM_DISTRIBUTION_COMPONENTS='{}'", components.join(";")),
+    ]
+}
+
+///
 /// Ignore duplicate libraries warnings for MacOS with XCode>=15.
 ///
 pub fn macos_build_opts_ignore_dupicate_libs_warnings() -> Vec<String> {

--- a/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
@@ -76,6 +76,6 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install")?;
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/x86_64_macos.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_macos.rs
@@ -66,7 +66,7 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install")?;
 
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -94,7 +94,10 @@ pub fn build(
     fs_extra::file::copy(
         crate::utils::path_windows_to_unix(llvm_config_source)?,
         crate::utils::path_windows_to_unix(llvm_config_dest_dir.join("llvm-config.exe"))?,
-        &fs_extra::file::CopyOptions::default(),
+        &fs_extra::file::CopyOptions {
+            overwrite: true,
+            ..Default::default()
+        },
     )?;
 
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
@@ -108,7 +111,10 @@ pub fn build(
     fs_extra::file::copy(
         crate::utils::path_windows_to_unix(libstdcpp_source_path)?,
         crate::utils::path_windows_to_unix(libstdcpp_destination_path)?,
-        &fs_extra::file::CopyOptions::default(),
+        &fs_extra::file::CopyOptions {
+            overwrite: true,
+            ..Default::default()
+        },
     )?;
 
     Ok(())

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -65,9 +65,7 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::windows_build_opts_distribution(
-                enable_mlir,
-            ))
+            .args(crate::llvm::platforms::shared::windows_build_opts_distribution(enable_mlir))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -65,6 +65,9 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::windows_build_opts_distribution(
+                enable_mlir,
+            ))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -72,7 +75,10 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    // Windows uses `install-distribution` + an explicit LLVM_DISTRIBUTION_COMPONENTS
+    // whitelist (set by `windows_build_opts_distribution`) to skip installing the
+    // ~200 LLVM tool binaries solx doesn't use. See #364.
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
 
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
         Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -78,6 +78,25 @@ pub fn build(
     // ~200 LLVM tool binaries solx doesn't use. See #364.
     crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
 
+    // `llvm-config` is excluded from the distribution because LLVM_BUILD_TOOLS=Off
+    // prevents its install target from ever being defined. Build and copy it by
+    // hand so llvm-sys can find it at Rust build time.
+    crate::utils::command(
+        Command::new("ninja")
+            .arg("-C")
+            .arg(&*llvm_build_final_str)
+            .arg("llvm-config"),
+        "Building llvm-config",
+    )?;
+    let llvm_config_source = llvm_build_final.join("bin").join("llvm-config.exe");
+    let llvm_config_dest_dir = llvm_target_final.join("bin");
+    std::fs::create_dir_all(&llvm_config_dest_dir)?;
+    fs_extra::file::copy(
+        crate::utils::path_windows_to_unix(llvm_config_source)?,
+        crate::utils::path_windows_to_unix(llvm_config_dest_dir.join("llvm-config.exe"))?,
+        &fs_extra::file::CopyOptions::default(),
+    )?;
+
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
         Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
         Err(error) => anyhow::bail!(

--- a/solx-dev/src/utils.rs
+++ b/solx-dev/src/utils.rs
@@ -217,13 +217,21 @@ pub fn remove(project_directory: &Path, project_name: &str) -> anyhow::Result<()
 }
 
 ///
-/// Call ninja to build the LLVM.
+/// Call ninja to build and install LLVM via the given install target.
 ///
-pub fn ninja(build_dir: &Path) -> anyhow::Result<()> {
+/// Most platforms pass `"install"`; Windows passes `"install-distribution"`
+/// together with `LLVM_DISTRIBUTION_COMPONENTS` to skip installing the ~200
+/// LLVM tool binaries that solx doesn't use (it consumes LLVM as a library
+/// via inkwell). See #364 for the wall-clock motivation.
+///
+pub fn ninja(build_dir: &Path, install_target: &str) -> anyhow::Result<()> {
     let mut ninja = Command::new("ninja");
     let build_dir_str = build_dir.to_string_lossy();
     ninja.args(["-C", &*build_dir_str]);
-    command(ninja.arg("install"), "Running ninja install")?;
+    command(
+        ninja.arg(install_target),
+        &format!("Running ninja {install_target}"),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #364. (#360 and #374 have merged.)

## Summary

On Windows, `lld-link` dominates LLVM build wall-clock — solx never uses the ~200 LLVM tool binaries (`opt.exe`, `llc.exe`, …), it consumes LLVM as a library via inkwell. Disabling them cuts the Build LLVM step substantially. Windows-only; Linux/macOS aren't link-bound.

## Reading the commit sequence

History preserved rather than squashed. `d4ed092` → `8464bf2` introduced the tool-disable via Option A (YAML file round-trip + manual `llvm-config` copy). `2215148` + `143d86f` are the Option B end state (install-distribution + Rust-side logic). `d61fceb` / `d45c6a9` is a TEMP measurement pair (added and reverted in-branch — end state has no TEMP).

## Approach

Option B from #364: LLVM's `install-distribution` target with an explicit `LLVM_DISTRIBUTION_COMPONENTS` whitelist. All Windows-specific cmake logic lives in `solx-dev` Rust (`solx-dev/src/llvm/platforms/shared.rs::windows_build_opts_distribution`), co-located with the rest of the per-platform config.

- `LLVM_BUILD_TOOLS=Off` + `LLVM_INCLUDE_TOOLS=On`: umbrella targets (`llvm-libraries`, `lld-libraries`, `mlir-libraries`) stay defined, but tools are `EXCLUDE_FROM_ALL`.
- `LLVM_DISTRIBUTION_COMPONENTS='llvm-libraries;llvm-headers;cmake-exports;lld-libraries;lld-headers;lld-cmake-exports[;mlir-*]'`.
- `llvm-config` is deliberately **not** in the whitelist — cmake's `llvm_add_tool` gates `install-<name>` target creation on `LLVM_BUILD_TOOLS`, so including it errors at configure time. After `install-distribution`, the Rust Windows builder force-builds `ninja llvm-config` and copies the binary into the install prefix's `bin/` so `llvm-sys` can find it at Rust build time.
- `solx-dev/src/utils.rs::ninja(build_dir, install_target)` parameterizes the install target; non-Windows platforms pass `"install"`, Windows passes `"install-distribution"`.

YAML side (`.github/actions/build-llvm/action.yml`) shrinks accordingly: `--extra-args` goes back to inline form (just `CMAKE_EXPORT_COMPILE_COMMANDS`, `LLVM_PARALLEL_LINK_JOBS`, `LLVM_OPTIMIZED_TABLEGEN`). No file round-trip for args, no Windows-specific force-build bash in the workflow, no dead `LLVM_TOOL_LLVM_CONFIG_BUILD='On'` flag.

## Cache-key dimension

Swaps the `args<hash>` dimension (removed with the YAML simplification) for `dev<hash>` computed via `hashFiles('solx-dev/src/llvm/**')`. Any Rust-side flag change automatically invalidates stale artifact-cache entries.

## Timings (Windows)

Build LLVM step wall-clock, across reference runs:

| Config | Cold ccache | Warm ccache |
|---|---|---|
| No tool-disable (#360 baselines) | 3h 34min¹ | 42:16² |
| This PR, Option A form (force-build + cp) | — | 15:04³ |
| This PR, Option B form (install-distribution) | **2h 48min**⁴ | **17:52**⁵ |

Whole-job Windows wall-clock:

| Config | Cold | Warm |
|---|---|---|
| No tool-disable (#360) | 4h 31min | 1h 19min |
| This PR, Option B | 3h 11min⁴ | **39:34**⁵ |

- Warm Build LLVM: **42:16 → 17:52**, 24 min saved (**2.4× speedup**). Slightly above Option A's 15:04 but within Windows runner variance for a single sample; MSYS2 pin also changed the baseline clang from Option A's reference run.
- Warm whole job: **1h 19min → 39:34**, ~40 min saved.
- Cold Build LLVM: 3h 34min → 2h 48min, ~46 min saved (21%) — link-phase savings from skipping ~200 tool binaries applied to a fresh-compile run.

¹ Run [24731422129](https://github.com/NomicFoundation/solx/actions/runs/24731422129) — first cold run on #360
² Run [24751701680](https://github.com/NomicFoundation/solx/actions/runs/24751701680) — warm ccache, link-jobs tuned, on #360
³ Run [24786924891](https://github.com/NomicFoundation/solx/actions/runs/24786924891) — prior Option A form of this PR
⁴ Run [24829390293](https://github.com/NomicFoundation/solx/actions/runs/24829390293) — current HEAD, Option B, cold ccache (MSYS2 pin changed the baseline)
⁵ [Re-run of the Windows job](https://github.com/NomicFoundation/solx/actions/runs/24829390293/job/72704011954) on the same head SHA, warm ccache populated by run 4

## Post-merge note

First push to `main` after merge invalidates the artifact cache on every platform — the new `dev<hash>` cache-key dimension doesn't match any existing entry. ccache uses a separate key and is unaffected, so Linux/macOS rebuild quickly via ccache fallback; Windows is the long pole at up to ~3h depending on ccache state. Subsequent pushes restore against the freshly-seeded entries.

