### PR TITLE
feat(slang): resolve compound Slang type variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,6 +4550,7 @@ dependencies = [
  "serde_json",
  "serde_stacker",
  "sha3 0.11.0",
+ "slang_solidity",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,12 @@ features = [
     "no-libffi-linking",
     "target-evm",
 ]
+
+# Slang
+[workspace.dependencies.slang_solidity]
+git = "https://github.com/NomicFoundation/slang.git"
+# TODO: pin to a release tag instead of a revision.
+rev = "d8388d6bf696383627ece31ba3551880d0b9eafc"
+# `__private_testing_utils` is required by `__private_backend_api` internals
+# (binder/types access in node_extensions). Both are unstable Slang APIs.
+features = ["__private_backend_api", "__private_testing_utils"]

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -14,6 +14,7 @@
 #include "mlir/CAPI/IR.h"
 
 #include <cstdlib>
+#include <vector>
 
 extern "C" {
 
@@ -74,6 +75,37 @@ MlirType solxCreateStringType(MlirContext ctx, uint32_t dataLocation) {
     auto *context = unwrap(ctx);
     auto location = static_cast<mlir::sol::DataLocation>(dataLocation);
     return wrap(mlir::sol::StringType::get(context, location));
+}
+
+MlirType solxCreateFixedBytesType(MlirContext ctx, uint32_t size) {
+    auto *context = unwrap(ctx);
+    return wrap(mlir::sol::FixedBytesType::get(context, size));
+}
+
+MlirType solxCreateArrayType(MlirContext ctx, int64_t size, MlirType elementType,
+                             uint32_t dataLocation) {
+    if (dataLocation > 5) abort();
+    auto *context = unwrap(ctx);
+    auto location = static_cast<mlir::sol::DataLocation>(dataLocation);
+    return wrap(mlir::sol::ArrayType::get(context, size, unwrap(elementType), location));
+}
+
+MlirType solxCreateMappingType(MlirContext ctx, MlirType keyType, MlirType valType) {
+    auto *context = unwrap(ctx);
+    return wrap(mlir::sol::MappingType::get(context, unwrap(keyType), unwrap(valType)));
+}
+
+MlirType solxCreateStructType(MlirContext ctx, const MlirType *member_types,
+                              size_t member_count, uint32_t dataLocation) {
+    if (dataLocation > 5) abort();
+    auto *context = unwrap(ctx);
+    std::vector<mlir::Type> mems;
+    mems.reserve(member_count);
+    for (size_t i = 0; i < member_count; i++) {
+        mems.push_back(unwrap(member_types[i]));
+    }
+    auto location = static_cast<mlir::sol::DataLocation>(dataLocation);
+    return wrap(mlir::sol::StructType::get(context, mems, location));
 }
 
 } /* extern "C" */

--- a/solx-mlir/src/context/builder/type_factory/array_size.rs
+++ b/solx-mlir/src/context/builder/type_factory/array_size.rs
@@ -1,0 +1,26 @@
+//!
+//! Length parameter for `sol::ArrayType`.
+//!
+
+/// Length of a `sol::ArrayType`.
+///
+/// The dialect's TableGen definition encodes the length as `int64_t`, with
+/// `-1` reserved as the sentinel for dynamic length. This enum keeps that
+/// encoding inside `solx-mlir` so call sites name the kind they want instead
+/// of passing a magic number.
+pub enum ArraySize {
+    /// Dynamic-length array (Solidity `T[]`).
+    Dynamic,
+    /// Fixed-length array of exactly `n` elements (Solidity `T[n]`).
+    Fixed(u64),
+}
+
+impl ArraySize {
+    /// Encodes the size into the dialect's wire format.
+    pub fn as_dialect_i64(self) -> i64 {
+        match self {
+            Self::Dynamic => -1,
+            Self::Fixed(n) => i64::try_from(n).expect("array size fits in i64"),
+        }
+    }
+}

--- a/solx-mlir/src/context/builder/type_factory/mod.rs
+++ b/solx-mlir/src/context/builder/type_factory/mod.rs
@@ -5,9 +5,13 @@
 //! parameterized Sol dialect types (pointers, addresses, integers).
 //!
 
+pub mod array_size;
+
 use melior::ir::Type;
 use melior::ir::TypeLike;
 use melior::ir::r#type::IntegerType;
+
+use self::array_size::ArraySize;
 
 /// MLIR type factory: pre-cached common types and parameterized constructors.
 ///
@@ -128,6 +132,82 @@ impl<'context> TypeFactory<'context> {
                 name_bytes.as_ptr() as *const std::ffi::c_char,
                 name_bytes.len(),
                 payable,
+            ))
+        }
+    }
+
+    /// Creates a `sol::StringType` at the given data location.
+    pub fn string(&self, location: solx_utils::DataLocation) -> Type<'context> {
+        // SAFETY: `solxCreateStringType` returns a valid MlirType from the
+        // C++ Sol dialect. The context pointer is valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateStringType(
+                self.context.to_raw(),
+                location as u32,
+            ))
+        }
+    }
+
+    /// Creates a `sol::FixedBytesType` of the given byte width.
+    pub fn fixed_bytes(&self, width: u32) -> Type<'context> {
+        // SAFETY: `solxCreateFixedBytesType` returns a valid MlirType from
+        // the C++ Sol dialect. The context pointer is valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateFixedBytesType(
+                self.context.to_raw(),
+                width,
+            ))
+        }
+    }
+
+    /// Creates a `sol::ArrayType`.
+    pub fn array(
+        &self,
+        size: ArraySize,
+        element_type: Type<'context>,
+        location: solx_utils::DataLocation,
+    ) -> Type<'context> {
+        // SAFETY: `solxCreateArrayType` returns a valid MlirType from the
+        // C++ Sol dialect. The context and element type pointers are valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateArrayType(
+                self.context.to_raw(),
+                size.as_dialect_i64(),
+                element_type.to_raw(),
+                location as u32,
+            ))
+        }
+    }
+
+    /// Creates a `sol::MappingType` with the given key and value types.
+    pub fn mapping(&self, key_type: Type<'context>, value_type: Type<'context>) -> Type<'context> {
+        // SAFETY: `solxCreateMappingType` returns a valid MlirType from the
+        // C++ Sol dialect. The context, key, and value type pointers are valid.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateMappingType(
+                self.context.to_raw(),
+                key_type.to_raw(),
+                value_type.to_raw(),
+            ))
+        }
+    }
+
+    /// Creates a `sol::StructType` from member types and a data location.
+    pub fn structure(
+        &self,
+        member_types: &[Type<'context>],
+        location: solx_utils::DataLocation,
+    ) -> Type<'context> {
+        let raw_types: Vec<mlir_sys::MlirType> = member_types.iter().map(|t| t.to_raw()).collect();
+        // SAFETY: `solxCreateStructType` returns a valid MlirType from the
+        // C++ Sol dialect. The context pointer is valid; the member type
+        // slice is borrowed for the duration of the call.
+        unsafe {
+            Type::from_raw(crate::ffi::solxCreateStructType(
+                self.context.to_raw(),
+                raw_types.as_ptr(),
+                raw_types.len(),
+                location as u32,
             ))
         }
     }

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -113,6 +113,33 @@ unsafe extern "C" {
     /// 2=Memory, 3=Stack, 4=Immutable, 5=Transient).
     pub fn solxCreateStringType(context: MlirContext, data_location: u32) -> mlir_sys::MlirType;
 
+    /// Creates a `sol::FixedBytesType` of the given byte width.
+    pub fn solxCreateFixedBytesType(context: MlirContext, size: u32) -> mlir_sys::MlirType;
+
+    /// Creates a `sol::ArrayType` with the given size, element type, and data
+    /// location. `size = -1` denotes a dynamic array.
+    pub fn solxCreateArrayType(
+        context: MlirContext,
+        size: i64,
+        element_type: mlir_sys::MlirType,
+        data_location: u32,
+    ) -> mlir_sys::MlirType;
+
+    /// Creates a `sol::MappingType` with the given key and value types.
+    pub fn solxCreateMappingType(
+        context: MlirContext,
+        key_type: mlir_sys::MlirType,
+        value_type: mlir_sys::MlirType,
+    ) -> mlir_sys::MlirType;
+
+    /// Creates a `sol::StructType` from a slice of member types and a data location.
+    pub fn solxCreateStructType(
+        context: MlirContext,
+        member_types: *const mlir_sys::MlirType,
+        member_count: usize,
+        data_location: u32,
+    ) -> mlir_sys::MlirType;
+
     // ---- MLIR core (not in mlir-sys) ----
 
     /// Returns the region that owns the given block.

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::attributes::state_mutability::StateMutability;
 pub use self::context::Context;
 pub use self::context::builder::Builder;
 pub use self::context::builder::type_factory::TypeFactory;
+pub use self::context::builder::type_factory::array_size::ArraySize;
 pub use self::context::environment::Environment;
 pub use self::dialect::Dialect;
 pub use self::output::MlirOutput;

--- a/solx-mlir/tests/lit/bytes.sol
+++ b/solx-mlir/tests/lit/bytes.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}bytes_id{{.*}}!sol.string<Memory>{{.*}}!sol.string<Memory>
+
+contract C {
+    function bytes_id(bytes memory b) public pure returns (bytes memory) { return b; }
+}

