### PR TITLE
fix(slang): skip no-op casts in TypeConversion::emit

### DIFF
--- a/solx-mlir/tests/lit/events.sol
+++ b/solx-mlir/tests/lit/events.sol
@@ -1,0 +1,24 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*}}fire{{.*}}(%arg0: !sol.address, %arg1: ui256)
+// CHECK:   %[[CALLER:.*]] = sol.caller
+// CHECK:   %[[TO:.*]] = sol.load
+// CHECK:   %[[AMT:.*]] = sol.load
+// CHECK:   sol.emit "Transfer(address,address,uint256)" indexed = [%[[CALLER]], %[[TO]]] non_indexed = [%[[AMT]]] : !sol.address, !sol.address, ui256
+
+// CHECK: sol.func @{{.*}}fireAnon
+// CHECK:   sol.emit non_indexed = [%{{.*}}] : ui256
+
+contract C {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Anon(uint256 v) anonymous;
+
+    function fire(address to, uint256 amount) public {
+        emit Transfer(msg.sender, to, amount);
+    }
+
+    function fireAnon(uint256 v) public {
+        emit Anon(v);
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -91,6 +91,15 @@ impl<'context> TypeConversion<'context> {
         }
     }
 
+    /// Returns the MLIR target type this conversion produces.
+    pub fn to_target_type(&self, builder: &solx_mlir::Builder<'context>) -> Type<'context> {
+        match self {
+            Self::Bool => builder.types.i1,
+            Self::Address => builder.types.sol_address,
+            Self::Cast(target_type) => *target_type,
+        }
+    }
+
     /// Resolves the declared Solidity type of a state variable to an MLIR type.
     pub fn resolve_state_variable_type(
         state_variable: &StateVariableDefinition,
@@ -134,12 +143,7 @@ impl<'context> TypeConversion<'context> {
     where
         'context: 'block,
     {
-        let target_type = match &self {
-            Self::Bool => builder.types.i1,
-            Self::Address => builder.types.sol_address,
-            Self::Cast(t) => *t,
-        };
-        if value.r#type() == target_type {
+        if value.r#type() == self.to_target_type(builder) {
             return value;
         }
         match self {

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -134,6 +134,14 @@ impl<'context> TypeConversion<'context> {
     where
         'context: 'block,
     {
+        let target_type = match &self {
+            Self::Bool => builder.types.i1,
+            Self::Address => builder.types.sol_address,
+            Self::Cast(t) => *t,
+        };
+        if value.r#type() == target_type {
+            return value;
+        }
         match self {
             Self::Bool => {
                 let zero = builder.emit_sol_constant(0, value.r#type(), block);


### PR DESCRIPTION
[`TypeConversion::Address::emit`](https://github.com/NomicFoundation/solx/blob/4dc3a815e695d67e940a991a842edc0ce28cc2bf/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs#L142-L155) always calls `sol.address_cast` and [`TypeConversion::Bool::emit`](https://github.com/NomicFoundation/solx/blob/4dc3a815e695d67e940a991a842edc0ce28cc2bf/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs#L138-L141) always emits `sol.constant 0` + `sol.cmp ne` regardless of whether the source value's type already matches the target. Only `Self::Cast(t)` short-circuits, via [`Builder::emit_sol_cast`'s built-in guard](https://github.com/NomicFoundation/solx/blob/4dc3a815e695d67e940a991a842edc0ce28cc2bf/solx-mlir/src/context/builder/mod.rs#L943).

After [#384](https://github.com/NomicFoundation/solx/pull/384) routed emit/revert arguments through `TypeConversion::from_target_type(...).emit(...)`, every address argument to `sol.emit` and `sol.revert` flows through `Self::Address::emit` and produces a redundant `sol.address_cast %X : !sol.address to !sol.address` between every `sol.caller` (or address-typed `sol.load`) and its consumer. The same redundancy fires for `!a` on an i1 source (`sol.constant false` + `sol.cmp ne` round-trip on `bool`). The LLVM mid-end folds both, so EVM bytecode is unaffected; the Sol-dialect IR has been carrying the noise.