### PR TITLE
feat(slang): emit sol.this for ThisKeyword expressions

### DIFF
--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -1,10 +1,11 @@
 /*
- * C wrappers for Sol dialect attribute creation.
+ * C wrappers for Sol dialect attribute and type creation.
  *
  * The Sol dialect's C API (mlir-c/Dialect/Sol.h) does not expose
- * ContractKindAttr or StateMutabilityAttr constructors. These thin
- * wrappers call the generated C++ get() methods via extern "C" linkage
- * so Rust can create these attributes through FFI.
+ * constructors for several attributes (e.g. ContractKindAttr,
+ * StateMutabilityAttr) or types (e.g. PointerType, AddressType,
+ * ContractType). These thin wrappers call the generated C++ get()
+ * methods via extern "C" linkage so Rust can create them through FFI.
  */
 
 #include "mlir/Dialect/Sol/Sol.h"
@@ -59,6 +60,13 @@ MlirType solxCreatePointerType(MlirContext ctx, MlirType elementType, uint32_t d
 MlirType solxCreateAddressType(MlirContext ctx, bool payable) {
     auto *context = unwrap(ctx);
     return wrap(mlir::sol::AddressType::get(context, payable));
+}
+
+MlirType solxCreateContractType(MlirContext ctx, const char *name_ptr,
+                                size_t name_len, bool payable) {
+    auto *context = unwrap(ctx);
+    llvm::StringRef name(name_ptr, name_len);
+    return wrap(mlir::sol::ContractType::get(context, name, payable));
 }
 
 } /* extern "C" */

--- a/solx-mlir/src/context/builder/type_factory.rs
+++ b/solx-mlir/src/context/builder/type_factory.rs
@@ -104,4 +104,20 @@ impl<'context> TypeFactory<'context> {
             ))
         }
     }
+
+    /// Creates a `sol::ContractType` for the named contract with the given payability.
+    pub fn contract(&self, name: &str, payable: bool) -> Type<'context> {
+        let name_bytes = name.as_bytes();
+        // SAFETY: `solxCreateContractType` returns a valid MlirType from the
+        // C++ Sol dialect. The context pointer and the name byte range are
+        // valid for the duration of the call.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateContractType(
+                self.context.to_raw(),
+                name_bytes.as_ptr() as *const std::ffi::c_char,
+                name_bytes.len(),
+                payable,
+            ))
+        }
+    }
 }

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -43,6 +43,9 @@ pub struct Context<'context> {
     pub builder: Builder<'context>,
     /// All function signatures for call resolution (bare name -> overloads).
     pub function_signatures: HashMap<String, Vec<Function<'context>>>,
+    /// The MLIR type of the contract currently being emitted, used to type
+    /// `this` expressions. Frontends set this before emitting function bodies.
+    pub current_contract_type: Option<Type<'context>>,
 }
 
 impl<'context> Context<'context> {
@@ -161,6 +164,7 @@ impl<'context> Context<'context> {
             module,
             function_signatures: HashMap::new(),
             builder: Builder::new(context),
+            current_contract_type: None,
         }
     }
 

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -96,6 +96,14 @@ unsafe extern "C" {
     /// Creates a `sol::AddressType` with the given payability.
     pub fn solxCreateAddressType(context: MlirContext, payable: bool) -> mlir_sys::MlirType;
 
+    /// Creates a `sol::ContractType` for a contract with the given name and payability.
+    pub fn solxCreateContractType(
+        context: MlirContext,
+        name_ptr: *const std::ffi::c_char,
+        name_len: usize,
+        payable: bool,
+    ) -> mlir_sys::MlirType;
+
     // ---- MLIR core (not in mlir-sys) ----
 
     /// Returns the region that owns the given block.

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -12,6 +12,7 @@ pub mod storage;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
@@ -25,6 +26,7 @@ use slang_solidity::cst::NodeId;
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
 use solx_mlir::Environment;
+use solx_mlir::ods::sol::ThisOperation;
 
 use self::call::type_conversion::TypeConversion;
 
@@ -132,6 +134,24 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             }
             Expression::FalseKeyword => {
                 let value = self.state.builder.emit_arith_constant_bool(false, &block);
+                Ok((Some(value), block))
+            }
+            Expression::ThisKeyword => {
+                let contract_type = self
+                    .state
+                    .current_contract_type
+                    .ok_or_else(|| anyhow::anyhow!("sol.this emitted outside a contract"))?;
+                let operation = ThisOperation::builder(
+                    self.state.builder.context,
+                    self.state.builder.unknown_location,
+                )
+                .addr(contract_type)
+                .build();
+                let value = block
+                    .append_operation(operation.into())
+                    .result(0)
+                    .expect("sol.this always produces one result")
+                    .into();
                 Ok((Some(value), block))
             }
             Expression::Identifier(identifier) => {

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::ContractDefinition;
 use slang_solidity::backend::ir::ast::FunctionKind;
+use slang_solidity::backend::ir::ast::FunctionMutability;
 use slang_solidity::cst::NodeId;
 
 use solx_mlir::Context;
@@ -54,6 +55,13 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
         self.pre_register_functions(contract);
         let storage_layout = Self::compute_storage_layout(contract, file_identifier);
 
+        let payable = contract.functions().iter().any(|function| {
+            matches!(function.kind(), FunctionKind::Receive)
+                || (matches!(function.kind(), FunctionKind::Fallback)
+                    && matches!(function.mutability(), FunctionMutability::Payable))
+        });
+        let contract_type = self.state.builder.types.contract(&contract_name, payable);
+
         // Emit sol.contract and functions.
         let module_body = self.state.module.body();
         let contract_body = self.state.builder.emit_sol_contract(
@@ -77,8 +85,10 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
                 FunctionKind::Constructor => has_constructor = true,
                 _ => {}
             }
+            self.state.current_contract_type = Some(contract_type);
             let emitter = FunctionEmitter::new(&self.semantic, self.state, &storage_layout);
             emitter.emit_sol(&function, &contract_body)?;
+            self.state.current_contract_type = None;
         }
 
         // Emit a default constructor if the contract doesn't define one.

--- a/tests/solidity/simple/context/this.sol
+++ b/tests/solidity/simple/context/this.sol
@@ -1,0 +1,23 @@
+//! { "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    function main() public view returns (bool) {
+        return address(this) == address(this);
+    }
+}


### PR DESCRIPTION
Adds a `ThisKeyword` match arm in the expression emitter so Solidity `this` lowers to `sol.this` with the enclosing contract's `!sol.contract<...>` type. Mirrors the reference pattern in `solx-solidity/libsolidity/codegen/mlir/SolidityToMLIR.cpp:611-616`. The contract type is stashed on `Context::current_contract_type` by the contract emitter, scoped per-function, so the expression layer reads it directly instead of threading the contract name through every emitter.

Foundational for later work on external calls (`this.f()`), `address(this).balance`, `payable(this)`, and related patterns — does not flip any test to PASSED on its own because the tests that exercise `this` also require features still not yet supported (external calls, inline assembly). Regression checked: identical pass/fail counts against `tests/solidity/simple` with and without this change.

`payable` is derived from the contract's `receive` / payable `fallback` functions, matching `ContractType(*currContract).isPayable()` in the reference compiler.