--- a/solx-mlir/tests/lit/bytes32.sol
+++ b/solx-mlir/tests/lit/bytes32.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}fixed_bytes{{.*}}!sol.fixedbytes<32>{{.*}}!sol.fixedbytes<32>
+
+contract C {
+    function fixed_bytes(bytes32 v) public pure returns (bytes32) { return v; }
+}

--- a/solx-mlir/tests/lit/dynamic_array.sol
+++ b/solx-mlir/tests/lit/dynamic_array.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}dyn_array{{.*}}!sol.array<{{.+}} x ui256, Memory>
+
+contract C {
+    function dyn_array(uint256[] memory a) public pure returns (uint256[] memory) { return a; }
+}

--- a/solx-mlir/tests/lit/fixed_array.sol
+++ b/solx-mlir/tests/lit/fixed_array.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}fixed_array{{.*}}!sol.array<4 x ui256, Memory>
+
+contract C {
+    function fixed_array(uint256[4] memory a) public pure returns (uint256[4] memory) { return a; }
+}

--- a/solx-mlir/tests/lit/string.sol
+++ b/solx-mlir/tests/lit/string.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}string_id{{.*}}!sol.string<Memory>{{.*}}!sol.string<Memory>
+
+contract C {
+    function string_id(string memory s) public pure returns (string memory) { return s; }
+}

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -13,14 +13,11 @@ doctest = false
 anyhow.workspace = true
 serde_json.workspace = true
 semver.workspace = true
