### PR TITLE
feat(slang): integer literal narrowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,7 +2577,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "metaslang_bindings"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "metaslang_cst"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
 dependencies = [
  "nom 8.0.0",
  "serde",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "metaslang_graph_builder"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "metaslang_stack_graphs"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
 dependencies = [
  "bitvec",
  "controlled-option",
@@ -4282,12 +4282,13 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6f892dff8e2d6d275cfe9737c3cb364486c41410#6f892dff8e2d6d275cfe9737c3cb364486c41410"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
 dependencies = [
  "indexmap 2.14.0",
  "metaslang_bindings",
  "metaslang_cst",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "paste",
  "semver 1.0.28",
@@ -4450,6 +4451,7 @@ dependencies = [
  "inkwell",
  "melior",
  "mlir-sys",
+ "num",
  "solx-utils",
 ]
 

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -11,6 +11,7 @@ cc = "1.2.60"
 
 [dependencies]
 anyhow.workspace = true
+num.workspace = true
 melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -27,6 +27,7 @@ use melior::ir::attribute::TypeAttribute;
 use melior::ir::operation::OperationLike;
 use melior::ir::r#type::FunctionType;
 use melior::ir::r#type::IntegerType;
+use num::BigInt;
 
 use crate::CmpPredicate;
 use crate::StateMutability;
@@ -224,92 +225,85 @@ impl<'context> Builder<'context> {
             .into()
     }
 
-    /// Emits a `sol.constant` of the given type from a decimal string.
+    /// Emits a typed integer constant, selecting the dialect by target type.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the string cannot be parsed as an MLIR integer attribute.
-    pub fn emit_sol_constant_from_decimal_str<'block, B>(
-        &self,
-        value: &str,
-        result_type: Type<'context>,
-        block: &B,
-    ) -> anyhow::Result<Value<'context, 'block>>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        let attribute = Attribute::parse(self.context, &format!("{value} : {result_type}"))
-            .ok_or_else(|| anyhow::anyhow!("invalid {result_type} decimal literal: {value}"))?;
-        self.emit_constant_operation(attribute, result_type, block)
-    }
-
-    /// Emits a `sol.constant` of the given type from a hex string (without `0x` prefix).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the string cannot be parsed as an MLIR integer attribute.
-    pub fn emit_sol_constant_from_hex_str<'block, B>(
-        &self,
-        hexadecimal: &str,
-        result_type: Type<'context>,
-        block: &B,
-    ) -> anyhow::Result<Value<'context, 'block>>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        let attribute = Attribute::parse(self.context, &format!("0x{hexadecimal} : {result_type}"))
-            .ok_or_else(|| anyhow::anyhow!("invalid {result_type} hex literal: 0x{hexadecimal}"))?;
-        self.emit_constant_operation(attribute, result_type, block)
-    }
-
-    /// Emits an all-ones `sol.constant` for the given integer type.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the constant cannot be parsed as an MLIR integer attribute.
-    pub fn emit_sol_constant_all_ones<'block, B>(
-        &self,
-        integer_type: Type<'context>,
-        block: &B,
-    ) -> anyhow::Result<Value<'context, 'block>>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        let bit_width = TypeFactory::integer_bit_width(integer_type);
-        let all_ones_hex = "f".repeat(bit_width as usize / 4);
-        self.emit_sol_constant_from_hex_str(&all_ones_hex, integer_type, block)
-    }
-
-    /// Emits an `arith.constant` for a signless `i1` boolean value.
-    ///
-    /// Boolean (`i1`) is signless in MLIR, so it uses `arith.constant`
-    /// instead of `sol.constant` (which is for signed/unsigned int types).
+    /// `i1` is the signless boolean type owned by the arith dialect; every
+    /// other integer type is signed or unsigned and belongs to the sol
+    /// dialect. This is the single entry point for MLIR integer constants
+    /// that carry a `BigInt`-sized value.
     ///
     /// # Panics
     ///
