### PR TITLE
refactor(slang): resolve callee via slang's binder

### DIFF
--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -42,8 +42,8 @@ pub struct Context<'context> {
     pub module: Module<'context>,
     /// Cached MLIR types and emission methods.
     pub builder: Builder<'context>,
-    /// All function signatures for call resolution (bare name -> overloads).
-    pub function_signatures: HashMap<String, Vec<Function<'context>>>,
+    /// Resolution metadata keyed by the AST definition id of each function.
+    pub function_signatures: HashMap<usize, Function<'context>>,
     /// The MLIR type of the contract currently being emitted, used to type
     /// `this` expressions. Frontends set this before emitting function bodies.
     pub current_contract_type: Option<Type<'context>>,
@@ -161,49 +161,40 @@ impl<'context> Context<'context> {
         }
     }
 
-    /// Registers a function signature for call resolution.
+    /// Registers a function signature keyed by its AST definition id.
     pub fn register_function_signature(
         &mut self,
-        base_name: &str,
+        definition_id: usize,
         mlir_name: String,
         parameter_types: Vec<Type<'context>>,
         return_types: Vec<Type<'context>>,
     ) {
-        self.function_signatures
-            .entry(base_name.to_owned())
-            .or_default()
-            .push(Function::new(mlir_name, parameter_types, return_types));
+        self.function_signatures.insert(
+            definition_id,
+            Function::new(mlir_name, parameter_types, return_types),
+        );
     }
 
-    /// Resolves a function call by bare name and argument count.
+    /// Resolves a function by its AST definition id.
     ///
     /// Returns the mangled MLIR name, declared parameter types, and return
     /// types.
     ///
     /// # Errors
     ///
-    /// Returns an error if the function is undefined or the call is ambiguous.
+    /// Returns an error if the definition was not registered.
     pub fn resolve_function(
         &self,
-        base_name: &str,
-        argument_types: &[Type<'context>],
+        definition_id: usize,
     ) -> anyhow::Result<(&str, &[Type<'context>], &[Type<'context>])> {
-        let signatures = self
+        let function = self
             .function_signatures
-            .get(base_name)
-            .ok_or_else(|| anyhow::anyhow!("undefined function: {base_name}"))?;
-        let matched = signatures
-            .iter()
-            .find(|signature| signature.parameter_types == argument_types)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no matching overload of '{base_name}' for the given argument types"
-                )
-            })?;
+            .get(&definition_id)
+            .ok_or_else(|| anyhow::anyhow!("undefined function for definition {definition_id}"))?;
         Ok((
-            matched.mlir_name.as_str(),
-            &matched.parameter_types,
-            &matched.return_types,
+            function.mlir_name.as_str(),
+            &function.parameter_types,
+            &function.return_types,
         ))
     }
 

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -169,9 +169,13 @@ impl<'context> Context<'context> {
         parameter_types: Vec<Type<'context>>,
         return_types: Vec<Type<'context>>,
     ) {
-        self.function_signatures.insert(
+        let previous = self.function_signatures.insert(
             definition_id,
             Function::new(mlir_name, parameter_types, return_types),
+        );
+        debug_assert!(
+            previous.is_none(),
+            "duplicate function signature registration for definition {definition_id}",
         );
     }
 

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -5,6 +5,7 @@
 pub mod built_in;
 pub mod type_conversion;
 
+use anyhow::Context as _;
 use melior::ir::BlockRef;
 use melior::ir::Value;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
@@ -100,7 +101,8 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         let (mlir_name, parameter_types, return_types) = self
             .expression_emitter
             .state
-            .resolve_function(function_definition.node_id().into())?;
+            .resolve_function(function_definition.node_id().into())
+            .with_context(|| format!("resolving callee '{}'", callee_identifier.name()))?;
 
         // Cast arguments to match the callee's declared parameter types.
         let builder = &self.expression_emitter.state.builder;

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -7,8 +7,8 @@ pub mod type_conversion;
 
 use melior::ir::BlockRef;
 use melior::ir::Value;
-use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
+use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::FunctionCallExpression;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
@@ -31,13 +31,15 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
 
     /// Emits a function call expression.
     ///
-    /// Resolves the callee by name and argument count, handling type
-    /// conversions, built-in functions, and user-defined calls.
+    /// Handles type conversions and built-in dispatch, then resolves
+    /// user-defined callees through slang's binder to a function definition
+    /// node id and looks up the registered MLIR signature.
     ///
     /// # Errors
     ///
     /// Returns an error if the callee is unsupported, arguments contain
-    /// unsupported constructs, or the function is undefined.
+    /// unsupported constructs, or the callee does not resolve to a registered
+    /// function definition.
     pub fn emit_function_call(
         &self,
         call: &FunctionCallExpression,
@@ -48,14 +50,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             anyhow::bail!("only positional arguments supported");
         };
 
-        // Resolve callee name for Identifier/PayableKeyword callees; None for
-        // ElementaryType and MemberAccessExpression (handled as identity casts).
         let callee = call.operand();
-        let callee_name: Option<String> = match &callee {
-            Expression::Identifier(identifier) => Some(identifier.name()),
-            Expression::PayableKeyword => Some("payable".to_owned()),
-            _ => None,
-        };
 
         if call.is_type_conversion() && positional_arguments.len() == 1 {
             let first = positional_arguments
@@ -75,13 +70,21 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             return Ok((Some(result), block));
         }
 
-        // Non-conversion path: require named callee.
-        let callee_name =
-            callee_name.ok_or_else(|| anyhow::anyhow!("unsupported callee expression"))?;
-
         if let Some(block) = self.try_emit_built_in_call(&callee, positional_arguments, block)? {
             return Ok((None, block));
         }
+
+        let Expression::Identifier(callee_identifier) = &callee else {
+            anyhow::bail!("unsupported callee expression");
+        };
+        let Some(Definition::Function(function_definition)) =
+            callee_identifier.resolve_to_definition()
+        else {
+            anyhow::bail!(
+                "callee '{}' does not resolve to a function",
+                callee_identifier.name()
+            );
+        };
 
         let mut argument_values = Vec::new();
         let mut current_block = block;
@@ -94,12 +97,10 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             current_block = next_block;
         }
 
-        let argument_types: Vec<melior::ir::Type<'context>> =
-            argument_values.iter().map(|value| value.r#type()).collect();
         let (mlir_name, parameter_types, return_types) = self
             .expression_emitter
             .state
-            .resolve_function(&callee_name, &argument_types)?;
+            .resolve_function(function_definition.node_id().into())?;
 
         // Cast arguments to match the callee's declared parameter types.
         let builder = &self.expression_emitter.state.builder;

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -115,13 +115,16 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
             if matches!(function.kind(), FunctionKind::Modifier) {
                 continue;
             }
-            let name = FunctionEmitter::mlir_base_name(&function);
             let mlir_name = FunctionEmitter::mlir_function_name(&function);
             let (parameter_types, return_types) =
                 TypeConversion::resolve_function_types(&function, &self.state.builder);
 
-            self.state
-                .register_function_signature(&name, mlir_name, parameter_types, return_types);
+            self.state.register_function_signature(
+                function.node_id().into(),
+                mlir_name,
+                parameter_types,
+                return_types,
+            );
         }
     }
 


### PR DESCRIPTION
Replaces the name + argument-types overload matching in `Context::resolve_function` with a definition-id lookup driven by slang's binder. Follow-up to abinavpp's review on #352.