-# `__private_testing_utils` is required by `__private_backend_api` internals
-# (binder/types access in node_extensions). Both are unstable Slang APIs.
-# TODO: pin to a release tag instead of branch = "main"
-slang_solidity = { git = "https://github.com/NomicFoundation/slang.git", rev = "d8388d6bf696383627ece31ba3551880d0b9eafc", features = ["__private_backend_api", "__private_testing_utils"] }
+slang_solidity.workspace = true
 melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-core = { path = "../solx-core", features = ["mlir"] }
 solx-mlir = { path = "../solx-mlir" }
 solx-standard-json = { path = "../solx-standard-json", features = ["mlir"] }
-solx-utils = { path = "../solx-utils" }
+solx-utils = { path = "../solx-utils", features = ["slang"] }

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -124,11 +124,14 @@ impl<'context> TypeConversion<'context> {
                 )
             }
             SlangType::Mapping(mapping_type) => {
-                let key_type =
-                    Self::resolve_slang_type(&mapping_type.key_type(), inherited_location, builder);
+                let key_type = Self::resolve_slang_type(
+                    &mapping_type.key_type(),
+                    Some(solx_utils::DataLocation::Storage),
+                    builder,
+                );
                 let value_type = Self::resolve_slang_type(
                     &mapping_type.value_type(),
-                    inherited_location,
+                    Some(solx_utils::DataLocation::Storage),
                     builder,
                 );
                 builder.types.mapping(key_type, value_type)
@@ -142,6 +145,9 @@ impl<'context> TypeConversion<'context> {
                     Definition::Struct(definition) => definition,
                     _ => unreachable!("Slang StructType always references a Struct definition"),
                 };
+                // TODO(v2): move struct-member type resolution into Slang itself
+                // so consumers don't have to walk `members()` and propagate the
+                // struct's data location by hand.
                 let mut member_types = Vec::new();
                 for member in struct_definition.members().iter() {
                     let member_slang_type = member

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -5,6 +5,7 @@
 use melior::ir::Type;
 use melior::ir::ValueLike;
 use melior::ir::r#type::IntegerType;
+use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::FunctionDefinition;
 use slang_solidity::backend::ir::ast::LiteralKind;
 use slang_solidity::backend::ir::ast::Parameter;
@@ -26,8 +27,14 @@ pub enum TypeConversion<'context> {
 
 impl<'context> TypeConversion<'context> {
     /// Maps a Slang semantic type to an MLIR type.
+    ///
+    /// `inherited_location` is the dialect data location to substitute when a
+    /// type's Slang location is `Inherited` (struct-field-relative). Top-level
+    /// callers pass `None`; the `Struct` arm sets it to the parent struct's
+    /// location for the duration of member resolution.
     pub fn resolve_slang_type(
         slang_type: &SlangType,
+        inherited_location: Option<solx_utils::DataLocation>,
         builder: &solx_mlir::Builder<'context>,
     ) -> Type<'context> {
         match slang_type {
@@ -65,14 +72,89 @@ impl<'context> TypeConversion<'context> {
                     let bits = bytes * solx_utils::BIT_LENGTH_BYTE as u32;
                     Type::from(IntegerType::unsigned(builder.context, bits))
                 }
-                kind @ (LiteralKind::Rational
-                | LiteralKind::HexString { .. }
-                | LiteralKind::String { .. }) => {
-                    unimplemented!(
-                        "MLIR type resolution is not yet implemented for literal kind {kind:?}"
-                    )
+                LiteralKind::String { .. } => {
+                    builder.types.string(solx_utils::DataLocation::Memory)
                 }
+                LiteralKind::HexString { bytes } => builder.types.fixed_bytes(bytes),
+                LiteralKind::Rational => unimplemented!(
+                    "MLIR type resolution is not yet implemented for rational literals"
+                ),
             },
+            SlangType::String(string_type) => {
+                let location = solx_utils::DataLocation::from_slang(
+                    string_type.location(),
+                    inherited_location,
+                );
+                builder.types.string(location)
+            }
+            SlangType::Bytes(bytes_type) => {
+                let location =
+                    solx_utils::DataLocation::from_slang(bytes_type.location(), inherited_location);
+                builder.types.string(location)
+            }
+            SlangType::ByteArray(byte_array_type) => {
+                builder.types.fixed_bytes(byte_array_type.width())
+            }
+            SlangType::Array(array_type) => {
+                let element_type = Self::resolve_slang_type(
+                    &array_type.element_type(),
+                    inherited_location,
+                    builder,
+                );
+                let location =
+                    solx_utils::DataLocation::from_slang(array_type.location(), inherited_location);
+                builder
+                    .types
+                    .array(solx_mlir::ArraySize::Dynamic, element_type, location)
+            }
+            SlangType::FixedSizeArray(fixed_array_type) => {
+                let element_type = Self::resolve_slang_type(
+                    &fixed_array_type.element_type(),
+                    inherited_location,
+                    builder,
+                );
+                let location = solx_utils::DataLocation::from_slang(
+                    fixed_array_type.location(),
+                    inherited_location,
+                );
+                builder.types.array(
+                    solx_mlir::ArraySize::Fixed(fixed_array_type.size() as u64),
+                    element_type,
+                    location,
+                )
+            }
+            SlangType::Mapping(mapping_type) => {
+                let key_type =
+                    Self::resolve_slang_type(&mapping_type.key_type(), inherited_location, builder);
+                let value_type = Self::resolve_slang_type(
+                    &mapping_type.value_type(),
+                    inherited_location,
+                    builder,
+                );
+                builder.types.mapping(key_type, value_type)
+            }
+            SlangType::Struct(struct_type) => {
+                let struct_location = solx_utils::DataLocation::from_slang(
+                    struct_type.location(),
+                    inherited_location,
+                );
+                let struct_definition = match struct_type.definition() {
+                    Definition::Struct(definition) => definition,
+                    _ => unreachable!("Slang StructType always references a Struct definition"),
+                };
+                let mut member_types = Vec::new();
+                for member in struct_definition.members().iter() {
+                    let member_slang_type = member
+                        .get_type()
+                        .expect("struct member type resolved by semantic analysis");
+                    member_types.push(Self::resolve_slang_type(
+                        &member_slang_type,
+                        Some(struct_location),
+                        builder,
+                    ));
+                }
+                builder.types.structure(&member_types, struct_location)
+            }
             _ => unimplemented!("unsupported Slang type"),
         }
     }
@@ -100,7 +182,7 @@ impl<'context> TypeConversion<'context> {
         let slang_type = state_variable
             .get_type()
             .ok_or_else(|| anyhow::anyhow!("unresolved type for state variable: {name}"))?;
-        Ok(Self::resolve_slang_type(&slang_type, builder))
+        Ok(Self::resolve_slang_type(&slang_type, None, builder))
     }
 
     /// Resolves a function's parameter and return types from Slang AST to MLIR.
@@ -113,6 +195,7 @@ impl<'context> TypeConversion<'context> {
                 &parameter
                     .get_type()
                     .expect("parameter type resolved by semantic analysis"),
+                None,
                 builder,
             )
         };

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -370,6 +370,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     pub fn resolve_slang_type(&self, slang_type: Option<SlangType>) -> Option<Type<'context>> {
         Some(TypeConversion::resolve_slang_type(
             &slang_type?,
+            None,
             &self.state.builder,
         ))
     }

