### PR TITLE
ci: rework label-gated suites as advisory checks + fix label concurrency

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,20 @@
+name: Checkout submodules
+description: >-
+  Initializes and updates all submodules at depth 1, including ones marked
+  inactive in .gitmodules. The repository must already be checked out before
+  calling this action.
+
+inputs:
+  working-directory:
+    description: Directory in which to run the submodule update
+    required: false
+    default: .
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --force --recursive --depth 1 --checkout

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,9 +3,10 @@ name: Code coverage
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 concurrency:
-  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -17,19 +18,13 @@ permissions:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:coverage'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:coverage'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,7 +32,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   coverage:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     runs-on: solx-linux-amd64
     permissions:
       contents: read
@@ -59,9 +54,7 @@ jobs:
           submodules: true
 
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --init --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw
@@ -272,3 +265,18 @@ jobs:
           files: 'llvm/codecov.lcov'
           slug: ${{ github.repository }}
           fail_ci_if_error: false
+
+  pr-checks:
+    name: PR Checks (Coverage)
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - cooldown-check
+      - coverage
+    steps:
+      - name: Decide on PR checks
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: >-
+            ${{ needs.cooldown-check.result == 'skipped' && 'cooldown-check, coverage' || '' }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -269,7 +269,7 @@ jobs:
   pr-checks:
     name: PR Checks (Coverage)
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - cooldown-check
       - coverage

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,7 +5,11 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Put the triggering label in the group so a `labeled` event for an unrelated
+  # label lands in its own group and can't cancel the in-flight run started by
+  # the label this workflow gates on. Other PR events (push, synchronize)
+  # share the `main` group and cancel-on-new as usual.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name || 'main' }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:
-  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -17,19 +17,13 @@ permissions:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:coverage'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:coverage'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,7 +31,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   coverage:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     runs-on: solx-linux-amd64-self-hosted
     permissions:
       contents: read

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -300,7 +300,7 @@ jobs:
   pr-checks:
     name: PR Checks (Integration)
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - cooldown-check
       - integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,6 +3,7 @@ name: Integration Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 permissions:
   contents: read
@@ -18,19 +19,13 @@ defaults:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:integration'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:integration'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,7 +34,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   integration:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     permissions:
       contents: read
       pull-requests: write
@@ -64,15 +59,13 @@ jobs:
           path: temp-solx-main
 
       - name: Checkout submodules (PR)
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --init --force --recursive --depth 1 --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Checkout submodules (main)
-        working-directory: temp-solx-main
+        uses: ./.github/actions/checkout-submodules
         continue-on-error: true
-        run: |
-          git submodule update --init --force --recursive --depth 1 --checkout
+        with:
+          working-directory: temp-solx-main
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw
@@ -303,3 +296,18 @@ jobs:
             echo "Failures: ${failures[*]}"
             exit 1
           fi
+
+  pr-checks:
+    name: PR Checks (Integration)
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - cooldown-check
+      - integration
+    steps:
+      - name: Decide on PR checks
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: >-
+            ${{ needs.cooldown-check.result == 'skipped' && 'cooldown-check, integration' || '' }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
 
-# Cancel the workflow if any new changes pushed to a feature branch or the trunk
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -18,19 +17,13 @@ defaults:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:integration'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:integration'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,7 +32,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   integration:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -8,7 +8,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Put the triggering label in the group so a `labeled` event for an unrelated
+  # label lands in its own group and can't cancel the in-flight run started by
+  # the label this workflow gates on. Other PR events (push, synchronize)
+  # share the `main` group and cancel-on-new as usual.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name || 'main' }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,14 @@ on:
 # Zero permissions baseline — each job declares only what it needs.
 permissions: {}
 
+# Dry-run release builds (pull_request with the `ci:release` label) re-trigger on
+# every `labeled` event; without dedup each one launches a full multi-platform
+# build. Collapse them into one run per PR. Real releases (tag push /
+# workflow_dispatch) get a per-ref group and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   label-check:

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -16,19 +16,13 @@ concurrency:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:sanitizer'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:sanitizer'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,7 +30,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   sanitizer:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     runs-on: solx-linux-amd64
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
@@ -52,9 +46,7 @@ jobs:
           submodules: true
 
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw
@@ -86,7 +78,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     needs:
-      - label-check
       - cooldown-check
       - sanitizer
     steps:
@@ -95,4 +86,4 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, sanitizer' || '' }}
+            ${{ needs.cooldown-check.result == 'skipped' && 'cooldown-check, sanitizer' || '' }}

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -76,7 +76,7 @@ jobs:
   pr-checks:
     name: PR Checks (Sanitizer)
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - cooldown-check
       - sanitizer

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -3,11 +3,9 @@ name: Sanitizer
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-  merge_group:
 
 permissions:
   contents: read
-  checks: write
   packages: read
 
 concurrency:
@@ -16,19 +14,13 @@ concurrency:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:sanitizer'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:sanitizer'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,7 +28,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   sanitizer:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     runs-on: solx-linux-amd64-self-hosted
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:c2b03000a1074d2cc3e6cf25a1c4fdc6eb0a61d23e63bef59205050249fa1d6e
@@ -78,19 +70,3 @@ jobs:
         with:
           target: ${{ env.TARGET }}
           sanitizer: ${{ env.RUST_SANITIZER }}
-
-  pr-checks:
-    name: PR Checks (Sanitizer)
-    runs-on: ubuntu-24.04
-    if: always()
-    needs:
-      - label-check
-      - cooldown-check
-      - sanitizer
-    steps:
-      - name: Decide on PR checks
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
-          allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, sanitizer' || '' }}

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -9,7 +9,11 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Put the triggering label in the group so a `labeled` event for an unrelated
+  # label lands in its own group and can't cancel the in-flight run started by
+  # the label this workflow gates on. Other PR events (push, synchronize)
+  # share the `main` group and cancel-on-new as usual.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name || 'main' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -16,19 +16,13 @@ concurrency:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:slang'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:slang'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,7 +30,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   slang-tests:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     env:
       CARGO_TARGET_DIR: target-slang
       CARGO_INCREMENTAL: "0"
@@ -73,9 +67,7 @@ jobs:
       # This step is required to checkout submodules
       # that are disabled in .gitmodules config
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw
@@ -127,7 +119,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     needs:
-      - label-check
       - cooldown-check
       - slang-tests
     steps:
@@ -136,4 +127,4 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, slang-tests' || '' }}
+            ${{ needs.cooldown-check.result == 'skipped' && 'cooldown-check, slang-tests' || '' }}

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -117,7 +117,7 @@ jobs:
   pr-checks:
     name: PR Checks (Slang)
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - cooldown-check
       - slang-tests

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -9,7 +9,11 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Put the triggering label in the group so a `labeled` event for an unrelated
+  # label lands in its own group and can't cancel the in-flight run started by
+  # the label this workflow gates on. Other PR events (push, synchronize)
+  # share the `main` group and cancel-on-new as usual.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name || 'main' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -3,11 +3,9 @@ name: Slang Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-  merge_group:
 
 permissions:
   contents: read
-  checks: write
   packages: read
 
 concurrency:
@@ -16,19 +14,13 @@ concurrency:
 
 jobs:
 
-  label-check:
+  cooldown-check:
+    name: Cargo cooldown check
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ci:slang'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:slang'))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
-  cooldown-check:
-    name: Cargo cooldown check
-    runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,7 +28,7 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   slang-tests:
-    needs: [label-check, cooldown-check]
+    needs: cooldown-check
     env:
       CARGO_TARGET_DIR: target-slang
       CARGO_INCREMENTAL: "0"
