### PR TITLE
fix(tests): correct EIP-55 checksum in literal_types fixture

### DIFF
--- a/tests/solidity/simple/constant_expressions/literal_types.sol
+++ b/tests/solidity/simple/constant_expressions/literal_types.sol
@@ -150,7 +150,7 @@ contract Test {
     }
 
     function address_literal() public pure returns (address) {
-        return 0x00000000000000000000000000000000000000Ff;
+        return 0x00000000000000000000000000000000000000ff;
     }
 
     function time_units() public pure returns (uint256) {


### PR DESCRIPTION
solc 0.8.34 rejects `0x00000000000000000000000000000000000000Ff` as an address literal with an invalid checksum, causing 10 INVALID outcomes across optimizer/codegen variants in the integration suite and a non-zero exit from solx-tester (despite 0 FAILED).

Introduced in #367; surfaces as an integration-tests gate failure on any PR carrying the `ci:integration` label.