--- a/solx-slang/src/ast/contract/function/statement/event.rs
+++ b/solx-slang/src/ast/contract/function/statement/event.rs
@@ -79,6 +79,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 &parameter
                     .get_type()
                     .expect("parameter type resolved by semantic analysis"),
+                None,
                 &self.state.builder,
             );
             let value = TypeConversion::from_target_type(parameter_type, &self.state.builder).emit(

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -174,7 +174,9 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         let name = declaration.name().name();
         let declared_type = declaration
             .get_type()
-            .map(|slang_type| TypeConversion::resolve_slang_type(&slang_type, &self.state.builder))
+            .map(|slang_type| {
+                TypeConversion::resolve_slang_type(&slang_type, None, &self.state.builder)
+            })
             .unwrap_or_else(|| self.state.builder.types.ui256);
 
         let emitter = ExpressionEmitter::new(
@@ -201,15 +203,17 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
 
         let pointer = emitter.state.builder.emit_sol_alloca(declared_type, &block);
 
-        let stored_value = initial_value.unwrap_or_else(|| {
-            self.state
+        if let Some(value) = initial_value {
+            emitter.state.builder.emit_sol_store(value, pointer, &block);
+        } else if melior::ir::r#type::IntegerType::try_from(declared_type).is_ok() {
+            let zero = self
+                .state
                 .builder
-                .emit_sol_constant(0, declared_type, &block)
-        });
-        emitter
-            .state
-            .builder
-            .emit_sol_store(stored_value, pointer, &block);
+                .emit_sol_constant(0, declared_type, &block);
+            emitter.state.builder.emit_sol_store(zero, pointer, &block);
+        } else {
+            unimplemented!("zero-initialization for non-integer type {declared_type}");
+        }
 
         self.environment
             .define_variable(name, pointer, declared_type);

--- a/solx-slang/src/ast/contract/function/statement/revert.rs
+++ b/solx-slang/src/ast/contract/function/statement/revert.rs
@@ -80,6 +80,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 &parameter
                     .get_type()
                     .expect("parameter type resolved by semantic analysis"),
+                None,
                 &self.state.builder,
             );
             *value = TypeConversion::from_target_type(parameter_type, &self.state.builder).emit(

--- a/solx-utils/Cargo.toml
+++ b/solx-utils/Cargo.toml
@@ -22,5 +22,8 @@ serde_arrays = "0.2"
 ipfs-hasher = "0.13"
 base58 = "0.2"
 
+slang_solidity = { workspace = true, optional = true }
+
 [features]
 mlir = []
+slang = ["dep:slang_solidity"]

--- a/solx-utils/src/data_location.rs
+++ b/solx-utils/src/data_location.rs
@@ -38,3 +38,31 @@ impl From<AddressSpace> for DataLocation {
         }
     }
 }
