### PR TITLE
feat(slang): wire gasleft, msg.sig, msg.data, addr.code intrinsics

### DIFF
--- a/solx-mlir/tests/lit/address_code.sol
+++ b/solx-mlir/tests/lit/address_code.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.code {{.*}} : !sol.address -> !sol.string<Memory>
+
+contract C {
+    function bytecode(address a) public view returns (bytes memory) { return a.code; }
+}

--- a/solx-mlir/tests/lit/gasleft.sol
+++ b/solx-mlir/tests/lit/gasleft.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.gasleft : ui256
+
+contract C {
+    function remaining() public view returns (uint256) { return gasleft(); }
+}

--- a/solx-mlir/tests/lit/msg_data.sol
+++ b/solx-mlir/tests/lit/msg_data.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.get_calldata : !sol.string<CallData>
+
+contract C {
+    function payload() external view returns (bytes calldata) { return msg.data; }
+}

--- a/solx-mlir/tests/lit/msg_sig.sol
+++ b/solx-mlir/tests/lit/msg_sig.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.sig : !sol.fixedbytes<4>
+
+contract C {
+    function selector() public pure returns (bytes4) { return msg.sig; }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -18,12 +18,16 @@ use solx_mlir::ods::sol::CallValueOperation;
 use solx_mlir::ods::sol::CallerOperation;
 use solx_mlir::ods::sol::ChainIdOperation;
 use solx_mlir::ods::sol::CodeHashOperation;
+use solx_mlir::ods::sol::CodeOperation;
 use solx_mlir::ods::sol::CoinbaseOperation;
 use solx_mlir::ods::sol::DifficultyOperation;
+use solx_mlir::ods::sol::GasLeftOperation;
 use solx_mlir::ods::sol::GasLimitOperation;
 use solx_mlir::ods::sol::GasPriceOperation;
+use solx_mlir::ods::sol::GetCallDataOperation;
 use solx_mlir::ods::sol::OriginOperation;
 use solx_mlir::ods::sol::PrevRandaoOperation;
+use solx_mlir::ods::sol::SigOperation;
 use solx_mlir::ods::sol::TimestampOperation;
 
 use crate::ast::contract::function::expression::call::CallEmitter;
@@ -32,9 +36,11 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
     /// Tries to emit `callee(arguments)` as a Solidity built-in.
     ///
     /// Resolves the callee via slang's binder to a [`BuiltIn`] variant.
-    /// Returns `Ok(Some(block))` if the call resolves to a recognized
-    /// built-in and was lowered; returns `Ok(None)` if the callee is not a
-    /// built-in and the caller should fall through to generic dispatch.
+    /// On match, returns `Ok(Some((value, block)))`, where `value` is
+    /// `Some(...)` for value-producing built-ins (e.g. `gasleft()`) and
+    /// `None` for statement-style built-ins (e.g. `assert`, `require`).
+    /// Returns `Ok(None)` if the callee is not a built-in and the caller
+    /// should fall through to generic dispatch.
     ///
     /// # Errors
     ///
@@ -45,7 +51,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         callee: &Expression,
         arguments: &PositionalArguments,
         block: BlockRef<'context, 'block>,
-    ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
+    ) -> anyhow::Result<Option<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)>> {
         let Expression::Identifier(identifier) = callee else {
             return Ok(None);
         };
@@ -55,7 +61,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         match built_in {
             BuiltIn::Assert if arguments.len() == 1 => {
                 let condition = arguments.iter().next().expect("argument count verified");
-                Ok(Some(self.emit_assert(&condition, block)?))
+                Ok(Some((None, self.emit_assert(&condition, block)?)))
             }
             BuiltIn::Require if matches!(arguments.len(), 1 | 2) => {
                 let mut iter = arguments.iter();
@@ -68,11 +74,24 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     Some(_) => anyhow::bail!("require message must be a string literal"),
                     None => None,
                 };
-                Ok(Some(self.emit_require(
-                    &condition,
-                    message.as_deref(),
-                    block,
-                )?))
+                Ok(Some((
+                    None,
+                    self.emit_require(&condition, message.as_deref(), block)?,
+                )))
+            }
+            BuiltIn::Gasleft if arguments.is_empty() => {
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        GasLeftOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.ui256)
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("gasleft always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
             }
             _ => Ok(None),
         }
@@ -82,8 +101,8 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
     ///
     /// Resolves the member via slang's binder to a specific `BuiltIn` variant
     /// and lowers it to the matching `sol.*` operation. Address-base intrinsics
