### PR TITLE
feat(slang): emit contract-level constant references

### DIFF
--- a/solx-mlir/tests/lit/constants.sol
+++ b/solx-mlir/tests/lit/constants.sol
@@ -1,0 +1,41 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// Each reference to a contract-level `constant` is inlined as if the
+// initializer expression appeared at the use site, so `FOO` lowers to
+// the same `sol.constant` + `sol.cast` chain as a bare `42` literal.
+
+// CHECK: sol.func @{{.*read.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 42 : ui8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK:      sol.func @{{.*sum.*}}() -> ui256
+// CHECK-DAG:    sol.constant 42 : ui8
+// CHECK-DAG:    sol.constant 42 : ui8
+// CHECK:        sol.cadd %{{.*}}, %{{.*}} : ui256
+// CHECK:        sol.return %{{.*}} : ui256
+
+// `DOUBLE` is a constant whose initializer references another constant,
+// exercising recursive inlining: `DOUBLE` → `FOO * 2` → `42 * 2`.
+// CHECK:      sol.func @{{.*getDouble.*}}() -> ui8
+// CHECK:        sol.constant 42 : ui8
+// CHECK:        sol.constant 2 : ui8
+// CHECK:        sol.cmul %{{.*}}, %{{.*}} : ui8
+
+contract C {
+    uint256 constant FOO = 42;
+    uint8 constant DOUBLE = uint8(FOO) * 2;
+
+    function read() public pure returns (uint256) {
+        return FOO;
+    }
+
+    function sum() public pure returns (uint256) {
+        return FOO + FOO;
+    }
+
+    function getDouble() public pure returns (uint8) {
+        return DOUBLE;
+    }
+}

--- a/solx-mlir/tests/lit/constants.sol
+++ b/solx-mlir/tests/lit/constants.sol
@@ -19,8 +19,8 @@
 // `DOUBLE` is a constant whose initializer references another constant,
 // exercising recursive inlining: `DOUBLE` → `FOO * 2` → `42 * 2`.
 // CHECK:      sol.func @{{.*getDouble.*}}() -> ui8
-// CHECK:        sol.constant 42 : ui8
-// CHECK:        sol.constant 2 : ui8
+// CHECK-DAG:    sol.constant 42 : ui8
+// CHECK-DAG:    sol.constant 2 : ui8
 // CHECK:        sol.cmul %{{.*}}, %{{.*}} : ui8
 
 contract C {

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -177,19 +177,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                         let initializer = constant
                             .value()
                             .ok_or_else(|| anyhow::anyhow!("constant {name} has no initializer"))?;
-                        let slang_type = constant.get_type().ok_or_else(|| {
-                            anyhow::anyhow!("unresolved type for constant: {name}")
-                        })?;
-                        let target_type = TypeConversion::resolve_slang_type(
-                            &slang_type,
-                            None,
-                            &self.state.builder,
-                        );
-                        let (value, block) = self.emit_value(&initializer, block)?;
-                        let cast =
-                            TypeConversion::from_target_type(target_type, &self.state.builder)
-                                .emit(value, &self.state.builder, &block);
-                        Ok((Some(cast), block))
+                        self.emit(&initializer, block)
                     }
                     None => anyhow::bail!("unresolved identifier: {name}"),
                     Some(_) => anyhow::bail!("unsupported identifier reference: {name}"),

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -173,6 +173,24 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                                 .emit_sol_load(pointer, element_type, &block)?;
                         Ok((Some(value), block))
                     }
+                    Some(Definition::Constant(constant)) => {
+                        let initializer = constant
+                            .value()
+                            .ok_or_else(|| anyhow::anyhow!("constant {name} has no initializer"))?;
+                        let slang_type = constant.get_type().ok_or_else(|| {
+                            anyhow::anyhow!("unresolved type for constant: {name}")
+                        })?;
+                        let target_type = TypeConversion::resolve_slang_type(
+                            &slang_type,
+                            None,
+                            &self.state.builder,
+                        );
+                        let (value, block) = self.emit_value(&initializer, block)?;
+                        let cast =
+                            TypeConversion::from_target_type(target_type, &self.state.builder)
+                                .emit(value, &self.state.builder, &block);
+                        Ok((Some(cast), block))
+                    }
                     None => anyhow::bail!("unresolved identifier: {name}"),
                     Some(_) => anyhow::bail!("unsupported identifier reference: {name}"),
                 }


### PR DESCRIPTION
Adds a `Definition::Constant` arm in the identifier lowering path so references to `uint256 constant FOO = 42;` and similar contract-level constants inline the initializer expression at the use site and cast it to the constant's declared type. Without the cast, slang types the literal at its natural width (e.g. `42` as `ui8`) and downstream arithmetic silently truncates against `uint256` declarations.

Lit test: `solx-mlir/tests/lit/constants.sol`.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1662 | 1686 | +24 |
| FAILED | 7 | 7 | 0 |
| INVALID | 383 | 376 | −7 |
| Total | 2052 | 2069 | +17 |

Newly fully passing:

- tests/solidity/simple/expression/constant_conditional.sol
- tests/solidity/simple/expression/constant_match.sol
- tests/solidity/simple/expression/mixed_item_constantness.sol
- tests/solidity/simple/loop/range_bitlength_inference/u8_to_u256_const.sol
- tests/solidity/simple/loop/range_bitlength_inference/u8_to_u64_const.sol
- tests/solidity/simple/order/casted_declared_const.sol
- tests/solidity/simple/order/declared_const.sol
