### PR TITLE
feat(slang): emit sol.return after sol.revert

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -300,8 +300,6 @@ impl<'context> Builder<'context> {
             .into()
     }
 
-    // ==== Terminators ====
-
     /// Emits a `sol.revert` carrying an optional payload.
     ///
     /// `signature` doubles as the payload string: for custom errors
@@ -311,8 +309,11 @@ impl<'context> Builder<'context> {
     /// (`revert("message")`) it is the literal message, with no `args` and
     /// `is_custom_error = false`. For plain `revert()` it is empty, with no
     /// `args` and `is_custom_error = false`.
-    // TODO(sol-dialect): mark `sol.revert` as `IsTerminator` like `sol.return`
-    // so callers don't need to append `llvm.unreachable` after it.
+    ///
+    /// `sol.revert` does not carry the `IsTerminator` trait, so callers must
+    /// ensure the enclosing block reaches a structural terminator through the
+    /// normal codegen path (a following statement, a region yield, or the
+    /// function-epilogue default return).
     ///
     /// # Panics
     ///

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -7,7 +7,6 @@ pub mod control_flow;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Region;
 use melior::ir::Type;
@@ -133,10 +132,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             Statement::RevertStatement(_revert) => {
                 // TODO: encode custom error data from revert arguments
                 self.state.builder.emit_sol_revert(&block);
-                // TODO(sol-dialect): remove once sol.revert is marked IsTerminator
-                block.append_operation(melior::dialect::llvm::unreachable(
-                    self.state.builder.unknown_location,
-                ));
                 Ok(None)
             }
             _ => anyhow::bail!(

--- a/solx-slang/src/ast/contract/function/statement/revert.rs
+++ b/solx-slang/src/ast/contract/function/statement/revert.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Value;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
@@ -39,9 +38,12 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
     /// matched to error parameters, or any argument expression cannot be
     /// lowered.
     ///
-    /// # Returns None
+    /// # Returns
     ///
-    /// Always returns `None` because `sol.revert` terminates control flow.
+    /// Returns the block after the `sol.revert` op. `sol.revert` is not a
+    /// terminator at the dialect level, so codegen continues in the same
+    /// block; the function epilogue (or an enclosing region's yield) supplies
+    /// the structural terminator.
     pub fn emit_revert(
         &self,
         revert: &RevertStatement,
@@ -50,11 +52,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         let error = match revert.error().resolve_to_definition() {
             None => {
                 self.state.builder.emit_sol_revert("", &[], false, &block);
-                // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
-                block.append_operation(melior::dialect::llvm::unreachable(
-                    self.state.builder.unknown_location,
-                ));
-                return Ok(None);
+                return Ok(Some(block));
             }
             Some(Definition::Error(error)) => error,
             Some(_) => anyhow::bail!("revert target does not resolve to an error definition"),
@@ -92,13 +90,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         self.state
             .builder
             .emit_sol_revert(&signature, &evaluated.values, true, &evaluated.block);
-        // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
-        evaluated
-            .block
-            .append_operation(melior::dialect::llvm::unreachable(
-                self.state.builder.unknown_location,
-            ));
-        Ok(None)
+        Ok(Some(evaluated.block))
     }
 
     /// Emits a `sol.revert` for the call form `revert()` or `revert("message")`.
@@ -110,9 +102,12 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
     /// the message is empty (which would emit ambiguous bytecode under the
     /// current Sol dialect; `revert()` is the no-data form).
     ///
-    /// # Returns None
+    /// # Returns
     ///
-    /// Always returns `None` because `sol.revert` terminates control flow.
+    /// Returns the block after the `sol.revert` op. `sol.revert` is not a
+    /// terminator at the dialect level, so codegen continues in the same
+    /// block; the function epilogue (or an enclosing region's yield) supplies
+    /// the structural terminator.
     pub fn emit_revert_call(
         &self,
         call: &FunctionCallExpression,
@@ -144,11 +139,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         self.state
             .builder
             .emit_sol_revert(&signature, &[], false, &block);
-        // TODO(sol-dialect): remove once `sol.revert` is marked `IsTerminator`.
-        block.append_operation(melior::dialect::llvm::unreachable(
-            self.state.builder.unknown_location,
-        ));
-        Ok(None)
+        Ok(Some(block))
     }
 
     /// Orders named revert arguments by the custom error's parameter declaration order.


### PR DESCRIPTION
The Sol dialect does not mark `sol.revert` with the `IsTerminator` trait, so the enclosing block still needs a structural terminator. The frontend previously treated `sol.revert` as control-flow-terminating and appended an immediate `sol.return` inside `emit_sol_revert`. That produced invalid IR whenever revert appeared mid-flow — `revert(...); some_stmt;` would emit `sol.revert; sol.return; some_stmt`, placing ops after a terminator and tripping the verifier.

`sol.revert` is conceptually closer to a noreturn call than a control-flow op: at the source language level it halts execution, but at the dialect level it is just a regular op without the `IsTerminator` trait. Treating it that way in codegen lets the existing function-epilogue path — already responsible for closing fall-through blocks with `sol.return` — supply the structural terminator, with no special-casing for revert.