-    /// Panics if the MLIR operation cannot be constructed.
-    pub fn emit_arith_constant_bool<'block, B>(
+    /// Panics if the MLIR attribute parser rejects the `{value} : {type}`
+    /// rendering. For well-typed callers this is unreachable because the
+    /// type is a melior `IntegerType` and the value is a `BigInt` that
+    /// always has a canonical decimal representation.
+    pub fn emit_constant<'block, B>(
         &self,
-        value: bool,
+        value: &BigInt,
+        result_type: Type<'context>,
         block: &B,
     ) -> Value<'context, 'block>
     where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
-        let i1_type = IntegerType::new(self.context, solx_utils::BIT_LENGTH_BOOLEAN as u32).into();
-        block
-            .append_operation(melior::dialect::arith::constant(
-                self.context,
-                IntegerAttribute::new(i1_type, i64::from(value)).into(),
-                self.unknown_location,
-            ))
-            .result(0)
-            .expect("arith.constant always produces one result")
-            .into()
+        if result_type == self.types.sol_address {
+            let integer = self.emit_constant(value, self.types.ui160, block);
+            return self.emit_sol_address_cast(integer, result_type, block);
+        }
+        if TypeFactory::integer_bit_width(result_type) == solx_utils::BIT_LENGTH_BOOLEAN as u32 {
+            let boolean_attribute =
+                IntegerAttribute::new(result_type, i64::from(*value != BigInt::ZERO)).into();
+            return block
+                .append_operation(melior::dialect::arith::constant(
+                    self.context,
+                    boolean_attribute,
+                    self.unknown_location,
+                ))
+                .result(0)
+                .expect("arith.constant always produces one result")
+                .into();
+        }
+        // melior does not expose a `BigInt`-accepting attribute constructor,
+        // so we round-trip through the MLIR attribute parser to avoid
+        // truncating values wider than 64 bits.
+        let attribute = Attribute::parse(self.context, &format!("{value} : {result_type}"))
+            .expect("BigInt value and melior integer type always parse as an MLIR attribute");
+        self.emit_constant_operation(attribute, result_type, block)
+            .expect("well-typed BigInt constant never fails emission")
+    }
+
+    /// Emits an `i1` boolean constant.
+    pub fn emit_bool<'block, B>(&self, value: bool, block: &B) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        self.emit_constant(&BigInt::from(u8::from(value)), self.types.i1, block)
+    }
+
+    /// Emits an all-ones `sol.constant` for the given integer type.
+    pub fn emit_sol_constant_all_ones<'block, B>(
+        &self,
+        integer_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        let all_ones = if IntegerType::try_from(integer_type)
+            .ok()
+            .is_some_and(|integer| integer.is_signed())
+        {
+            // Two's-complement all-ones for any signed width is `-1`.
+            BigInt::from(-1)
+        } else {
+            let bit_width = TypeFactory::integer_bit_width(integer_type);
+            (BigInt::from(1u32) << bit_width) - BigInt::from(1u32)
+        };
+        self.emit_constant(&all_ones, integer_type, block)
     }
 
     // ==== String literals ====

--- a/solx-mlir/tests/lit/literal_types.sol
+++ b/solx-mlir/tests/lit/literal_types.sol
@@ -1,0 +1,35 @@
+// RUN: solx --emit-mlir %s | FileCheck %s
+
+// CHECK: sol.func @"address_literal()"
+// CHECK:   sol.constant 255 : ui160
+// CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
+
+// CHECK: sol.func @"neg_int8()"
+// CHECK:   %[[POS:.*]] = sol.constant 1 : ui8
+// CHECK:   %[[CAST:.*]] = sol.cast %[[POS]] : ui8 to si8
+// CHECK:   %[[ZERO:.*]] = sol.constant 0 : si8
+// CHECK:   sol.sub %[[ZERO]], %[[CAST]] : si8
+
+// CHECK: sol.func @"ether_rational()"
+// CHECK:   sol.constant 500000000000000000 : ui64
+
+// CHECK: sol.func @"scientific()"
+// CHECK:   sol.constant 1000000000000000000 : ui64
+
+contract C {
+    function address_literal() public pure returns (address) {
+        return 0x00000000000000000000000000000000000000Ff;
+    }
+
+    function neg_int8() public pure returns (int8) {
+        return -1;
+    }
+
+    function ether_rational() public pure returns (uint256) {
+        return 0.5 ether;
+    }
+
+    function scientific() public pure returns (uint256) {
+        return 1e18;
+    }
+}

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -16,7 +16,7 @@ semver.workspace = true
 # `__private_testing_utils` is required by `__private_backend_api` internals
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 # TODO: pin to a release tag instead of branch = "main"
-slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "6f892dff8e2d6d275cfe9737c3cb364486c41410", features = ["__private_backend_api", "__private_testing_utils"] }
+slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "d8388d6bf696383627ece31ba3551880d0b9eafc", features = ["__private_backend_api", "__private_testing_utils"] }
 melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -105,7 +105,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let all_ones = self
                     .state
                     .builder