@@ -156,19 +148,3 @@ jobs:
         run: |
           LIT=llvm-lit${{ runner.os == 'Windows' && '.py' || '' }}
           ${LIT} -v solx-mlir/tests/lit/
-
-  pr-checks:
-    name: PR Checks (Slang)
-    runs-on: ubuntu-24.04
-    if: always()
-    needs:
-      - label-check
-      - cooldown-check
-      - slang-tests
-    steps:
-      - name: Decide on PR checks
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
-          allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, slang-tests' || '' }}


### PR DESCRIPTION
## Summary

The four label-gated suites (`coverage`, `integration-tests`, `sanitizer`, `slang-tests`) are **advisory opt-in checks**, not merge gates: add the `ci:*` label to run a suite (e.g. the long integration tests) and read the result on the PR, but they don't block merging or run in the merge queue. This PR unifies them on one simple advisory shape and fixes a label-concurrency bug that could silently cancel an opted-in run.

> Originally scoped as "unify so they can all be marked **required**"; we settled on **advisory** instead — required gating for long opt-in suites caused more flakiness than it prevented. The shared submodule-checkout composite action from the original plan landed separately in #383, so it is **not** part of this PR.

## Changes

- **Unify + advisory** (`6a48dc45`): drop the dummy `label-check` job (gate inlined onto `cooldown-check`); remove the `pr-checks` / `re-actors/alls-green` aggregators and their `allowed-skips`, the `merge_group:` triggers, and the now-unused `checks: write` on sanitizer/slang. Each suite posts its own status; absent label → clearly **skipped** rather than a misleading green-via-skip.
- **Per-label concurrency** (`8d50c89e`): put the triggering label into the concurrency group, so a `labeled` event for an *unrelated* label lands in its own group and can't cancel the run started by the matching label. Fixes the "add two labels → one suite gets cancelled/skipped" flakiness. Other PR events (push/synchronize) share the `main` group and cancel-on-new as before.
- **release dedup** (`2f841114`): `release.yaml` had no concurrency block and gates the dry-run on plain `contains(labels, 'ci:release')`, so every `labeled` event launched a fresh full multi-platform build. Add a per-PR concurrency group; `cancel-in-progress` is gated on `pull_request` so real releases (tag push / `workflow_dispatch`) get a per-ref group and are never cancelled.

## ⚠️ Branch protection — must land together with this PR

Remove `PR Checks (Coverage)`, `PR Checks (Integration)`, `PR Checks (Sanitizer)`, `PR Checks (Slang)` from the **required status checks** list. `sanitizer` and `slang` previously reported in the merge queue via `merge_group`; if they stay required after that trigger is removed, **the merge queue will block on checks that never report.**

## Test plan

- [ ] Workflows parse (validated locally).
- [ ] PR with no `ci:*` label: the four suites show as skipped; nothing blocks merge.
- [ ] Add `ci:integration`, then `ci:coverage`: both real runs complete; neither cancels the other.
- [ ] Add all `ci:*` labels at once: each suite's real run completes.
- [ ] Remove a label: no re-trigger (`unlabeled` is not a trigger).
- [ ] `release.yaml`: several `ci:*` labels at once → one dry-run pipeline, not several.