### PR TITLE
ci(cache): drop LLVM_PARALLEL_LINK_JOBS to 1 on macOS x86

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -74,11 +74,6 @@ runs:
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
         [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
-        # TEMP: force a cold artifact-cache miss on macOS x86 to measure the
-        # LINK_JOBS=1 effect against PR #396's cold reference. Revert before merge.
-        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
-          KEY="${KEY}-cold-test"
-        fi
         KEY="${KEY}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
@@ -124,11 +119,6 @@ runs:
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
         [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
-        # TEMP: force a cold ccache miss on macOS x86 to measure the
-        # LINK_JOBS=1 effect against PR #396's cold reference. Revert before merge.
-        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
-          KEY="${KEY}-cold-test"
-        fi
         # Terminator: prevents shorter-variant keys from prefix-matching longer ones
         # via ccache-action's restore-keys (e.g. `...-mlir` matching `...-mlir-coverage-no-assertions`).
         KEY="${KEY}-end"

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -180,13 +180,16 @@ runs:
         fi
 
         # With ccache at 99%+ hit rate, link time dominates. Each LLVM tool link
-        # peaks at 2-4 GB RSS on RelWithDebInfo. The hosted macos-15 ARM runner
-        # has 3 vCPU / 7 GB RAM — two parallel links alone can exceed RAM and
-        # push into swap, which is net slower than serialized links. The intel
-        # macos-15 has 14 GB and handles 2 parallel links fine, as do Linux and
-        # Windows hosted (16 GB).
+        # peaks at 2-4 GB RSS on RelWithDebInfo. Both hosted macos-15 runners
+        # benefit from serialized links, for different reasons:
+        #   ARM64 (3 vCPU / 7 GB): 2 parallel links exceed RAM → swap.
+        #   x86_64 (4 vCPU / 14 GB): RAM is fine but the runner is CPU-weak;
+        #     PR #396 cold build saw +1h 12min vs the pre-utils reference, and
+        #     PR #360's link-jobs=1 win on ARM64 suggests x86 is similarly
+        #     bottlenecked on link wall-clock.
+        # Linux and Windows hosted (16 GB) handle 2 parallel links fine.
         LINK_JOBS=2
-        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
+        if [ "${{ runner.os }}" = "macOS" ]; then
           LINK_JOBS=1
         fi
 

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -74,6 +74,11 @@ runs:
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
         [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
+        # TEMP: force a cold artifact-cache miss on macOS x86 to measure the
+        # LINK_JOBS=1 effect against PR #396's cold reference. Revert before merge.
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
+          KEY="${KEY}-cold-test"
+        fi
         KEY="${KEY}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
@@ -119,6 +124,11 @@ runs:
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
         [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
+        # TEMP: force a cold ccache miss on macOS x86 to measure the
+        # LINK_JOBS=1 effect against PR #396's cold reference. Revert before merge.
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
+          KEY="${KEY}-cold-test"
+        fi
         # Terminator: prevents shorter-variant keys from prefix-matching longer ones
         # via ccache-action's restore-keys (e.g. `...-mlir` matching `...-mlir-coverage-no-assertions`).
         KEY="${KEY}-end"


### PR DESCRIPTION
You don't need to link that muchSmall improvement, I'll have a further look after this PR into the LLVM tooling vs utils, including https://github.com/NomicFoundation/solx/pull/365. 

Follow-up to #396 / #360. Mirrors the macOS ARM64 link-jobs-1 change to macOS x86 to address the +1h 12min cold-build regression observed on PR #396 (3h 52min vs 2h 40min reference).

The macos-15-intel runner has 14 GB RAM (so it's not RAM-bound like the ARM64 runner), but it appears CPU-weak — link wall-clock dominates once ccache hits 99%+. PR #360's link-jobs=1 win on ARM64 suggests the same fix applies here.

Collapses the conditional from `macOS && ARM64` to just `macOS`. Linux and Windows hosted runners (16 GB) keep `LINK_JOBS=2`.

## Measurement results

Cold rebuild on macOS x86, Build LLVM step ([run 25365589502](https://github.com/NomicFoundation/solx/actions/runs/25365589502/job/74375504698)):

| Reference | Build LLVM (cold) |
|---|---|
| #360 baseline (pre-utils, link-jobs=2) | 2h 40min |
| #396 cold (utils, link-jobs=2) | 3h 52min |
| **This PR (utils, link-jobs=1)** | **3h 33min** |

- **−19 min vs #396 cold** (~8%). Real but modest — much smaller than the −1h 14min the same change bought on macOS ARM64. macos-15-intel isn't swap-bound; the win is just sequencing CPU-heavy link phases on a CPU-weak runner.
- **+53 min vs #360 baseline.** Link-jobs=1 doesn't close the gap on its own. The remainder is the `--enable-utils` cost from #396 — recoverable separately by gating `enable-utils=true` to #384's lit-tests workflow rather than test.yaml.
- Other platforms hit the warm cache (1–4 min Build LLVM) as intended; only macOS x86 was forced cold.