-                    .emit_sol_constant_all_ones(operand_type, &block)?;
+                    .emit_sol_constant_all_ones(operand_type, &block);
                 let result = block
                     .append_operation(
                         XorOperation::builder(

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -5,6 +5,7 @@
 use melior::ir::Type;
 use melior::ir::ValueLike;
 use melior::ir::r#type::IntegerType;
+use slang_solidity::backend::ir::ast::LiteralKind;
 use slang_solidity::backend::ir::ast::StateVariableDefinition;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 
@@ -41,7 +42,35 @@ impl<'context> TypeConversion<'context> {
                 solx_utils::BIT_LENGTH_BOOLEAN as u32,
             )),
             SlangType::Address(_) => builder.types.sol_address,
-            SlangType::Literal(_) => builder.types.ui256,
+            SlangType::Literal(literal_type) => match literal_type.kind() {
+                LiteralKind::Zero => Type::from(IntegerType::unsigned(
+                    builder.context,
+                    solx_utils::BIT_LENGTH_BYTE as u32,
+                )),
+                LiteralKind::Address => builder.types.sol_address,
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: true,
+                } => {
+                    let bits = bytes * solx_utils::BIT_LENGTH_BYTE as u32;
+                    Type::from(IntegerType::signed(builder.context, bits))
+                }
+                LiteralKind::DecimalInteger {
+                    bytes,
+                    signed: false,
+                }
+                | LiteralKind::HexInteger { bytes } => {
+                    let bits = bytes * solx_utils::BIT_LENGTH_BYTE as u32;
+                    Type::from(IntegerType::unsigned(builder.context, bits))
+                }
+                kind @ (LiteralKind::Rational
+                | LiteralKind::HexString { .. }
+                | LiteralKind::String { .. }) => {
+                    unimplemented!(
+                        "MLIR type resolution is not yet implemented for literal kind {kind:?}"
+                    )
+                }
+            },
             _ => unimplemented!("unsupported Slang type"),
         }
     }

--- a/solx-slang/src/ast/contract/function/expression/logical.rs
+++ b/solx-slang/src/ast/contract/function/expression/logical.rs
@@ -67,7 +67,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
         let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
-        let false_value = self.state.builder.emit_arith_constant_bool(false, &block);
+        let false_value = self.state.builder.emit_bool(false, &block);
         self.state
             .builder
             .emit_sol_store(false_value, result_ptr, &block);
@@ -111,7 +111,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
         let i1_type = self.state.builder.types.i1;
         let result_ptr = self.state.builder.emit_sol_alloca(i1_type, &block);
-        let true_value = self.state.builder.emit_arith_constant_bool(true, &block);
+        let true_value = self.state.builder.emit_bool(true, &block);
         self.state
             .builder
             .emit_sol_store(true_value, result_ptr, &block);

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -17,7 +17,6 @@ use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::ValueLike;
-use melior::ir::r#type::IntegerType;
 use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
