### PR TITLE
feat(slang): emit tuple deconstruction statements

### DIFF
--- a/solx-mlir/src/context/environment.rs
+++ b/solx-mlir/src/context/environment.rs
@@ -64,28 +64,25 @@ impl<'context, 'block> Environment<'context, 'block> {
             .insert(name, (pointer, element_type));
     }
 
-    /// Looks up a variable's alloca'd pointer by name.
-    ///
-    /// Searches from the innermost scope outward.
-    pub fn variable(&self, name: &str) -> Option<Value<'context, 'block>> {
-        self.variable_with_type(name).map(|(pointer, _)| pointer)
-    }
-
     /// Looks up a variable's alloca'd pointer and element type by name.
     ///
     /// Searches from the innermost scope outward.
     ///
-    /// Returns `None` if no variable with the given name has been defined
-    /// in any enclosing scope.
-    pub fn variable_with_type(
-        &self,
-        name: &str,
-    ) -> Option<(Value<'context, 'block>, Type<'context>)> {
+    /// # Panics
+    ///
+    /// Panics if no binding exists. Slang's semantic pass guarantees every
+    /// emitted identifier reference resolves, so a miss here is a solx-internal
+    /// invariant failure rather than a user error.
+    ///
+    // TODO: key on the Slang `NodeId` of the declaration instead of the textual
+    // name to disambiguate same-named locals across scopes without relying on
+    // `enter_scope`/`exit_scope` discipline at the call sites.
+    pub fn variable_with_type(&self, name: &str) -> (Value<'context, 'block>, Type<'context>) {
         for scope in self.scopes.iter().rev() {
             if let Some(entry) = scope.get(name) {
-                return Some(*entry);
+                return *entry;
             }
         }
-        None
+        unreachable!("unregistered local variable: {name}");
     }
 }

