### PR TITLE
feat(slang): support multi-result function calls in deconstruction

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -745,7 +745,9 @@ impl<'context> Builder<'context> {
 
     // ==== Calls ====
 
-    /// Emits a `sol.call` operation.
+    /// Emits a `sol.call` operation and returns its first result value, or
+    /// `None` if the callee is `void`. Use [`Self::emit_sol_call_results`]
+    /// when all results are needed.
     ///
     /// # Errors
     ///
@@ -765,6 +767,34 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
+        let results = self.emit_sol_call_results(callee, operands, result_types, block)?;
+        Ok(results.into_iter().next())
+    }
+
+    /// Emits a `sol.call` operation and returns all of its result values in
+    /// declaration order. Use [`Self::emit_sol_call`] when only the first
+    /// result is needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the call operation results cannot be
+    /// extracted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MLIR operation cannot be constructed, indicating a
+    /// bug in the builder.
+    pub fn emit_sol_call_results<'block, B>(
+        &self,
+        callee: &str,
+        operands: &[Value<'context, 'block>],
+        result_types: &[Type<'context>],
+        block: &B,
+    ) -> anyhow::Result<Vec<Value<'context, 'block>>>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
         let operation = block.append_operation(
             CallOperation::builder(self.context, self.unknown_location)
                 .callee(FlatSymbolRefAttribute::new(self.context, callee))
@@ -773,12 +803,11 @@ impl<'context> Builder<'context> {
                 .build()
                 .into(),
         );
-        if result_types.is_empty() {
-            Ok(None)
-        } else {
-            // TODO: return all results for multi-return functions
-            Ok(Some(operation.result(0)?.into()))
+        let mut results = Vec::with_capacity(result_types.len());
+        for index in 0..result_types.len() {
+            results.push(operation.result(index)?.into());
         }
+        Ok(results)
     }
 
     // ==== Comparisons ====

--- a/solx-mlir/tests/lit/multi_result_call.sol
+++ b/solx-mlir/tests/lit/multi_result_call.sol
@@ -1,0 +1,23 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*pair.*}}
+// CHECK: sol.return %{{.*}}, %{{.*}}
+// CHECK: sol.func @{{.*sum_pair.*}}
+// The call returns 2 results bound as a single SSA tuple.
+// CHECK: %{{[0-9]+}}:2 = sol.call
+// `a` is bound to result #0 and `b` to result #1, in declaration order:
+// CHECK-NEXT: sol.alloca
+// CHECK-NEXT: sol.store %{{[0-9]+}}#0
+// CHECK-NEXT: sol.alloca
+// CHECK-NEXT: sol.store %{{[0-9]+}}#1
+
+contract C {
+    function pair() public pure returns (uint256, uint256) {
+        return (3, 7);
+    }
+    function sum_pair() public pure returns (uint256) {
+        (uint256 a, uint256 b) = pair();
+        return a + b;
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -12,7 +12,9 @@ use slang_solidity::backend::ir::ast::ArgumentsDeclaration;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::FunctionCallExpression;
+use slang_solidity::backend::ir::ast::FunctionDefinition;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
+use slang_solidity::backend::ir::ast::PositionalArguments;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 
@@ -89,29 +91,9 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             );
         };
 
-        let mut argument_values = Vec::new();
-        let mut current_block = block;
-
-        for argument in positional_arguments.iter() {
-            let (value, next_block) = self
-                .expression_emitter
-                .emit_value(&argument, current_block)?;
-            argument_values.push(value);
-            current_block = next_block;
-        }
-
-        let (mlir_name, parameter_types, return_types) = self
-            .expression_emitter
-            .state
-            .resolve_function(function_definition.node_id().into())
+        let (mlir_name, argument_values, return_types, current_block) = self
+            .emit_call_setup(&function_definition, positional_arguments, block)
             .with_context(|| format!("resolving callee '{}'", callee_identifier.name()))?;