@@ -93,48 +92,42 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
         match expression {
-            Expression::DecimalNumberExpression(decimal) => {
-                let literal = decimal.literal();
-                let text = literal.text.as_str();
-                // TODO: use resolve_expression_type once slang provides the
-                // implicit conversion target type for literals.
-                let digit_count = text.chars().filter(|char| *char != '_').count() as u32;
-                let approx_bits = (digit_count * 3322).div_ceil(1000);
-                let bit_width = Self::round_up_to_solidity_width(approx_bits);
-                let min_type =
-                    Type::from(IntegerType::unsigned(self.state.builder.context, bit_width));
-                let value = self
+            Expression::DecimalNumberExpression(decimal_number) => {
+                let value = decimal_number.integer_value().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "decimal literal cannot be lowered: it must evaluate to an integer \
+                         after applying any units"
+                    )
+                })?;
+                let result_type = self
+                    .resolve_expression_type(decimal_number.node_id())
+                    .expect("binder types every decimal literal node");
+                let constant = self
                     .state
                     .builder
-                    .emit_sol_constant_from_decimal_str(text, min_type, &block)?;
-                Ok((Some(value), block))
+                    .emit_constant(&value, result_type, &block);
+                Ok((Some(constant), block))
             }
-            Expression::HexNumberExpression(hex) => {
-                let literal = hex.literal();
-                let text = literal.text.as_str();
-                let stripped = text
-                    .strip_prefix("0x")
-                    .or(text.strip_prefix("0X"))
-                    .unwrap_or(text);
-                // TODO: use resolve_expression_type once slang provides the
-                // implicit conversion target type for literals.
-                let significant_digits = stripped.trim_start_matches('0').len() as u32;
-                let bit_width = Self::round_up_to_solidity_width(significant_digits * 4);
-                let min_type =
-                    Type::from(IntegerType::unsigned(self.state.builder.context, bit_width));
-                let value = self
+            Expression::HexNumberExpression(hex_number) => {
+                let value = hex_number
+                    .integer_value()
+                    .expect("hex literals always evaluate to integers");
+                let result_type = self
+                    .resolve_expression_type(hex_number.node_id())
+                    .expect("binder types every hex literal node");
+                let constant = self
                     .state
                     .builder
-                    .emit_sol_constant_from_hex_str(stripped, min_type, &block)?;
-                Ok((Some(value), block))
+                    .emit_constant(&value, result_type, &block);
+                Ok((Some(constant), block))
             }
             Expression::TrueKeyword => {
-                let value = self.state.builder.emit_arith_constant_bool(true, &block);
-                Ok((Some(value), block))
+                let constant = self.state.builder.emit_bool(true, &block);
+                Ok((Some(constant), block))
             }
             Expression::FalseKeyword => {
-                let value = self.state.builder.emit_arith_constant_bool(false, &block);
-                Ok((Some(value), block))
+                let constant = self.state.builder.emit_bool(false, &block);
+                Ok((Some(constant), block))
             }
             Expression::ThisKeyword => {
                 let contract_type = self
@@ -370,18 +363,5 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             &slang_type,
             &self.state.builder,
         ))
