### PR TITLE
feat(slang): resolve Contract, Interface, and Enum type variants

### DIFF
--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -108,4 +108,9 @@ MlirType solxCreateStructType(MlirContext ctx, const MlirType *member_types,
     return wrap(mlir::sol::StructType::get(context, mems, location));
 }
 
+MlirType solxCreateEnumType(MlirContext ctx, uint32_t max) {
+    auto *context = unwrap(ctx);
+    return wrap(mlir::sol::EnumType::get(context, max));
+}
+
 } /* extern "C" */

--- a/solx-mlir/src/context/builder/type_factory/mod.rs
+++ b/solx-mlir/src/context/builder/type_factory/mod.rs
@@ -211,4 +211,12 @@ impl<'context> TypeFactory<'context> {
             ))
         }
     }
+
+    /// Creates a `sol::EnumType` whose maximum valid value is `max`
+    /// (one less than the number of enum members).
+    pub fn enumeration(&self, max: u32) -> Type<'context> {
+        // SAFETY: `solxCreateEnumType` returns a valid MlirType from the
+        // C++ Sol dialect. The context pointer is valid.
+        unsafe { Type::from_raw(crate::ffi::solxCreateEnumType(self.context.to_raw(), max)) }
+    }
 }

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -140,6 +140,10 @@ unsafe extern "C" {
         data_location: u32,
     ) -> mlir_sys::MlirType;
 
+    /// Creates a `sol::EnumType` whose maximum valid value is `max`
+    /// (one less than the number of enum members).
+    pub fn solxCreateEnumType(context: MlirContext, max: u32) -> mlir_sys::MlirType;
+
     // ---- MLIR core (not in mlir-sys) ----
 
     /// Returns the region that owns the given block.

--- a/solx-mlir/tests/lit/named_types.sol
+++ b/solx-mlir/tests/lit/named_types.sol
@@ -1,0 +1,26 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}identity_color{{.*}}!sol.enum<2>{{.*}}!sol.enum<2>
+// CHECK: sol.func {{.*}}identity_iface{{.*}}!sol.contract<"IFoo{{.*}}">{{.*}}!sol.contract<"IFoo{{.*}}">
+// CHECK: sol.func {{.*}}identity_token{{.*}}!sol.contract<"Token{{.*}}">{{.*}}!sol.contract<"Token{{.*}}">
+// CHECK: sol.func {{.*}}identity_vault{{.*}}!sol.contract<"Vault{{.*}}", payable>{{.*}}!sol.contract<"Vault{{.*}}", payable>
+
+contract C {
+    enum Color { Red, Green, Blue }
+
+    function identity_color(Color c) public pure returns (Color) { return c; }
+    function identity_iface(IFoo f) public pure returns (IFoo) { return f; }
+    function identity_token(Token t) public pure returns (Token) { return t; }
+    function identity_vault(Vault v) public pure returns (Vault) { return v; }
+}
+
+interface IFoo { function go() external; }
+
+contract Token {
+    function tag() external pure returns (uint8) { return 1; }
+}
+
+contract Vault {
+    receive() external payable {}
+}

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -12,6 +12,8 @@ use slang_solidity::backend::ir::ast::Parameter;
 use slang_solidity::backend::ir::ast::StateVariableDefinition;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 
+use crate::ast::contract::ContractEmitter;
+
 /// Classification of Solidity type conversions.
 ///
 /// Used for both explicit conversions (`uint256(x)`, `address(x)`, `bool(x)`)
@@ -160,6 +162,38 @@ impl<'context> TypeConversion<'context> {
                     ));
                 }
                 builder.types.structure(&member_types, struct_location)
+            }
+            SlangType::Contract(contract_type) => {
+                let contract_definition = match contract_type.definition() {
+                    Definition::Contract(definition) => definition,
+                    _ => unreachable!("Slang ContractType always references a Contract definition"),
+                };
+                builder.types.contract(
+                    contract_definition.name().name().as_str(),
+                    ContractEmitter::is_contract_payable(&contract_definition),
+                )
+            }
+            SlangType::Interface(interface_type) => {
+                let interface_definition = match interface_type.definition() {
+                    Definition::Interface(definition) => definition,
+                    _ => unreachable!(
+                        "Slang InterfaceType always references an Interface definition"
+                    ),
+                };
+                // Interfaces are never `payable` themselves; payability lives
+                // on the address-cast at the call site.
+                builder
+                    .types
+                    .contract(interface_definition.name().name().as_str(), false)
+            }
+            SlangType::Enum(enum_type) => {
+                let enum_definition = match enum_type.definition() {
+                    Definition::Enum(definition) => definition,
+                    _ => unreachable!("Slang EnumType always references an Enum definition"),
+                };
+                let member_count = enum_definition.members().iter().count();
+                let max = u32::try_from(member_count - 1).expect("enum member count fits in u32");
+                builder.types.enumeration(max)
             }
             _ => unimplemented!("unsupported Slang type"),
         }

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -192,8 +192,10 @@ impl<'context> TypeConversion<'context> {
                     _ => unreachable!("Slang EnumType always references an Enum definition"),
                 };
                 let member_count = enum_definition.members().iter().count();
