### PR TITLE
feat(slang): wire cryptographic and modular-arithmetic intrinsics

### DIFF
--- a/solx-mlir/tests/lit/addmod.sol
+++ b/solx-mlir/tests/lit/addmod.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.addmod {{.*}} : ui256
+
+contract C {
+    function f(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
+        return addmod(x, y, m);
+    }
+}

--- a/solx-mlir/tests/lit/ecrecover.sol
+++ b/solx-mlir/tests/lit/ecrecover.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.ecrecover{{.*}}: (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
+
+contract C {
+    function recover(bytes32 h, uint8 v, bytes32 r, bytes32 s) public pure returns (address) {
+        return ecrecover(h, v, r, s);
+    }
+}

--- a/solx-mlir/tests/lit/keccak256.sol
+++ b/solx-mlir/tests/lit/keccak256.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.keccak256{{.*}}: (!sol.string<Memory>) -> !sol.fixedbytes<32>
+
+contract C {
+    function digest(bytes memory data) public pure returns (bytes32) { return keccak256(data); }
+}

--- a/solx-mlir/tests/lit/mulmod.sol
+++ b/solx-mlir/tests/lit/mulmod.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.mulmod {{.*}} : ui256
+
+contract C {
+    function f(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
+        return mulmod(x, y, m);
+    }
+}

--- a/solx-mlir/tests/lit/ripemd160.sol
+++ b/solx-mlir/tests/lit/ripemd160.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.ripemd160{{.*}}: (!sol.string<Memory>) -> !sol.fixedbytes<20>
+
+contract C {
+    function digest(bytes memory data) public pure returns (bytes20) { return ripemd160(data); }
+}

--- a/solx-mlir/tests/lit/sha256.sol
+++ b/solx-mlir/tests/lit/sha256.sol
@@ -1,0 +1,8 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.sha256{{.*}}: (!sol.string<Memory>) -> !sol.fixedbytes<32>
+
+contract C {
+    function digest(bytes memory data) public pure returns (bytes32) { return sha256(data); }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -10,6 +10,7 @@ use slang_solidity::backend::built_ins::BuiltIn;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
 use slang_solidity::backend::ir::ast::PositionalArguments;
+use solx_mlir::ods::sol::AddModOperation;
 use solx_mlir::ods::sol::BalanceOperation;
 use solx_mlir::ods::sol::BaseFeeOperation;
 use solx_mlir::ods::sol::BlobBaseFeeOperation;
@@ -21,12 +22,17 @@ use solx_mlir::ods::sol::CodeHashOperation;
 use solx_mlir::ods::sol::CodeOperation;
 use solx_mlir::ods::sol::CoinbaseOperation;
 use solx_mlir::ods::sol::DifficultyOperation;
+use solx_mlir::ods::sol::EcrecoverOperation;
 use solx_mlir::ods::sol::GasLeftOperation;
 use solx_mlir::ods::sol::GasLimitOperation;
 use solx_mlir::ods::sol::GasPriceOperation;
 use solx_mlir::ods::sol::GetCallDataOperation;
+use solx_mlir::ods::sol::Keccak256Operation;
+use solx_mlir::ods::sol::MulModOperation;
 use solx_mlir::ods::sol::OriginOperation;
 use solx_mlir::ods::sol::PrevRandaoOperation;
+use solx_mlir::ods::sol::Ripemd160Operation;
+use solx_mlir::ods::sol::Sha256Operation;
 use solx_mlir::ods::sol::SigOperation;
 use solx_mlir::ods::sol::TimestampOperation;
 
@@ -90,6 +96,107 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     )
                     .result(0)
                     .expect("gasleft always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Keccak256 if arguments.len() == 1 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        Keccak256Operation::builder(builder.context, builder.unknown_location)
+                            .addr(values[0])
+                            .result(builder.types.fixed_bytes(32))
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("keccak256 always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Sha256 if arguments.len() == 1 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        Sha256Operation::builder(builder.context, builder.unknown_location)
+                            .data(values[0])
+                            .result(builder.types.fixed_bytes(32))
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("sha256 always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Ripemd160 if arguments.len() == 1 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        Ripemd160Operation::builder(builder.context, builder.unknown_location)
+                            .data(values[0])
+                            .result(builder.types.fixed_bytes(20))
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("ripemd160 always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Ecrecover if arguments.len() == 4 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        EcrecoverOperation::builder(builder.context, builder.unknown_location)
+                            .hash(values[0])
+                            .v(values[1])
+                            .r(values[2])
+                            .s(values[3])
+                            .result(builder.types.sol_address)
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("ecrecover always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Addmod if arguments.len() == 3 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        AddModOperation::builder(builder.context, builder.unknown_location)
+                            .x(values[0])
+                            .y(values[1])
+                            .r#mod(values[2])
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("addmod always produces one result")
+                    .into();
+                Ok(Some((Some(value), block)))
+            }
+            BuiltIn::Mulmod if arguments.len() == 3 => {
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let builder = &self.expression_emitter.state.builder;
+                let value = block
+                    .append_operation(
+                        MulModOperation::builder(builder.context, builder.unknown_location)
+                            .x(values[0])
+                            .y(values[1])
+                            .r#mod(values[2])
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("mulmod always produces one result")
                     .into();
                 Ok(Some((Some(value), block)))
             }
@@ -270,6 +377,23 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             .expect("address-base intrinsic always produces one result")
             .into();
         Ok((value, block))
+    }
+
+    /// Emits each positional argument and returns the resulting values
+    /// alongside the current block.
+    fn emit_argument_values(
+        &self,
+        arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Vec<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        let mut values = Vec::with_capacity(arguments.len());
+        let mut current = block;
+        for argument in arguments.iter() {
+            let (value, next) = self.expression_emitter.emit_value(&argument, current)?;
+            values.push(value);
+            current = next;
+        }
+        Ok((values, current))
     }
 
     /// Emits an `assert(condition)` built-in via `sol.assert`.


### PR DESCRIPTION
Adds dispatch arms for the cryptographic and modular-arithmetic built-ins, each lowering to an existing Sol dialect op:

| Identifier             | Sol op           | Result type             | Notes                                              |
|------------------------|------------------|-------------------------|----------------------------------------------------|
| `keccak256(bytes)`     | `sol.keccak256`  | `!sol.fixedbytes<32>`   | Receiver is `Sol_StringType` (bytes/string)        |
| `sha256(bytes)`        | `sol.sha256`     | `!sol.fixedbytes<32>`   | Same shape                                         |
| `ripemd160(bytes)`     | `sol.ripemd160`  | `!sol.fixedbytes<20>`   | Same shape, narrower result                        |
| `ecrecover(h, v, r, s)`| `sol.ecrecover`  | `!sol.address`          | Four operands: bytes32, uint8, bytes32, bytes32    |
| `addmod(x, y, m)`      | `sol.addmod`     | inferred from operands  | `SameOperandsAndResultType` — no result setter     |
| `mulmod(x, y, m)`      | `sol.mulmod`     | inferred from operands  | Same                                               |

A private `emit_argument_values` helper evaluates each positional argument so the new multi-arg arms share argument-emission logic.

Depends on #392.

Lit tests: `solx-mlir/tests/lit/{keccak256,sha256,ripemd160,ecrecover,addmod,mulmod}.sol`.

Newly passing tests vs #392, simple suite:

- `tests/solidity/simple/modular/addmod.sol`
- `tests/solidity/simple/modular/mulmod.sol`

Newly passing tests vs #392, upstream `solx-solidity/test/libsolidity/semanticTests`:

- `solx-solidity/test/libsolidity/semanticTests/builtinFunctions/keccak256_empty.sol`
- `solx-solidity/test/libsolidity/semanticTests/builtinFunctions/ripemd160_empty.sol`
- `solx-solidity/test/libsolidity/semanticTests/builtinFunctions/sha256_empty.sol`
- `solx-solidity/test/libsolidity/semanticTests/ecrecover/ecrecover.sol`
- `solx-solidity/test/libsolidity/semanticTests/ecrecover/ecrecover_abiV2.sol`
- `solx-solidity/test/libsolidity/semanticTests/viaYul/keccak.sol`