-    }
-
-    /// Rounds a bit count up to the nearest Solidity integer width.
-    ///
-    /// Solidity supports unsigned integers in 8-bit increments: 8, 16, 24, ..., 256.
-    /// Returns 8 for zero bits (smallest Solidity type).
-    fn round_up_to_solidity_width(bits: u32) -> u32 {
-        if bits == 0 {
-            return solx_utils::BIT_LENGTH_BYTE as u32;
-        }
-        let rounded =
-            bits.div_ceil(solx_utils::BIT_LENGTH_BYTE as u32) * solx_utils::BIT_LENGTH_BYTE as u32;
-        rounded.min(solx_utils::BIT_LENGTH_FIELD as u32)
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -357,6 +357,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     ///
     /// Returns `None` when the semantic analysis has no type info for the node.
     /// Panics on types that `resolve_slang_type` does not yet handle.
+    // TODO: slang's binder does not fold binary expressions of literal operands —
+    // its typing rules return the type of one operand (e.g. type of the left
+    // operand for shifts), so `1 << 100` gets typed as ui8 (the type of `1`)
+    // and constant subexpressions overflow at that width. solc folds via
+    // `RationalNumberType::binaryOperatorResult`, sizing the result to fit the
+    // folded value. Either teach slang to fold, or fold here before lowering.
     pub fn resolve_expression_type(&self, node_id: NodeId) -> Option<Type<'context>> {
         let slang_type = self.semantic.get_type_from_node_id(node_id)?;
         Some(TypeConversion::resolve_slang_type(

--- a/solx-slang/src/ast/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/ast/contract/function/statement/control_flow.rs
@@ -4,7 +4,6 @@
 
 use melior::ir::BlockRef;
 use melior::ir::RegionLike;
-
 use slang_solidity::backend::ir::ast::ForStatementCondition;
 use slang_solidity::backend::ir::ast::ForStatementInitialization;
 use slang_solidity::backend::ir::ast::Statement;
@@ -134,10 +133,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                     .emit_sol_condition(condition_boolean, &condition_end);
             }
             ForStatementCondition::Semicolon => {
-                let true_value = self
-                    .state
-                    .builder
-                    .emit_arith_constant_bool(true, &condition_block);
+                let true_value = self.state.builder.emit_bool(true, &condition_block);
                 self.state
                     .builder
                     .emit_sol_condition(true_value, &condition_block);

--- a/tests/solidity/simple/constant_expressions/literal_types.sol
+++ b/tests/solidity/simple/constant_expressions/literal_types.sol
@@ -1,0 +1,167 @@
+//! { "cases": [ {
+//!     "name": "neg_min_int8",
+//!     "inputs": [
+//!         {
+//!             "method": "neg_min_int8",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "-128"
+//!     ]
+//! }, {
+//!     "name": "neg_one_int8",
+//!     "inputs": [
+//!         {
+//!             "method": "neg_one_int8",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "-1"
+//!     ]
+//! }, {
+//!     "name": "bool_false",
+//!     "inputs": [
+//!         {
+//!             "method": "bool_false",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "0"
+//!     ]
+//! }, {
+//!     "name": "zero_literal",
+//!     "inputs": [
+//!         {
+//!             "method": "zero_literal",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "0"
+//!     ]
+//! }, {
+//!     "name": "bool_true",
+//!     "inputs": [
+//!         {
+//!             "method": "bool_true",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1"
+//!     ]
+//! }, {
+//!     "name": "hex_underscored",
+//!     "inputs": [
+//!         {
+//!             "method": "hex_underscored",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "239"
+//!     ]
+//! }, {
+//!     "name": "address_literal",
+//!     "inputs": [
+//!         {
+//!             "method": "address_literal",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "0x00000000000000000000000000000000000000ff"
+//!     ]
+//! }, {
+//!     "name": "time_units",
+//!     "inputs": [
+//!         {
+//!             "method": "time_units",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "86400"
+//!     ]
+//! }, {
+//!     "name": "digit_separators",
+//!     "inputs": [
+//!         {
+//!             "method": "digit_separators",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "2000000"
+//!     ]
+//! }, {
+//!     "name": "ether_unit",
+//!     "inputs": [
+//!         {
+//!             "method": "ether_unit",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1000000000000000000"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    function neg_min_int8() public pure returns (int8) {
+        return -128;
+    }
+
+    function neg_one_int8() public pure returns (int8) {
+        return -1;
+    }
+
+    function bool_false() public pure returns (bool) {
+        return false;
+    }
+
+    function zero_literal() public pure returns (uint256) {
+        return 0;
+    }
+
+    function bool_true() public pure returns (bool) {
+        return true;
+    }
+
+    function hex_underscored() public pure returns (uint256) {
+        return 0xde_ad_be_ef & 0xff;
+    }
+
+    function address_literal() public pure returns (address) {
+        return 0x00000000000000000000000000000000000000Ff;
+    }
+
+    function time_units() public pure returns (uint256) {
+        return 1 days;
+    }
+
+    function digit_separators() public pure returns (uint256) {
+        return 1_000_000 * 2;
+    }
+
+    function ether_unit() public pure returns (uint256) {
+        return 1 ether;
+    }
+}

--- a/tests/solidity/simple/constant_expressions/rational_literals.sol
+++ b/tests/solidity/simple/constant_expressions/rational_literals.sol
@@ -1,0 +1,135 @@
+//! { "cases": [ {
+//!     "name": "half_minute",
+//!     "inputs": [
+//!         {
+//!             "method": "half_minute",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "30"
+//!     ]
+//! }, {
+//!     "name": "half_gwei",
+//!     "inputs": [
+//!         {
+//!             "method": "half_gwei",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "500000000"
+//!     ]
+//! }, {
+//!     "name": "quarter_ether",
+//!     "inputs": [
+//!         {
+//!             "method": "quarter_ether",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "250000000000000000"
+//!     ]
+//! }, {
+//!     "name": "half_ether",
+//!     "inputs": [
+//!         {
+//!             "method": "half_ether",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "500000000000000000"
+//!     ]
+//! }, {
+//!     "name": "three_halves_ether",
+//!     "inputs": [
+//!         {
+//!             "method": "three_halves_ether",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1500000000000000000"
+//!     ]
+//! }, {
+//!     "name": "scientific_thousand",
+//!     "inputs": [
+//!         {
+//!             "method": "scientific_thousand",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1000"
+//!     ]
+//! }, {
+//!     "name": "scientific_fractional",
+//!     "inputs": [
+//!         {
+//!             "method": "scientific_fractional",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1500"
+//!     ]
+//! }, {
+//!     "name": "scientific_large",
+//!     "inputs": [
+//!         {
+//!             "method": "scientific_large",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1000000000000000000"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    function half_minute() public pure returns (uint256) {
+        return 0.5 minutes;
+    }
+
+    function half_gwei() public pure returns (uint256) {
+        return 0.5 gwei;
+    }
+
+    function quarter_ether() public pure returns (uint256) {
+        return 0.25 ether;
+    }
+
+    function half_ether() public pure returns (uint256) {
+        return 0.5 ether;
+    }
+
+    function three_halves_ether() public pure returns (uint256) {
+        return 1.5 ether;
+    }
+
+    function scientific_thousand() public pure returns (uint256) {
+        return 1e3;
+    }
+
+    function scientific_fractional() public pure returns (uint256) {
+        return 1.5e3;
+    }
+
+    function scientific_large() public pure returns (uint256) {
+        return 1e18;
+    }
+}


