### PR TITLE
fix(ci): pin MSYS2 to stabilize Windows ccache

### DIFF
--- a/.github/actions/prepare-msys/action.yml
+++ b/.github/actions/prepare-msys/action.yml
@@ -3,33 +3,37 @@ description: 'Prepares msys2 for Windows builds.'
 runs:
   using: composite
   steps:
-    - name: Setup msys2 (no auto-update)
-      uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
+    # MSYS2 is pinned via the setup-msys2 action version: each release
+    # hardcodes a specific msys2-installer release in its bundled index.js
+    # (v2.31.1 → 2026-03-22). `update: false` skips the per-run `pacman -Syu`
+    # that would otherwise pull whatever MSYS2 head looks like today. Two
+    # reasons:
+    #
+    # 1. CCACHE_COMPILERCHECK=content in build-llvm/action.yml hashes the
+    #    clang binary's bytes — uncontrolled MSYS2 refreshes invalidated the
+    #    Windows ccache wholesale.
+    # 2. Prior history of MSYS2 auto-updates silently breaking the build
+    #    (libstdc++ incident, which led to switching to rustup's vendored
+    #    MinGW for that lib).
+    #
+    # Bumping the MSYS2 snapshot is an explicit setup-msys2 SHA bump.
+    - name: Setup msys2 (pinned)
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
         path-type: inherit
-        update: true
+        update: false
         cache: false
-
-    - name: Repair keyring + update + install packages
-      shell: msys2 {0}
-      run: |
-        set -euxo pipefail
-
-        # Keyring repair (fixes "signature is invalid")
-        pacman-key --init
-        pacman-key --populate msys2
-
-        # Now install what you need
-        pacman -S --noconfirm --needed \
-          base-devel \
-          git \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-cmake \
-          mingw-w64-x86_64-ninja \
-          mingw-w64-x86_64-gcc \
-          mingw-w64-x86_64-gcc-libs \
+        install: >-
+          base-devel
+          git
+          mingw-w64-x86_64-clang
+          mingw-w64-x86_64-lld
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-ninja
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-libs
+          mingw-w64-x86_64-headers-git
           mingw-w64-x86_64-python
 
     - name: Prepare env


### PR DESCRIPTION
Extracted from #365 — was previously bundled with the Windows tool-disable work.

## Background

`CCACHE_COMPILERCHECK=content` in `build-llvm/action.yml` hashes the clang binary's bytes. `prepare-msys/action.yml` ran `msys2/setup-msys2` with `update: true` (`pacman -Syuu` to upstream head on every Windows run). Any MSYS2 clang rebuild — several times a week — invalidated every ccache entry wholesale. The GHA tarball still restored, but 0% of compiles hit. Windows ccache was effectively a same-day cache.

Discovered 2026-04-23 debugging #365's baseline measurement: 28 min into a supposedly-warm run the Windows build was at [688/4381] objects — cold-build wall-clock despite `last_accessed_at` confirming GHA-level restore. Same-day measurements on 2026-04-22 (saves 14:24 + 16:00) were genuinely warm; cross-day was not.

## Fix

Pins MSYS2 via two mechanisms:

1. **`msys2/setup-msys2@v2.31.1`** — each release of this action bundles a specific msys2-installer release in its `index.js` (v2.31.1 → 2026-03-22). That snapshot is the base MSYS2 install — including the pacman db.
2. **`update: false`** — skip the per-run `pacman -Syuu`.

With `update: false`, setup-msys2 calls `pacman -S --needed --overwrite '*' <install:>` and **does not** run `pacman -Sy` first ([source at the v2.31.0/.1 release point](https://github.com/msys2/setup-msys2/blob/b747bcc1ffba/main.js#L427-L446)). So pacman resolves the `install:` package versions against the snapshot's bundled db — not against live `repo.msys2.org`. Live mirror is then just a file server for those exact pinned package versions. Clang bytes are identical run-to-run as long as the action SHA doesn't change → ccache holds.

Replaces the manual `pacman -S --noconfirm --needed` step with the action's native `install:` parameter. Drops the keyring-repair incantation: with `update: false` we're not upgrading against newer signing keys. Adds `mingw-w64-x86_64-headers-git` explicitly (transitive via gcc but pinned for clarity).

## Drift vectors

Three, all bounded:

1. **Action SHA bumps**: refresh the bundled snapshot db → new toolchain versions → ccache invalidated wholesale once. Intentional and explicit.
2. **Snapshot internal consistency**: bundled snapshots can themselves be self-inconsistent. Evidence on this very PR: an earlier run on \`6e8b079\` (v2.30.0 + 2025-12-13 base) hit a \`libstdc++\` ↔ \`libmsvcrt.a\` \`__declspec(dllimport) wctype\` linker error — gcc 15.2.0 in the December snapshot was paired with mingw-w64-headers/CRT that didn't provide matching dllimport stubs. Bumping to v2.31.1 (March base) got a consistent set. So action-SHA bumps need a CI smoke test, not blind merging.
3. **Live mirror retention**: \`repo.msys2.org\` eventually rotates old package files out. If we don't bump the action SHA for many months, \`pacman -S\` may 404 on a version the snapshot db references. MSYS2 retention is typically months, so this is a slow drift; safety valve below.

Considered alternatives (pre-baked MSYS2 tarball, llvm-mingw, switching to \`*-windows-msvc\`) — all materially more work for a problem that's now bounded. Prior libstdc++ incident → moved that lib to rustup's vendored MinGW is the precedent for keeping MSYS2 stable rather than replacing it.

## Bumping the pin

Composite-action \`uses:\` lines aren't scanned by dependabot's \`github-actions\` ecosystem ([dependabot-core#6345](https://github.com/dependabot/dependabot-core/issues/6345)) — SHA bumps here are manual, or via Renovate, or by inlining the step into the workflow files. For now: manual, low-frequency. When a Cargo/submodule update needs a newer toolchain ABI, or when live-mirror retention drops a pinned package: bump the action SHA and validate.

For one-shot validation against upstream head: flip to \`update: true\`, run, flip back.

## Comment

Added above the \`setup-msys2\` step in \`prepare-msys/action.yml\` so the next person debugging "warm but 0% hit" Windows ccache lands directly on the cause.