+
+#[cfg(feature = "slang")]
+impl DataLocation {
+    /// Converts a Slang semantic data location into the dialect's data location.
+    ///
+    /// `inherited_fallback` is substituted when the Slang location is `Inherited`
+    /// (struct-field-relative). Top-level callers pass `None`; recursive struct
+    /// member resolution passes the parent struct's resolved location.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `location` is `Inherited` and `inherited_fallback` is `None`,
+    /// because semantic analysis guarantees `Inherited` only appears inside a
+    /// struct member context where a fallback is available.
+    pub fn from_slang(
+        location: slang_solidity::backend::types::DataLocation,
+        inherited_fallback: Option<Self>,
+    ) -> Self {
+        use slang_solidity::backend::types::DataLocation as Slang;
+        match location {
+            Slang::Storage => Self::Storage,
+            Slang::Calldata => Self::CallData,
+            Slang::Memory => Self::Memory,
+            Slang::Inherited => inherited_fallback
+                .expect("data location 'Inherited' encountered without a parent struct location"),
+        }
+    }
+}


### PR DESCRIPTION
Adds Slang→Sol-dialect resolution for compound type variants, each mapped to an existing TableGen-generated builder via thin C wrappers:

| Slang variant     | Sol dialect type     | Notes                                       |
|-------------------|----------------------|---------------------------------------------|
| `String`          | `Sol_StringType`     | parameterized by data location              |
| `Bytes`           | `Sol_StringType`     | parameterized by data location              |
| `ByteArray`       | `Sol_FixedBytesType` | parameterized by width                      |
| `Array`           | `Sol_ArrayType`      | dynamic length, recursive element           |
| `FixedSizeArray`  | `Sol_ArrayType`      | concrete length, recursive element          |
| `Mapping`         | `Sol_MappingType`    | recursive key/value                         |
| `Struct`          | `Sol_StructType`     | recursive over `StructDefinition::members()`|