### PR DESCRIPTION
Consumes slang's new literal-typing accessors to narrow integer literal emission, replaces the digit-count width heuristic, and unifies constant emission through a single builder entry point.

### What's new

- Uses `decimal.value()`, `hex.value()`, `literal_type.kind()` — no more reaching into slang's evaluator or `ir_node` fields.
- Single `Builder::emit_constant(&BigInt, Type)` for all integer constants — dispatches to `sol.address_cast`, `arith.constant`, or `sol.constant` by target type.
- Deletes the text-based decimal/hex emitters, the boolean-specific helper, and the digit-count width heuristic.
- Supports rational decimals that reduce to integers (`1.5 ether`, `0.5 gwei`), scientific notation (`1e18`, `2.5e10`), and signed negatives via slang's prefix-expression fold.

Depends on https://github.com/NomicFoundation/slang/pull/1722.

### Newly passing tests

- `tests/solidity/simple/constant_expressions/literal_types.sol` — digit separators, underscored hex, address literal, `ether`/`days` units, zero, negative `int8` literals, boolean keywords.
- `tests/solidity/simple/constant_expressions/rational_literals.sol` — `0.5 minutes`, `0.5 gwei`, `0.25 ether`, `0.5 ether`, `1.5 ether`, `1e3`, `1.5e3`, `1e18`.
- Six pre-existing tests recovered from the signed-negative path: `loop/range_bound/{i8,i16,i32_lower,i64_lower}.sol::main`, `operator/arithmetic/exponentiation_i128_const.sol::{ordinar_positive,to_max}`.

### Known regression

- `constant_expressions/bitwise.sol::test` regresses from PASS to FAIL. Slang's binder does not fold binary expressions of literal operands, so the narrowed leaf widths (`1 : ui8`, `100 : ui8`) cause `1 << 100` and similar constant subexpressions to overflow at 8-bit width. The previous code masked this by mapping every `LiteralKind` to ui256. Tracked by a TODO in `resolve_expression_type`; proper fix is constant-expression folding either upstream in slang's binder (matching solc's `RationalNumberType::binaryOperatorResult`) or locally in solx-slang.