-
-        // Cast arguments to match the callee's declared parameter types.
-        let builder = &self.expression_emitter.state.builder;
-        for (value, &param_type) in argument_values.iter_mut().zip(parameter_types) {
-            let conversion = TypeConversion::from_target_type(param_type, builder);
-            *value = conversion.emit(*value, builder, &current_block);
-        }
 
         if return_types.is_empty() {
             self.expression_emitter.state.builder.emit_sol_call(
@@ -130,6 +112,92 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 .expect("function call always produces at least one result");
             Ok((Some(result), current_block))
         }
+    }
+
+    /// Emits a direct, named function call and returns all of its result
+    /// values in declaration order.
+    ///
+    /// Unlike [`Self::emit_function_call`], this entry point does not handle
+    /// explicit type conversions or built-in dispatch — it is intended for
+    /// callers that need the full result tuple (e.g. tuple deconstruction).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the call uses non-positional arguments, if the
+    /// callee is not a named identifier, or if name resolution fails.
+    pub fn emit_function_call_results(
+        &self,
+        call: &FunctionCallExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Vec<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        let ArgumentsDeclaration::PositionalArguments(positional_arguments) = &call.arguments()
+        else {
+            anyhow::bail!("only positional arguments supported");
+        };
+
+        let Expression::Identifier(callee_identifier) = call.operand() else {
+            anyhow::bail!("multi-result calls only support direct named function callees");
+        };
+        let Some(Definition::Function(function_definition)) =
+            callee_identifier.resolve_to_definition()
+        else {
+            anyhow::bail!(
+                "callee '{}' does not resolve to a function",
+                callee_identifier.name()
+            );
+        };
+
+        let (mlir_name, argument_values, return_types, current_block) = self
+            .emit_call_setup(&function_definition, positional_arguments, block)
+            .with_context(|| format!("resolving callee '{}'", callee_identifier.name()))?;
+
+        let results = self
+            .expression_emitter
+            .state
+            .builder
+            .emit_sol_call_results(mlir_name, &argument_values, return_types, &current_block)?;
+        Ok((results, current_block))
+    }
+
+    /// Emits argument values for a named call, resolves the callee's MLIR
+    /// signature, and casts each argument to its declared parameter type.
+    ///
+    /// Returns the resolved MLIR name, the cast argument values, the
+    /// declared return types, and the block in which the call should be
+    /// emitted.
+    fn emit_call_setup<'a>(
+        &'a self,
+        function_definition: &FunctionDefinition,
+        positional_arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(
+        &'a str,
+        Vec<Value<'context, 'block>>,
+        &'a [melior::ir::Type<'context>],
+        BlockRef<'context, 'block>,
+    )> {
+        let mut argument_values = Vec::new();
+        let mut current_block = block;
+        for argument in positional_arguments.iter() {
+            let (value, next_block) = self
+                .expression_emitter
+                .emit_value(&argument, current_block)?;
+            argument_values.push(value);
+            current_block = next_block;
+        }
+
+        let (mlir_name, parameter_types, return_types) = self
+            .expression_emitter
+            .state
+            .resolve_function(function_definition.node_id().into())?;
+
+        let builder = &self.expression_emitter.state.builder;
+        for (value, &param_type) in argument_values.iter_mut().zip(parameter_types) {
+            let conversion = TypeConversion::from_target_type(param_type, builder);
+            *value = conversion.emit(*value, builder, &current_block);
+        }
+
+        Ok((mlir_name, argument_values, return_types, current_block))
     }
 
     /// Emits a member access expression (e.g. `tx.origin`, `msg.sender`).

--- a/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
+++ b/solx-slang/src/ast/contract/function/statement/tuple_deconstruction.rs
@@ -6,39 +6,26 @@ use slang_solidity::backend::ir::ast::TupleDeconstructionMember;
 use slang_solidity::backend::ir::ast::TupleDeconstructionStatement;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
+use crate::ast::contract::function::expression::call::CallEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
 use crate::ast::contract::function::statement::StatementEmitter;
 
 impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
     /// Emits a tuple deconstruction statement of the form
-    /// `(decl_or_id_or_skip, ...) = (rhs0, rhs1, ...)`.
+    /// `(decl_or_id_or_skip, ...) = expression`.
     ///