Struct member resolution substitutes the struct's own location whenever a member type carries the `Inherited` (struct-field-relative) location.

Depends on #384.

Lit tests: `solx-mlir/tests/lit/{string,bytes,bytes32,dynamic_array,fixed_array}.sol`.

Newly passing tests vs #384, simple suite:

- `tests/solidity/simple/unused/argument.sol::one`

Newly passing tests vs #384, upstream `solx-solidity/test/libsolidity/semanticTests`:

- `solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/calldata_arrays_too_large.sol`
- `solx-solidity/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_short_no_revert_string.sol`
- `solx-solidity/test/libsolidity/semanticTests/array/copying/bytes_calldata_to_string_calldata.sol`
- `solx-solidity/test/libsolidity/semanticTests/array/copying/string_calldata_to_bytes_calldata.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/static_base_function.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/static_base_function_deployed.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/subassembly_deduplication.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/super_function.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/super_function_deployed.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/virtual_function.sol`
- `solx-solidity/test/libsolidity/semanticTests/deployedCodeExclusion/virtual_function_deployed.sol`
- `solx-solidity/test/libsolidity/semanticTests/errors/error_static_calldata_uint_array_and_dynamic_array.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision2.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_emit.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_emit_file_level.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_lots_of_data.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_static_calldata_uint_array_and_dynamic_array.sol`
- `solx-solidity/test/libsolidity/semanticTests/inheritance/dataLocation/external_public_calldata.sol`
- `solx-solidity/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_calldata_interface.sol`
- `solx-solidity/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_memory_interface.sol`
- `solx-solidity/test/libsolidity/semanticTests/isoltestTesting/format_raw_string_with_control_chars.sol`
- `solx-solidity/test/libsolidity/semanticTests/strings/empty_string.sol`
- `solx-solidity/test/libsolidity/semanticTests/strings/unicode_escapes.sol`
- `solx-solidity/test/libsolidity/semanticTests/strings/unicode_string.sol`
- `solx-solidity/test/libsolidity/semanticTests/types/convert_fixed_bytes_to_fixed_bytes_same_size.sol`