### PR TITLE
feat(solx-dev): split LLVM utils and tests build flags

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Working directory.'
     required: false
     default: '.'
+  enable-utils:
+    description: "Build and install the LLVM utility binaries (FileCheck, llvm-lit, etc.). Implied by enable-tests."
+    required: false
+    default: 'false'
   enable-tests:
     description: "Enable tests."
     required: false
@@ -64,6 +68,12 @@ runs:
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
+        # `enable-tests` implies `enable-utils` (LLVM CMake requires it),
+        # so normalize before keying to avoid splitting identical artifacts.
+        UTILS='${{ inputs.enable-utils }}'
+        [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
+        [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
+        [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
         KEY="${KEY}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
@@ -103,6 +113,12 @@ runs:
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
+        # `enable-tests` implies `enable-utils` (LLVM CMake requires it),
+        # so normalize before keying to avoid splitting identical artifacts.
+        UTILS='${{ inputs.enable-utils }}'
+        [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
+        [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
+        [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
         # Terminator: prevents shorter-variant keys from prefix-matching longer ones
         # via ccache-action's restore-keys (e.g. `...-mlir` matching `...-mlir-coverage-no-assertions`).
         KEY="${KEY}-end"
@@ -150,6 +166,7 @@ runs:
         LIBSTDCPP_SOURCE_PATH: "${{ runner.temp }}/msys64/mingw64/lib/libstdc++.a"
       run: |
         set -x
+        [ "${{ inputs.enable-utils }}" = "true" ] && ENABLE_UTILS="--enable-utils"
         [ "${{ inputs.enable-tests }}" = "true" ] && ENABLE_TESTS="--enable-tests"
         [ "${{ inputs.enable-assertions }}" = "true" ] && ENABLE_ASSERTIONS="--enable-assertions"
         [ "${{ inputs.enable-coverage }}" = "true" ] && ENABLE_COVERAGE="--enable-coverage"
@@ -174,7 +191,7 @@ runs:
         fi
 
         ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
-          --ccache-variant=ccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
+          --ccache-variant=ccache ${ENABLE_UTILS} ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -86,6 +86,7 @@ jobs:
           build-type: RelWithDebInfo
           enable-assertions: 'true'
           enable-mlir: 'true'
+          enable-utils: 'true'
 
       # When the artifact cache is warm, build-llvm skips ccache entirely,
       # so the ccache entry's LRU timer isn't refreshed. Touch it explicitly

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -88,6 +88,7 @@ jobs:
           build-type: RelWithDebInfo
           enable-assertions: 'true'
           enable-mlir: 'true'
+          enable-utils: 'true'
 
       # bindgen's embedded clang needs to know it's targeting MinGW,
       # otherwise it can't parse MinGW-specific __attribute__ extensions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,7 @@ jobs:
           build-type: RelWithDebInfo
           enable-assertions: 'true'
           enable-mlir: 'true'
+          enable-utils: 'true'
 
       - name: Cargo checks
         uses: ./.github/actions/cargo-check
@@ -278,6 +279,7 @@ jobs:
           build-type: RelWithDebInfo
           enable-assertions: 'true'
           enable-mlir: 'true'
+          enable-utils: 'true'
 
       - name: Building solc
         uses: ./.github/actions/build-solc

--- a/solx-dev/src/arguments/llvm/build.rs
+++ b/solx-dev/src/arguments/llvm/build.rs
@@ -44,6 +44,11 @@ pub struct Build {
     //
     // Build Features
     //
+    /// Whether to build and install the LLVM utility binaries
+    /// (`FileCheck`, `llvm-lit`, etc.). Implied by `--enable-tests`.
+    #[arg(long, help_heading = "Build Features")]
+    pub enable_utils: bool,
+
     /// Whether to build the LLVM tests.
     #[arg(long, help_heading = "Build Features")]
     pub enable_tests: bool,

--- a/solx-dev/src/llvm/mod.rs
+++ b/solx-dev/src/llvm/mod.rs
@@ -23,6 +23,7 @@ use anyhow::Context;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -43,11 +44,18 @@ pub fn build(
 
     std::fs::create_dir_all(Path::DIRECTORY_LLVM_TARGET)?;
 
+    // LLVM's CMake bails with a fatal error when `LLVM_INCLUDE_TESTS=On` and
+    // `LLVM_INCLUDE_UTILS=Off` (solx-llvm/llvm/CMakeLists.txt:1361, "Including
+    // tests when not building utils will not work"), so promote `enable_tests`
+    // to imply `enable_utils` rather than push that contract onto every caller.
+    let enable_utils = enable_utils || enable_tests;
+
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
             platforms::x86_64_linux_gnu::build(
                 build_type,
                 enable_mlir,
+                enable_utils,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -61,6 +69,7 @@ pub fn build(
             platforms::x86_64_macos::build(
                 build_type,
                 enable_mlir,
+                enable_utils,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -72,6 +81,7 @@ pub fn build(
             platforms::x86_64_windows_gnu::build(
                 build_type,
                 enable_mlir,
+                enable_utils,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -87,6 +97,7 @@ pub fn build(
             platforms::aarch64_linux_gnu::build(
                 build_type,
                 enable_mlir,
+                enable_utils,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -100,6 +111,7 @@ pub fn build(
             platforms::aarch64_macos::build(
                 build_type,
                 enable_mlir,
+                enable_utils,
                 enable_tests,
                 enable_coverage,
                 extra_args,

--- a/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
@@ -15,6 +15,7 @@ use crate::llvm::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -57,6 +58,9 @@ pub fn build(
                 enable_mlir,
             ))
             .args(crate::llvm::platforms::shared::shared_build_opts_targets())
+            .args(crate::llvm::platforms::shared::shared_build_opts_utils(
+                enable_utils,
+            ))
             .args(crate::llvm::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-dev/src/llvm/platforms/aarch64_macos.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_macos.rs
@@ -15,6 +15,7 @@ use crate::llvm::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -50,6 +51,9 @@ pub fn build(
                 enable_mlir,
             ))
             .args(crate::llvm::platforms::shared::shared_build_opts_targets())
+            .args(crate::llvm::platforms::shared::shared_build_opts_utils(
+                enable_utils,
+            ))
             .args(crate::llvm::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -131,20 +131,42 @@ pub fn shared_build_opts_targets() -> Vec<String> {
 }
 
 ///
-/// The LLVM tests build options shared by all platforms.
+/// The LLVM utils build options shared by all platforms.
 ///
-pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
+/// Toggles `FileCheck`, `llvm-lit`, and the rest of the LLVM utility binaries
+/// (`-DLLVM_{BUILD,INCLUDE,INSTALL}_UTILS`). Sufficient for workflows that
+/// only need the lit-test runners against pre-built MLIR/IR fixtures, without
+/// pulling in the full `--enable-tests` build.
+///
+pub fn shared_build_opts_utils(enabled: bool) -> Vec<String> {
     vec![
         format!(
             "-DLLVM_BUILD_UTILS='{}'",
             if enabled { "On" } else { "Off" },
         ),
         format!(
-            "-DLLVM_BUILD_TESTS='{}'",
+            "-DLLVM_INCLUDE_UTILS='{}'",
             if enabled { "On" } else { "Off" },
         ),
         format!(
-            "-DLLVM_INCLUDE_UTILS='{}'",
+            "-DLLVM_INSTALL_UTILS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+    ]
+}
+
+///
+/// The LLVM tests build options shared by all platforms.
+///
+/// Toggles the LLVM regression and unit tests (`-DLLVM_{BUILD,INCLUDE}_TESTS`).
+/// `--enable-tests` implies `--enable-utils` (see `crate::llvm::build`);
+/// callers that only need `FileCheck`/`llvm-lit` should prefer
+/// `--enable-utils` alone.
+///
+pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
+    vec![
+        format!(
+            "-DLLVM_BUILD_TESTS='{}'",
             if enabled { "On" } else { "Off" },
         ),
         format!(

--- a/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
@@ -15,6 +15,7 @@ use crate::llvm::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -57,6 +58,9 @@ pub fn build(
                 enable_mlir,
             ))
             .args(crate::llvm::platforms::shared::shared_build_opts_targets())
+            .args(crate::llvm::platforms::shared::shared_build_opts_utils(
+                enable_utils,
+            ))
             .args(crate::llvm::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-dev/src/llvm/platforms/x86_64_macos.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_macos.rs
@@ -15,6 +15,7 @@ use crate::llvm::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -50,6 +51,9 @@ pub fn build(
                 enable_mlir,
             ))
             .args(crate::llvm::platforms::shared::shared_build_opts_targets())
+            .args(crate::llvm::platforms::shared::shared_build_opts_utils(
+                enable_utils,
+            ))
             .args(crate::llvm::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -16,6 +16,7 @@ use crate::llvm::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
+    enable_utils: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -57,6 +58,9 @@ pub fn build(
                 enable_mlir,
             ))
             .args(crate::llvm::platforms::shared::shared_build_opts_targets())
+            .args(crate::llvm::platforms::shared::shared_build_opts_utils(
+                enable_utils,
+            ))
             .args(crate::llvm::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/solx-dev/src/solx_dev/main.rs
+++ b/solx-dev/src/solx_dev/main.rs
@@ -55,6 +55,7 @@ fn main_inner() -> anyhow::Result<()> {
             solx_dev::llvm_build(
                 arguments.build_type,
                 arguments.enable_mlir,
+                arguments.enable_utils,
                 arguments.enable_tests,
                 arguments.enable_coverage,
                 extra_args_unescaped,


### PR DESCRIPTION
Splits `--enable-tests` into two flags so workflows that only need the LLVM utility binaries (`FileCheck`, `llvm-lit`, etc.) can opt into the smaller build:

- `--enable-utils` (new) → `-DLLVM_{BUILD,INCLUDE,INSTALL}_UTILS=On`.
- `--enable-tests` → `-DLLVM_{BUILD,INCLUDE}_TESTS=On`. Auto-promotes `--enable-utils` because LLVM's CMake fatal-errors when `LLVM_INCLUDE_TESTS=On` and `LLVM_INCLUDE_UTILS=Off` (see `solx-llvm/llvm/CMakeLists.txt`). Existing callers passing `enable-tests: true` keep working with no change.

The matching `enable-utils` input is added to `.github/actions/build-llvm/action.yml`, threaded into both the artifact and ccache keys (with the same normalization, so `enable-tests: true` and `enable-tests: true` + `enable-utils: true` share an artifact), and forwarded to `solx-dev`.

Per @nebasuke on #384: the lit-tests workflow only needs `FileCheck`/`llvm-lit`, but `--enable-tests` regressed cold-cache CI to ~5h on macOS x86. #384 will rebase on top.