### PR TITLE
feat(slang): lower additional EVM intrinsics

### DIFF
--- a/solx-mlir/tests/lit/evm_context.sol
+++ b/solx-mlir/tests/lit/evm_context.sol
@@ -30,6 +30,18 @@
 // CHECK: sol.func @"get_gaslimit()"
 // CHECK:   sol.gaslimit : ui256
 
+// CHECK: sol.func @"get_blobbasefee()"
+// CHECK:   sol.blobbasefee : ui256
+
+// CHECK: sol.func @"get_difficulty()"
+// CHECK:   sol.difficulty : ui256
+
+// CHECK: sol.func @"get_prevrandao()"
+// CHECK:   sol.prevrandao : ui256
+
+// CHECK: sol.func @"get_balance(address)"
+// CHECK:   sol.balance %{{.*}} : !sol.address -> ui256
+
 contract C {
     function get_sender() public view returns (address) {
         return msg.sender;
@@ -69,5 +81,21 @@ contract C {
 
     function get_gaslimit() public view returns (uint256) {
         return block.gaslimit;
+    }
+
+    function get_blobbasefee() public view returns (uint256) {
+        return block.blobbasefee;
+    }
+
+    function get_difficulty() public view returns (uint256) {
+        return block.difficulty;
+    }
+
+    function get_prevrandao() public view returns (uint256) {
+        return block.prevrandao;
+    }
+
+    function get_balance(address a) public view returns (uint256) {
+        return a.balance;
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -1,0 +1,269 @@
+//!
+//! Solidity built-in function and EVM intrinsic lowering.
+//!
+
+use melior::ir::BlockLike;
+use melior::ir::BlockRef;
+use melior::ir::Operation;
+use melior::ir::Value;
+use slang_solidity::backend::built_ins::BuiltIn;
+use slang_solidity::backend::ir::ast::Expression;
+use slang_solidity::backend::ir::ast::MemberAccessExpression;
+use slang_solidity::backend::ir::ast::PositionalArguments;
+use solx_mlir::ods::sol::BalanceOperation;
+use solx_mlir::ods::sol::BaseFeeOperation;
+use solx_mlir::ods::sol::BlobBaseFeeOperation;
+use solx_mlir::ods::sol::BlockNumberOperation;
+use solx_mlir::ods::sol::CallValueOperation;
+use solx_mlir::ods::sol::CallerOperation;
+use solx_mlir::ods::sol::ChainIdOperation;
+use solx_mlir::ods::sol::CodeHashOperation;
+use solx_mlir::ods::sol::CoinbaseOperation;
+use solx_mlir::ods::sol::DifficultyOperation;
+use solx_mlir::ods::sol::GasLimitOperation;
+use solx_mlir::ods::sol::GasPriceOperation;
+use solx_mlir::ods::sol::OriginOperation;
+use solx_mlir::ods::sol::PrevRandaoOperation;
+use solx_mlir::ods::sol::TimestampOperation;
+
+use crate::ast::contract::function::expression::call::CallEmitter;
+
+impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context, 'block> {
+    /// Tries to emit `callee(arguments)` as a Solidity built-in.
+    ///
+    /// Resolves the callee via slang's binder to a [`BuiltIn`] variant.
+    /// Returns `Ok(Some(block))` if the call resolves to a recognized
+    /// built-in and was lowered; returns `Ok(None)` if the callee is not a
+    /// built-in and the caller should fall through to generic dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the callee is a built-in but its arguments are
+    /// malformed (e.g. non-string `require` message).
+    pub fn try_emit_built_in_call(
+        &self,
+        callee: &Expression,
+        arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
+        let Expression::Identifier(identifier) = callee else {
+            return Ok(None);
+        };
+        let Some(built_in) = identifier.resolved_built_in() else {
+            return Ok(None);
+        };
+        match built_in {
+            BuiltIn::Assert if arguments.len() == 1 => {
+                let condition = arguments.iter().next().expect("argument count verified");
+                Ok(Some(self.emit_assert(&condition, block)?))
+            }
+            BuiltIn::Require if matches!(arguments.len(), 1 | 2) => {
+                let mut iter = arguments.iter();
+                let condition = iter.next().expect("argument count verified");
+                let message = match iter.next() {
+                    Some(Expression::StringExpression(string_expression)) => {
+                        let bytes = string_expression.value();
+                        Some(String::from_utf8(bytes).expect("require message is valid UTF-8"))
+                    }
+                    Some(_) => anyhow::bail!("require message must be a string literal"),
+                    None => None,
+                };
+                Ok(Some(self.emit_require(
+                    &condition,
+                    message.as_deref(),
+                    block,
+                )?))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Emits a member access expression as an EVM intrinsic.
+    ///
+    /// Resolves the member via slang's binder to a specific `BuiltIn` variant
+    /// and lowers it to the matching `sol.*` operation. Address-base intrinsics
+    /// (`address.balance`, `address.codehash`) first evaluate the address
+    /// operand and pass it as the operation's container address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the member access does not resolve to a recognized
+    /// EVM intrinsic.
+    pub fn emit_built_in_member_access(
+        &self,
+        access: &MemberAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
+        let builder = &self.expression_emitter.state.builder;
+        match access.member().resolved_built_in() {
+            Some(BuiltIn::AddressBalance) => {
+                self.emit_address_base_intrinsic(access, block, |address_value| {
+                    BalanceOperation::builder(builder.context, builder.unknown_location)
+                        .cont_addr(address_value)
+                        .out(builder.types.ui256)
+                        .build()
+                        .into()
+                })
+            }
+            Some(BuiltIn::AddressCodehash) => {
+                self.emit_address_base_intrinsic(access, block, |address_value| {
+                    CodeHashOperation::builder(builder.context, builder.unknown_location)
+                        .cont_addr(address_value)
+                        .out(builder.types.ui256)
+                        .build()
+                        .into()
+                })
+            }
+            resolved => {
+                let operation = match resolved {
+                    Some(BuiltIn::TxOrigin) => {
+                        OriginOperation::builder(builder.context, builder.unknown_location)
+                            .addr(builder.types.sol_address)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::TxGasPrice) => {
+                        GasPriceOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::MsgSender) => {
+                        CallerOperation::builder(builder.context, builder.unknown_location)
+                            .addr(builder.types.sol_address)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::MsgValue) => {
+                        CallValueOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockTimestamp) => {
+                        TimestampOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockNumber) => {
+                        BlockNumberOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockCoinbase) => {
+                        CoinbaseOperation::builder(builder.context, builder.unknown_location)
+                            .addr(builder.types.sol_address)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockChainid) => {
+                        ChainIdOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockBasefee) => {
+                        BaseFeeOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockGaslimit) => {
+                        GasLimitOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockBlobbasefee) => {
+                        BlobBaseFeeOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockDifficulty) => {
+                        DifficultyOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::BlockPrevrandao) => {
+                        PrevRandaoOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    _ => anyhow::bail!("unsupported member access: {}", access.member().name()),
+                };
+                let value = block
+                    .append_operation(operation)
+                    .result(0)
+                    .expect("intrinsic always produces one result")
+                    .into();
+                Ok((value, block))
+            }
+        }
+    }
+
+    /// Emits an EVM intrinsic that reads from a per-address container, e.g.
+    /// `address.balance` (`sol.balance`) or `address.codehash` (`sol.code_hash`).
+    ///
+    /// Evaluates the address operand, builds the operation via `build_op`, and
+    /// extracts its single result.
+    fn emit_address_base_intrinsic<F>(
+        &self,
+        access: &MemberAccessExpression,
+        block: BlockRef<'context, 'block>,
+        build_op: F,
+    ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)>
+    where
+        F: FnOnce(Value<'context, 'block>) -> Operation<'context>,
+    {
+        let (address_value, block) = self
+            .expression_emitter
+            .emit_value(&access.operand(), block)?;
+        let value = block
+            .append_operation(build_op(address_value))
+            .result(0)
+            .expect("address-base intrinsic always produces one result")
+            .into();
+        Ok((value, block))
+    }
+
+    /// Emits an `assert(condition)` built-in via `sol.assert`.
+    fn emit_assert(
+        &self,
+        condition: &Expression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<BlockRef<'context, 'block>> {
+        let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
+        let condition_boolean = self
+            .expression_emitter
+            .emit_is_nonzero(condition_value, &block);
+        self.expression_emitter
+            .state
+            .builder
+            .emit_sol_assert(condition_boolean, &block);
+        Ok(block)
+    }
+
+    /// Emits a `require(condition)` or `require(condition, "message")` built-in
+    /// via `sol.require`.
+    fn emit_require(
+        &self,
+        condition: &Expression,
+        message: Option<&str>,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<BlockRef<'context, 'block>> {
+        let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
+        let condition_boolean = self
+            .expression_emitter
+            .emit_is_nonzero(condition_value, &block);
+        self.expression_emitter
+            .state
+            .builder
+            .emit_sol_require(condition_boolean, message, &block);
+        Ok(block)
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -2,25 +2,15 @@
 //! Function call and member access expression lowering.
 //!
 
+pub mod built_in;
 pub mod type_conversion;
 
-use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Value;
-use slang_solidity::backend::built_ins::BuiltIn;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::FunctionCallExpression;
-use solx_mlir::ods::sol::BaseFeeOperation;
-use solx_mlir::ods::sol::BlockNumberOperation;
-use solx_mlir::ods::sol::CallValueOperation;
-use solx_mlir::ods::sol::CallerOperation;
-use solx_mlir::ods::sol::ChainIdOperation;
-use solx_mlir::ods::sol::CoinbaseOperation;
-use solx_mlir::ods::sol::GasLimitOperation;
-use solx_mlir::ods::sol::GasPriceOperation;
-use solx_mlir::ods::sol::OriginOperation;
-use solx_mlir::ods::sol::TimestampOperation;
+use slang_solidity::backend::ir::ast::MemberAccessExpression;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 
@@ -33,15 +23,6 @@ pub struct CallEmitter<'emitter, 'state, 'context, 'block> {
 }
 
 impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context, 'block> {
-    /// Solidity built-in `assert()` function name.
-    const ASSERT: &'static str = "assert";
-
-    /// Solidity built-in `require()` function name.
-    const REQUIRE: &'static str = "require";
-
-    /// Maximum number of arguments for `require()` (condition + optional message).
-    const MAX_REQUIRE_ARGUMENTS: usize = 2;
-
     /// Creates a new call emitter.
     pub fn new(expression_emitter: &'emitter ExpressionEmitter<'state, 'context, 'block>) -> Self {
         Self { expression_emitter }
@@ -97,33 +78,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         let callee_name =
             callee_name.ok_or_else(|| anyhow::anyhow!("unsupported callee expression"))?;
 
-        // Handle require() built-in.
-        if callee_name == Self::REQUIRE
-            && (positional_arguments.len() == 1
-                || positional_arguments.len() == Self::MAX_REQUIRE_ARGUMENTS)
-        {
-            let mut args = positional_arguments.iter();
-            let condition = args.next().expect("length checked above");
-            let message_arg = args.next();
-            let message = match &message_arg {
-                Some(Expression::StringExpression(string_expression)) => {
-                    let bytes = string_expression.value();
-                    Some(String::from_utf8(bytes).expect("require message is valid UTF-8"))
-                }
-                Some(_) => anyhow::bail!("require message must be a string literal"),
-                None => None,
-            };
-            let block = self.emit_require(&condition, message.as_deref(), block)?;
-            return Ok((None, block));
-        }
-
-        // Handle assert() built-in.
-        if callee_name == Self::ASSERT && positional_arguments.len() == 1 {
-            let first = positional_arguments
-                .iter()
-                .next()
-                .expect("length checked above");
-            let block = self.emit_assert(&first, block)?;
+        if let Some(block) = self.try_emit_built_in_call(&callee, positional_arguments, block)? {
             return Ok((None, block));
         }
 
@@ -172,100 +127,9 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
     /// Returns an error if the member access is not a recognized EVM intrinsic.
     pub fn emit_member_access(
         &self,
-        member_identifier: &slang_solidity::backend::ir::ast::Identifier,
+        access: &MemberAccessExpression,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
-        let builder = &self.expression_emitter.state.builder;
-        let context = builder.context;
-        let location = builder.unknown_location;
-        let address_type = builder.types.sol_address;
-        let ui256_type = builder.types.ui256;
-        let operation = match member_identifier.resolved_built_in() {
-            Some(BuiltIn::TxOrigin) => OriginOperation::builder(context, location)
-                .addr(address_type)
-                .build()
-                .into(),
-            Some(BuiltIn::TxGasPrice) => GasPriceOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::MsgSender) => CallerOperation::builder(context, location)
-                .addr(address_type)
-                .build()
-                .into(),
-            Some(BuiltIn::MsgValue) => CallValueOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockTimestamp) => TimestampOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockNumber) => BlockNumberOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockCoinbase) => CoinbaseOperation::builder(context, location)
-                .addr(address_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockChainid) => ChainIdOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockBasefee) => BaseFeeOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            Some(BuiltIn::BlockGaslimit) => GasLimitOperation::builder(context, location)
-                .val(ui256_type)
-                .build()
-                .into(),
-            _ => anyhow::bail!("unsupported member access: {}", member_identifier.name()),
-        };
-        let value = block
-            .append_operation(operation)
-            .result(0)
-            .expect("intrinsic always produces one result")
-            .into();
-        Ok((value, block))
-    }
-
-    /// Emits an `assert(condition)` built-in via `sol.assert`.
-    fn emit_assert(
-        &self,
-        condition: &Expression,
-        block: BlockRef<'context, 'block>,
-    ) -> anyhow::Result<BlockRef<'context, 'block>> {
-        let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
-        let condition_boolean = self
-            .expression_emitter
-            .emit_is_nonzero(condition_value, &block);
-        self.expression_emitter
-            .state
-            .builder
-            .emit_sol_assert(condition_boolean, &block);
-        Ok(block)
-    }
-
-    /// Emits a `require(condition)` or `require(condition, "message")` built-in
-    /// via `sol.require`.
-    fn emit_require(
-        &self,
-        condition: &Expression,
-        message: Option<&str>,
-        block: BlockRef<'context, 'block>,
-    ) -> anyhow::Result<BlockRef<'context, 'block>> {
-        let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
-        let condition_boolean = self
-            .expression_emitter
-            .emit_is_nonzero(condition_value, &block);
-
-        self.expression_emitter
-            .state
-            .builder
-            .emit_sol_require(condition_boolean, message, &block);
-
-        Ok(block)
+        self.emit_built_in_member_access(access, block)
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -282,12 +282,9 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             Expression::FunctionCallExpression(call) => {
                 self::call::CallEmitter::new(self).emit_function_call(call, block)
             }
-            Expression::MemberAccessExpression(access) => {
-                let member = access.member();
-                self::call::CallEmitter::new(self)
-                    .emit_member_access(&member, block)
-                    .map(|(value, block)| (Some(value), block))
-            }
+            Expression::MemberAccessExpression(access) => self::call::CallEmitter::new(self)
+                .emit_member_access(access, block)
+                .map(|(value, block)| (Some(value), block)),
             Expression::TupleExpression(tuple) => {
                 let items = tuple.items();
                 // TODO: support multi-value tuples (e.g. tuple deconstruction)

--- a/tests/solidity/simple/context/prevrandao.sol
+++ b/tests/solidity/simple/context/prevrandao.sol
@@ -1,0 +1,24 @@
+//! { "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "$PREVRANDAO"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.18;
+
+contract Test {
+    function main() public view returns(uint) {
+        uint _prevrandao = block.prevrandao;
+        return _prevrandao;
+    }
+}


### PR DESCRIPTION
Wires up five additional EVM intrinsics in the Slang/MLIR adapter: three zero-arg block-namespace globals (`block.blobbasefee`, `block.difficulty`, `block.prevrandao`) and two runtime-base address intrinsics (`address.balance`, `address.codehash`). The address-base path is plumbed by passing the full `MemberAccessExpression` to `emit_member_access`, so the operand can be evaluated and threaded through `sol.balance` / `sol.code_hash`.

The built-in dispatch (`assert`, `require`, EVM intrinsics) is extracted from `call/mod.rs` into a new `call/built_in.rs` module, keeping `call/mod.rs` as a thin dispatcher. The two address-base intrinsic arms share a private `emit_address_base_intrinsic` helper that takes a closure to construct the operation.

## Newly passing tests

- `tests/solidity/simple/context/difficulty.sol` (all)
- `tests/solidity/simple/context/prevrandao.sol` (all)

## Out of scope

- `address.code` — depends on broader bytes/string lowering not yet in place.
- `address.codehash` Solidity-level test — blocked on `bytes32` lowering (panics in `type_conversion.rs:45`).
- `msg.sig` — needs a `!sol.fixedbytes<4>` type which has no FFI constructor in `solx-mlir` yet.
- `gasleft()` — function-call dispatch path (separate from member access).