### PR TITLE
ci: extract submodule init into a composite action

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -16,5 +16,5 @@ runs:
     - shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        git config --global --add safe.directory '*'
+        git config --global --replace-all safe.directory '*'
         git submodule update --init --force --recursive --depth 1 --checkout

--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,20 @@
+name: Checkout submodules
+description: >-
+  Initializes and updates all submodules at depth 1, including ones marked
+  inactive in .gitmodules. The repository must already be checked out before
+  calling this action.
+
+inputs:
+  working-directory:
+    description: Directory in which to run the submodule update
+    required: false
+    default: .
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --force --recursive --depth 1 --checkout

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -59,9 +59,7 @@ jobs:
           submodules: true
 
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --init --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,15 +64,13 @@ jobs:
           path: temp-solx-main
 
       - name: Checkout submodules (PR)
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --init --force --recursive --depth 1 --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Checkout submodules (main)
-        working-directory: temp-solx-main
+        uses: ./.github/actions/checkout-submodules
         continue-on-error: true
-        run: |
-          git submodule update --init --force --recursive --depth 1 --checkout
+        with:
+          working-directory: temp-solx-main
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -52,9 +52,7 @@ jobs:
           submodules: true
 
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -73,9 +73,7 @@ jobs:
       # This step is required to checkout submodules
       # that are disabled in .gitmodules config
       - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
+        uses: ./.github/actions/checkout-submodules
 
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw


### PR DESCRIPTION
Reason for this PR is to unify behaviour between tests that run on the heavier machines (integration/sanitizer/coverage), as the self-hosted runner seems a bit mores sensitive to the particular git incantations. See https://github.com/NomicFoundation/solx/pull/375


Claude:
The same `safe.directory + git submodule update` dance was inlined in five places across four workflows (sanitizer, slang-tests, coverage, integration-tests — the last with two invocations: PR + temp-solx-main). Three subtly different argument sets had drifted between them.

Move it to a single composite action `.github/actions/checkout-submodules` with a `working-directory` input so the integration-tests "main" checkout can target `temp-solx-main`. All callers now run the same command:

  `git submodule update --init --force --recursive --depth 1 --checkout`

This consolidates the previously divergent forms (some had `--init`, some didn't; some used `--depth=1`, some `--depth 1`).