-                let max = u32::try_from(member_count - 1).expect("enum member count fits in u32");
-                builder.types.enumeration(max)
+                // Solidity caps enums at 256 members, so the max enumerator
+                // index always fits in a `u8`.
+                let max = u8::try_from(member_count - 1).expect("enum member count fits in u8");
+                builder.types.enumeration(max.into())
             }
             _ => unimplemented!("unsupported Slang type"),
         }

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -37,6 +37,9 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
     /// a `payable` `fallback()` function). Single source of truth for payability
     /// derivation — used both when emitting the `sol.contract` op and when
     /// resolving `SlangType::Contract` to a `Sol_ContractType`.
+    // TODO: walk the inheritance tree like solc does (`receiveFunction` /
+    // `fallbackFunction` on `ContractDefinition`, `ContractType::isPayable`)
+    // and move this helper into Slang.
     pub fn is_contract_payable(contract: &ContractDefinition) -> bool {
         contract.functions().iter().any(|function| {
             matches!(function.kind(), FunctionKind::Receive)

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -33,6 +33,18 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
         Self { state }
     }
 
+    /// Returns whether `contract` is payable (declares a `receive()` function or
+    /// a `payable` `fallback()` function). Single source of truth for payability
+    /// derivation — used both when emitting the `sol.contract` op and when
+    /// resolving `SlangType::Contract` to a `Sol_ContractType`.
+    pub fn is_contract_payable(contract: &ContractDefinition) -> bool {
+        contract.functions().iter().any(|function| {
+            matches!(function.kind(), FunctionKind::Receive)
+                || (matches!(function.kind(), FunctionKind::Fallback)
+                    && matches!(function.mutability(), FunctionMutability::Payable))
+        })
+    }
+
     /// Emits a `sol.contract` containing all function definitions.
     ///
     /// # Errors
@@ -48,12 +60,11 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
         self.pre_register_functions(contract);
         let storage_layout = Self::compute_storage_layout(contract, file_identifier);
 
-        let payable = contract.functions().iter().any(|function| {
-            matches!(function.kind(), FunctionKind::Receive)
-                || (matches!(function.kind(), FunctionKind::Fallback)
-                    && matches!(function.mutability(), FunctionMutability::Payable))
-        });
-        let contract_type = self.state.builder.types.contract(&contract_name, payable);
+        let contract_type = self
+            .state
+            .builder
+            .types
+            .contract(&contract_name, Self::is_contract_payable(contract));
 
         // Emit sol.contract and functions.
         let module_body = self.state.module.body();


### PR DESCRIPTION
Adds Slang→Sol-dialect resolution for three named-definition variants:

| Slang variant | Sol dialect type   | Parameterization                                  |
|---------------|--------------------|---------------------------------------------------|
| `Contract`    | `Sol_ContractType` | keyed by definition name; payable iff the contract declares `receive()` or `fallback() payable` |
| `Interface`   | `Sol_ContractType` | keyed by definition name; never payable           |
| `Enum`        | `Sol_EnumType`     | maximum valid enumerator index (member count − 1) |

Adds a C wrapper around `sol::EnumType::get` and a `TypeFactory::enumeration` method to expose it.

Depends on #387.

Lit test: `solx-mlir/tests/lit/named_types.sol`.

Newly passing tests vs #387, simple suite: none.

Newly passing tests vs #387, upstream `solx-solidity/test/libsolidity/semanticTests`: none.

Justification: tests in both suites that declare `Contract`, `Interface`, or `Enum` types as parameters or state variables also depend on at least one of `unsupported callee expression` (interface dispatch — 40 sites measured on this branch in `simple/`), `unsupported expression: Discriminant(18)` (`IndexAccessExpression` — 22 sites), or `unsupported assignment target` (29 sites). Removing the type-resolution blocker exposes the next blocker rather than turning a test green; the type-resolution mechanics are verified directly by the lit test instead.