-    /// The right-hand side must currently be a tuple expression; each item is
-    /// emitted independently, then assigned to the corresponding LHS slot.
-    /// `None` slots discard their value, `Identifier` slots store into an
-    /// existing variable, and `VariableDeclarationStatement` slots allocate a
-    /// new variable. Multi-result function calls on the RHS are not yet
-    /// supported.
+    /// The right-hand side may be either a tuple expression (each item is
+    /// emitted independently) or a direct call to a multi-return function
+    /// (its result tuple is used). `None` slots discard their value,
+    /// `Identifier` slots store into an existing variable, and
+    /// `VariableDeclarationStatement` slots allocate a new variable.
     pub fn emit_tuple_deconstruction(
         &mut self,
         statement: &TupleDeconstructionStatement,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
         let expression = statement.expression();
-        let Expression::TupleExpression(tuple) = &expression else {
-            anyhow::bail!(
-                "tuple deconstruction with non-tuple right-hand side is not yet supported"
-            );
-        };
-
-        let items = tuple.items();
         let members = statement.members();
-        anyhow::ensure!(
-            items.len() == members.len(),
-            "tuple deconstruction arity mismatch: {} LHS slots vs {} RHS values",
-            members.len(),
-            items.len(),
-        );
 
         let emitter = ExpressionEmitter::new(
             self.state,
@@ -47,16 +34,42 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             self.checked,
         );
 
-        let mut values = Vec::with_capacity(items.len());
-        let mut current = block;
-        for item in items.iter() {
-            let inner = item
-                .expression()
-                .ok_or_else(|| anyhow::anyhow!("empty tuple element on RHS of deconstruction"))?;
-            let (value, next) = emitter.emit_value(&inner, current)?;
-            values.push(value);
-            current = next;
-        }
+        let (values, current) = match &expression {
+            Expression::TupleExpression(tuple) => {
+                let items = tuple.items();
+                anyhow::ensure!(
+                    items.len() == members.len(),
+                    "tuple deconstruction arity mismatch: {} LHS slots vs {} RHS values",
+                    members.len(),
+                    items.len(),
+                );
+                let mut values = Vec::with_capacity(items.len());
+                let mut current = block;
+                for item in items.iter() {
+                    let inner = item.expression().ok_or_else(|| {
+                        anyhow::anyhow!("empty tuple element on RHS of deconstruction")
+                    })?;
+                    let (value, next) = emitter.emit_value(&inner, current)?;
+                    values.push(value);
+                    current = next;
+                }
+                (values, current)
+            }
+            Expression::FunctionCallExpression(call) => {
+                let call_emitter = CallEmitter::new(&emitter);
+                let (values, current) = call_emitter.emit_function_call_results(call, block)?;
+                anyhow::ensure!(
+                    values.len() == members.len(),
+                    "tuple deconstruction arity mismatch: {} LHS slots vs {} call results",
+                    members.len(),
+                    values.len(),
+                );
+                (values, current)
+            }
+            _ => anyhow::bail!(
+                "tuple deconstruction with this right-hand side shape is not yet supported"
+            ),
+        };
 
         for (member, value) in members.iter().zip(values.into_iter()) {
             match member {


### PR DESCRIPTION
Adds support for function-call right-hand sides in tuple deconstruction. `emit_sol_call_results` returns every result of a `sol.call` in declaration order. `emit_function_call_results` and the existing `emit_function_call` both go through a private `emit_call_setup` helper that handles argument emission, function resolution, and parameter-type casting; the two entry points only differ in their dispatch and return projection.

Depends on #389.

Lit test: `solx-mlir/tests/lit/multi_result_call.sol`.

Newly passing tests vs #389, simple suite: none.

Newly passing tests vs #389, upstream `solx-solidity/test/libsolidity/semanticTests`: none.

Justification: tests that use `(a, b) = f();` also depend on at least one of the same unimplemented downstream features that bound #390 — `unsupported callee expression`, `unsupported assignment target`, or `IndexAccessExpression`. The deconstruction-with-call construct now lowers end-to-end (verified by the lit test), but the surrounding test code hits the next blocker before reaching a green assertion.