-    /// (`address.balance`, `address.codehash`) first evaluate the address
-    /// operand and pass it as the operation's container address.
+    /// (`address.balance`, `address.codehash`, `address.code`) first evaluate
+    /// the address operand and pass it as the operation's container address.
     ///
     /// # Errors
     ///
@@ -110,6 +129,15 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     CodeHashOperation::builder(builder.context, builder.unknown_location)
                         .cont_addr(address_value)
                         .out(builder.types.ui256)
+                        .build()
+                        .into()
+                })
+            }
+            Some(BuiltIn::AddressCode) => {
+                self.emit_address_base_intrinsic(access, block, |address_value| {
+                    CodeOperation::builder(builder.context, builder.unknown_location)
+                        .cont_addr(address_value)
+                        .out(builder.types.sol_string_memory)
                         .build()
                         .into()
                 })
@@ -191,6 +219,18 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     Some(BuiltIn::BlockPrevrandao) => {
                         PrevRandaoOperation::builder(builder.context, builder.unknown_location)
                             .val(builder.types.ui256)
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::MsgSig) => {
+                        SigOperation::builder(builder.context, builder.unknown_location)
+                            .val(builder.types.fixed_bytes(4))
+                            .build()
+                            .into()
+                    }
+                    Some(BuiltIn::MsgData) => {
+                        GetCallDataOperation::builder(builder.context, builder.unknown_location)
+                            .addr(builder.types.string(solx_utils::DataLocation::CallData))
                             .build()
                             .into()
                     }

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -234,6 +234,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                             .build()
                             .into()
                     }
+                    // TODO: split this catch-all so non-built-in member accesses (struct fields, etc.) and unimplemented built-ins surface distinct errors.
                     _ => anyhow::bail!("unsupported member access: {}", access.member().name()),
                 };
                 let value = block

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -71,8 +71,10 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             return Ok((Some(result), block));
         }
 
-        if let Some(block) = self.try_emit_built_in_call(&callee, positional_arguments, block)? {
-            return Ok((None, block));
+        if let Some((value, block)) =
+            self.try_emit_built_in_call(&callee, positional_arguments, block)?
+        {
+            return Ok((value, block));
         }
 
         let Expression::Identifier(callee_identifier) = &callee else {


### PR DESCRIPTION
Adds dispatch arms for four current Solidity intrinsics, each lowering to an existing Sol dialect op:

| Identifier  | Sol op             | Result type             | Notes                                                         |
|-------------|--------------------|-------------------------|---------------------------------------------------------------|
| `gasleft()` | `sol.gasleft`      | `ui256`                 | Function-call dispatch (identifier callee, no args)           |
| `msg.sig`   | `sol.sig`          | `!sol.fixedbytes<4>`    | Member access; bytes4 selector                                |
| `msg.data`  | `sol.get_calldata` | `!sol.string<CallData>` | Member access; full calldata bytes                            |
| `addr.code` | `sol.code`         | `!sol.string<Memory>`   | Address-base intrinsic; result location matches dialect's custom builder |

`try_emit_built_in_call` now returns `(Option<Value>, BlockRef)` so the `gasleft()` arm can surface its `ui256` result; `assert` and `require` remain value-less and pass `None`.

Deprecated intrinsics (`now`, `msg.gas`) are not added — both were removed from Solidity (0.7.0 and 0.5.0 respectively).

Depends on #387.

Lit tests: `solx-mlir/tests/lit/{gasleft,msg_sig,msg_data,address_code}.sol`.

Newly passing tests vs #387, simple suite: none — none of the four intrinsics appear in `tests/solidity/simple/` fixtures.

Newly passing tests vs #387, upstream `solx-solidity/test/libsolidity/semanticTests`:

- `solx-solidity/test/libsolidity/semanticTests/builtinFunctions/msg_sig.sol`
- `solx-solidity/test/libsolidity/semanticTests/builtinFunctions/msg_sig_after_internal_call_is_same.sol`
- `solx-solidity/test/libsolidity/semanticTests/events/event_really_lots_of_data.sol`
- `solx-solidity/test/libsolidity/semanticTests/state/gasleft.sol`
- `solx-solidity/test/libsolidity/semanticTests/state/msg_data.sol`
- `solx-solidity/test/libsolidity/semanticTests/state/msg_sig.sol`
- `solx-solidity/test/libsolidity/semanticTests/various/gasleft_decrease.sol`