--- a/solx-mlir/tests/lit/tuple_deconstruction.sol
+++ b/solx-mlir/tests/lit/tuple_deconstruction.sol
@@ -1,0 +1,27 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*sum.*}}
+// Parameters get their own alloca + store from %arg.
+// CHECK: sol.store %arg0
+// CHECK: sol.store %arg1
+// CHECK: sol.store %arg2
+// Then loads (the RHS tuple values) come before the deconstructed allocas.
+// CHECK: sol.load
+// CHECK-NEXT: sol.load
+// CHECK-NEXT: sol.load
+// Each deconstructed local: alloca followed by a store of a loaded value
+// (not %arg), proving the deconstruction allocated fresh slots for a, b, c.
+// CHECK: sol.alloca
+// CHECK-NEXT: sol.store %{{[0-9]+}}
+// CHECK: sol.alloca
+// CHECK-NEXT: sol.store %{{[0-9]+}}
+// CHECK: sol.alloca
+// CHECK-NEXT: sol.store %{{[0-9]+}}
+
+contract C {
+    function sum(uint256 x, uint256 y, uint256 z) public pure returns (uint256) {
+        (uint256 a, uint256 b, uint256 c) = (x, y, z);
+        return a + b + c;
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -208,10 +208,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 Ok((old, new_value))
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {
-                let (pointer, element_type) = self
-                    .environment
-                    .variable_with_type(&name)
-                    .ok_or_else(|| anyhow::anyhow!("unregistered local variable: {name}"))?;
+                let (pointer, element_type) = self.environment.variable_with_type(&name);
                 let old = self
                     .state
                     .builder

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -49,10 +49,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 AssignmentTarget::Storage(*slot, element_type)
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {
-                let (pointer, element_type) = self
-                    .environment
-                    .variable_with_type(&name)
-                    .ok_or_else(|| anyhow::anyhow!("unregistered local variable: {name}"))?;
+                let (pointer, element_type) = self.environment.variable_with_type(&name);
                 AssignmentTarget::Local(pointer, element_type)
             }
             None => anyhow::bail!("unresolved identifier: {name}"),

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -166,10 +166,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                         Ok((Some(value), block))
                     }
                     Some(Definition::Variable(_) | Definition::Parameter(_)) => {
-                        let (pointer, element_type) =
-                            self.environment.variable_with_type(&name).ok_or_else(|| {
-                                anyhow::anyhow!("unregistered local variable: {name}")
-                            })?;
+                        let (pointer, element_type) = self.environment.variable_with_type(&name);
                         let value =
                             self.state
                                 .builder

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -5,6 +5,7 @@
 pub mod control_flow;
 pub mod event;
 pub mod revert;
+pub mod tuple_deconstruction;
 
 use std::collections::HashMap;
 
@@ -133,6 +134,9 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             }
             Statement::RevertStatement(revert) => self.emit_revert(revert, block),
             Statement::EmitStatement(emit_statement) => self.emit_event(emit_statement, block),
+            Statement::TupleDeconstructionStatement(deconstruction) => {
+                self.emit_tuple_deconstruction(deconstruction, block)
+            }
             _ => anyhow::bail!(
                 "unsupported statement: {:?}",
                 std::mem::discriminant(statement)

--- a/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
+++ b/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
@@ -1,0 +1,98 @@
+//! Tuple deconstruction statement lowering.
+
+use melior::ir::BlockRef;
+use slang_solidity::backend::ir::ast::Expression;
+use slang_solidity::backend::ir::ast::TupleDeconstructionMember;
+use slang_solidity::backend::ir::ast::TupleDeconstructionStatement;
+
+use crate::ast::contract::function::expression::ExpressionEmitter;
+use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
+use crate::ast::contract::function::statement::StatementEmitter;
+
+impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
+    /// Emits a tuple deconstruction statement of the form
+    /// `(decl_or_id_or_skip, ...) = (rhs0, rhs1, ...)`.
+    ///
+    /// The right-hand side must currently be a tuple expression; each item is
+    /// emitted independently, then assigned to the corresponding LHS slot.
+    /// `None` slots discard their value, `Identifier` slots store into an
+    /// existing variable, and `VariableDeclarationStatement` slots allocate a
+    /// new variable. Multi-result function calls on the RHS are not yet
+    /// supported.
+    pub fn emit_tuple_deconstruction(
+        &mut self,
+        statement: &TupleDeconstructionStatement,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
+        let expression = statement.expression();
+        let Expression::TupleExpression(tuple) = &expression else {
+            anyhow::bail!(
+                "tuple deconstruction with non-tuple right-hand side is not yet supported"
+            );
+        };
+
+        let items = tuple.items();
+        let members = statement.members();
+        anyhow::ensure!(
+            items.len() == members.len(),
+            "tuple deconstruction arity mismatch: {} LHS slots vs {} RHS values",
+            members.len(),
+            items.len(),
+        );
+
+        let emitter = ExpressionEmitter::new(
+            self.state,
+            self.environment,
+            self.storage_layout,
+            self.checked,
+        );
+
+        let mut values = Vec::with_capacity(items.len());
+        let mut current = block;
+        for item in items.iter() {
+            let inner = item
+                .expression()
+                .ok_or_else(|| anyhow::anyhow!("empty tuple element on RHS of deconstruction"))?;
+            let (value, next) = emitter.emit_value(&inner, current)?;
+            values.push(value);
+            current = next;
+        }
+
+        for (member, value) in members.iter().zip(values.into_iter()) {
+            match member {
+                TupleDeconstructionMember::None => {
+                    // Discard the value; nothing to bind.
+                }
+                TupleDeconstructionMember::Identifier(identifier) => {
+                    let name = identifier.name();
+                    let (pointer, target_type) = self
+                        .environment
+                        .variable_with_type(&name)
+                        .ok_or_else(|| anyhow::anyhow!("unregistered local variable: {name}"))?;
+                    let builder = &self.state.builder;
+                    let cast = TypeConversion::from_target_type(target_type, builder)
+                        .emit(value, builder, &current);
+                    builder.emit_sol_store(cast, pointer, &current);
+                }
+                TupleDeconstructionMember::VariableDeclarationStatement(declaration) => {
+                    let name = declaration.name().name();
+                    let builder = &self.state.builder;
+                    let declared_type = declaration
+                        .get_type()
+                        .map(|slang_type| {
+                            TypeConversion::resolve_slang_type(&slang_type, None, builder)
+                        })
+                        .unwrap_or_else(|| builder.types.ui256);
+                    let cast = TypeConversion::from_target_type(declared_type, builder)
+                        .emit(value, builder, &current);
+                    let pointer = builder.emit_sol_alloca(declared_type, &current);
+                    builder.emit_sol_store(cast, pointer, &current);
+                    self.environment
+                        .define_variable(name, pointer, declared_type);
+                }
+            }
+        }
+
+        Ok(Some(current))
+    }
+}

--- a/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
+++ b/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
@@ -65,10 +65,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 }
                 TupleDeconstructionMember::Identifier(identifier) => {
                     let name = identifier.name();
-                    let (pointer, target_type) = self
-                        .environment
-                        .variable_with_type(&name)
-                        .ok_or_else(|| anyhow::anyhow!("unregistered local variable: {name}"))?;
+                    let (pointer, target_type) = self.environment.variable_with_type(&name);
                     let builder = &self.state.builder;
                     let cast = TypeConversion::from_target_type(target_type, builder)
                         .emit(value, builder, &current);


### PR DESCRIPTION
Adds the `Statement::TupleDeconstructionStatement` arm to the statement emitter. The right-hand side is a tuple expression whose elements are emitted independently. Each LHS slot may be one of:

- `None` — the slot is discarded.
- `Identifier` — the value is stored into an existing variable.
- `VariableDeclarationStatement` — a new local is allocated, then stored.

Depends on #388.

Lit test: `solx-mlir/tests/lit/tuple_deconstruction.sol`.

Newly passing tests vs #388, simple suite: none.

Newly passing tests vs #388, upstream `solx-solidity/test/libsolidity/semanticTests`: none.

Justification: real-world tuple deconstruction in Solidity overwhelmingly uses a function-call right-hand side (`(a, b) = f();`), not a tuple-expression right-hand side (`(a, b) = (x, y);`). #389 supports only the latter; the former is enabled by #391. The few simple/semanticTests fixtures that use tuple-expression RHS also depend on other unimplemented features (storage assignment, member access on the LHS) and bail before reaching the new arm.