### PR TITLE
refactor(slang): don't thread `SemanticAnalysis` through the emitters

### DIFF
--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -63,7 +63,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
 
             let target_type = self
                 .expression_emitter
-                .resolve_expression_type(call.node_id())
+                .resolve_slang_type(call.get_type())
                 .ok_or_else(|| anyhow::anyhow!("unresolved type conversion target"))?;
 
             let result =

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -10,16 +10,15 @@ pub mod operator;
 pub mod storage;
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::ValueLike;
-use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
+use slang_solidity::backend::ir::ast::Type as SlangType;
 use slang_solidity::cst::NodeId;
 
 use solx_mlir::CmpPredicate;
@@ -31,8 +30,6 @@ use self::call::type_conversion::TypeConversion;
 
 /// Lowers Solidity expressions to MLIR SSA values.
 pub struct ExpressionEmitter<'state, 'context, 'block> {
-    /// Slang semantic analysis for resolving expression types.
-    pub semantic: Rc<SemanticAnalysis>,
     /// The shared MLIR context.
     pub state: &'state Context<'context>,
     /// Variable environment.
@@ -49,14 +46,12 @@ pub struct ExpressionEmitter<'state, 'context, 'block> {
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Creates a new expression emitter.
     pub fn new(
-        semantic: &Rc<SemanticAnalysis>,
         state: &'state Context<'context>,
         environment: &'state Environment<'context, 'block>,
         storage_layout: &'state HashMap<NodeId, u64>,
         checked: bool,
     ) -> Self {
         Self {
-            semantic: Rc::clone(semantic),
             state,
             environment,
             storage_layout,
@@ -100,7 +95,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     )
                 })?;
                 let result_type = self
-                    .resolve_expression_type(decimal_number.node_id())
+                    .resolve_slang_type(decimal_number.get_type())
                     .expect("binder types every decimal literal node");
                 let constant = self
                     .state
@@ -113,7 +108,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .integer_value()
                     .expect("hex literals always evaluate to integers");
                 let result_type = self
-                    .resolve_expression_type(hex_number.node_id())
+                    .resolve_slang_type(hex_number.get_type())
                     .expect("binder types every hex literal node");
                 let constant = self
                     .state
@@ -189,7 +184,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 .emit_assignment(assign, block)
                 .map(|(value, block)| (Some(value), block)),
             Expression::AdditiveExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 let operator = expression.operator();
@@ -197,7 +192,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::MultiplicativeExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 let operator = expression.operator();
@@ -205,7 +200,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::ExponentiationExpression(expression) => {
-                let target_type = self.resolve_expression_type(expression.node_id());
+                let target_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 self.emit_binary_op(&left, &right, "**", target_type, block)
@@ -244,35 +239,35 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::PrefixExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
                 let operator = expression.operator();
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let operand = expression.operand();
                 self.emit_prefix(&operator.text, &operand, result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::BitwiseAndExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 self.emit_binary_op(&left, &right, "&", result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::BitwiseOrExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 self.emit_binary_op(&left, &right, "|", result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::BitwiseXorExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 self.emit_binary_op(&left, &right, "^", result_type, block)
                     .map(|(value, block)| (Some(value), block))
             }
             Expression::ShiftExpression(expression) => {
-                let result_type = self.resolve_expression_type(expression.node_id());
+                let result_type = self.resolve_slang_type(expression.get_type());
                 let left = expression.left_operand();
                 let right = expression.right_operand();
                 let operator = expression.operator();
@@ -297,7 +292,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             }
             Expression::ConditionalExpression(conditional) => {
                 let result_type = self
-                    .resolve_expression_type(conditional.node_id())
+                    .resolve_slang_type(conditional.get_type())
                     .unwrap_or(self.state.builder.types.ui256);
                 let condition = conditional.operand();
                 let (condition_value, block) = self.emit_value(&condition, block)?;
@@ -350,20 +345,21 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             .emit_sol_cmp(value, zero, CmpPredicate::Ne, block)
     }
 
-    /// Resolves the Solidity type of an expression node to an MLIR type.
+    /// Resolves the Solidity type from Slang to an MLIR type.
     ///
-    /// Returns `None` when the semantic analysis has no type info for the node.
-    /// Panics on types that `resolve_slang_type` does not yet handle.
+    /// Returns `None` when the incoming slang type is `None`. This can happen when calling
+    /// `node.get_type()` if the node doesn't have typing information, for example when
+    /// there are unresolved references or semantic errors.
+    /// Panics on types that `TypeConversion::resolve_slang_type` does not yet handle.
     // TODO: slang's binder does not fold binary expressions of literal operands —
     // its typing rules return the type of one operand (e.g. type of the left
     // operand for shifts), so `1 << 100` gets typed as ui8 (the type of `1`)
     // and constant subexpressions overflow at that width. solc folds via
     // `RationalNumberType::binaryOperatorResult`, sizing the result to fit the
     // folded value. Either teach slang to fold, or fold here before lowering.
-    pub fn resolve_expression_type(&self, node_id: NodeId) -> Option<Type<'context>> {
-        let slang_type = self.semantic.get_type_from_node_id(node_id)?;
+    pub fn resolve_slang_type(&self, slang_type: Option<SlangType>) -> Option<Type<'context>> {
         Some(TypeConversion::resolve_slang_type(
-            &slang_type,
+            &slang_type?,
             &self.state.builder,
         ))
     }

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -6,11 +6,9 @@ pub mod expression;
 pub mod statement;
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use melior::ir::BlockLike;
 use melior::ir::Type;
-use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::abi::AbiEntry;
 use slang_solidity::backend::ir::ast::ElementaryType;
 use slang_solidity::backend::ir::ast::Expression;
@@ -28,8 +26,6 @@ use self::statement::StatementEmitter;
 
 /// Lowers a Solidity function definition to a `sol.func` operation.
 pub struct FunctionEmitter<'state, 'context> {
-    /// Slang semantic analysis for resolving expression types.
-    semantic: Rc<SemanticAnalysis>,
     /// The shared MLIR context.
     state: &'state Context<'context>,
     /// State variable node ID to storage slot mapping.
@@ -39,12 +35,10 @@ pub struct FunctionEmitter<'state, 'context> {
 impl<'state, 'context> FunctionEmitter<'state, 'context> {
     /// Creates a new function emitter.
     pub fn new(
-        semantic: &Rc<SemanticAnalysis>,
         state: &'state Context<'context>,
         storage_layout: &'state HashMap<NodeId, u64>,
     ) -> Self {
         Self {
-            semantic: Rc::clone(semantic),
             state,
             storage_layout,
         }
@@ -130,7 +124,6 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
         let mut terminated = false;
         for statement in body.statements().iter() {
             let mut emitter = StatementEmitter::new(
-                &self.semantic,
                 self.state,
                 &mut environment,
                 &region,

--- a/solx-slang/src/ast/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/ast/contract/function/statement/control_flow.rs
@@ -24,7 +24,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
     ) -> anyhow::Result<Option<BlockRef<'context, 'block>>> {
         let condition_expression = if_statement.condition();
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,
@@ -119,7 +118,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             ForStatementCondition::ExpressionStatement(expression_statement) => {
                 let expression = expression_statement.expression();
                 let emitter = ExpressionEmitter::new(
-                    &self.semantic,
                     self.state,
                     self.environment,
                     self.storage_layout,
@@ -150,7 +148,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         // Step region — always unchecked (matches solc: loop step i++ uses sol.add).
         if let Some(ref iterator_expression) = for_statement.iterator() {
             let emitter = ExpressionEmitter::new(
-                &self.semantic,
                 self.state,
                 self.environment,
                 self.storage_layout,
@@ -184,7 +181,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         // Condition region.
         let condition_expression = while_statement.condition();
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,
@@ -232,7 +228,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         // Condition region.
         let condition_expression = do_while.condition();
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,

--- a/solx-slang/src/ast/contract/function/statement/event.rs
+++ b/solx-slang/src/ast/contract/function/statement/event.rs
@@ -62,7 +62,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         );
 
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -7,12 +7,10 @@ pub mod event;
 pub mod revert;
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use melior::ir::BlockRef;
 use melior::ir::Region;
 use melior::ir::Type;
-use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::Statement;
 use slang_solidity::backend::ir::ast::Statements;
@@ -29,8 +27,6 @@ use crate::ast::contract::function::expression::call::type_conversion::TypeConve
 /// Returns `Some(block)` as the continuation block, or `None` when control
 /// flow has been terminated (by `return`, `break`, or `continue`).
 pub struct StatementEmitter<'state, 'context, 'block> {
-    /// Slang semantic analysis for resolving expression types.
-    semantic: Rc<SemanticAnalysis>,
     /// The shared MLIR context.
     state: &'state Context<'context>,
     /// Variable environment (mutable for new declarations and loop targets).
@@ -52,7 +48,6 @@ pub struct StatementEmitter<'state, 'context, 'block> {
 impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
     /// Creates a new statement emitter.
     pub fn new(
-        semantic: &Rc<SemanticAnalysis>,
         state: &'state Context<'context>,
         environment: &'state mut Environment<'context, 'block>,
         region: &Region<'context>,
@@ -60,7 +55,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         return_types: &'state [Type<'context>],
     ) -> Self {
         Self {
-            semantic: Rc::clone(semantic),
             state,
             environment,
             region_pointer: region as *const Region<'context>,
@@ -112,7 +106,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                     return self.emit_revert_call(call, block);
                 }
                 let emitter = ExpressionEmitter::new(
-                    &self.semantic,
                     self.state,
                     self.environment,
                     self.storage_layout,
@@ -185,7 +178,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             .unwrap_or_else(|| self.state.builder.types.ui256);
 
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,
@@ -255,7 +247,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 "multi-return functions are not yet supported"
             );
             let emitter = ExpressionEmitter::new(
-                &self.semantic,
                 self.state,
                 self.environment,
                 self.storage_layout,

--- a/solx-slang/src/ast/contract/function/statement/revert.rs
+++ b/solx-slang/src/ast/contract/function/statement/revert.rs
@@ -195,7 +195,6 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         Arguments: IntoIterator<Item = Expression>,
     {
         let emitter = ExpressionEmitter::new(
-            &self.semantic,
             self.state,
             self.environment,
             self.storage_layout,

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -6,9 +6,7 @@
 pub mod function;
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
-use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::ContractDefinition;
 use slang_solidity::backend::ir::ast::FunctionKind;
 use slang_solidity::backend::ir::ast::FunctionMutability;
@@ -25,19 +23,14 @@ use self::function::expression::call::type_conversion::TypeConversion;
 /// `convert-sol-to-std` pass generates the entry-point dispatcher
 /// from the function selectors.
 pub struct ContractEmitter<'state, 'context> {
-    /// Slang semantic analysis for resolving expression types.
-    semantic: Rc<SemanticAnalysis>,
     /// The shared MLIR context.
     state: &'state mut Context<'context>,
 }
 
 impl<'state, 'context> ContractEmitter<'state, 'context> {
     /// Creates a new contract emitter.
-    pub fn new(semantic: &Rc<SemanticAnalysis>, state: &'state mut Context<'context>) -> Self {
-        Self {
-            semantic: Rc::clone(semantic),
-            state,
-        }
+    pub fn new(state: &'state mut Context<'context>) -> Self {
+        Self { state }
     }
 
     /// Emits a `sol.contract` containing all function definitions.
@@ -86,7 +79,7 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
                 _ => {}
             }
             self.state.current_contract_type = Some(contract_type);
-            let emitter = FunctionEmitter::new(&self.semantic, self.state, &storage_layout);
+            let emitter = FunctionEmitter::new(self.state, &storage_layout);
             emitter.emit_sol(&function, &contract_body)?;
             self.state.current_contract_type = None;
         }

--- a/solx-slang/src/ast/mod.rs
+++ b/solx-slang/src/ast/mod.rs
@@ -6,9 +6,7 @@
 pub mod contract;
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
 
-use slang_solidity::backend::SemanticAnalysis;
 use slang_solidity::backend::ir::ast::ContractMember;
 use slang_solidity::backend::ir::ast::SourceUnit;
 
@@ -18,19 +16,14 @@ use self::contract::ContractEmitter;
 
 /// Walks a Slang AST and lowers its contract definitions to MLIR.
 pub struct AstEmitter<'state, 'context> {
-    /// Slang semantic analysis for resolving expression types.
-    semantic: Rc<SemanticAnalysis>,
     /// The shared MLIR context.
     state: &'state mut Context<'context>,
 }
 
 impl<'state, 'context> AstEmitter<'state, 'context> {
     /// Creates a new AST emitter.
-    pub fn new(semantic: &Rc<SemanticAnalysis>, state: &'state mut Context<'context>) -> Self {
-        Self {
-            semantic: Rc::clone(semantic),
-            state,
-        }
+    pub fn new(state: &'state mut Context<'context>) -> Self {
+        Self { state }
     }
 
     /// Emits MLIR for the first contract definition in the source unit.
@@ -59,7 +52,7 @@ impl<'state, 'context> AstEmitter<'state, 'context> {
 
         let name = contract.name().name();
         let file_identifier = unit.file_id();
-        let mut emitter = ContractEmitter::new(&self.semantic, self.state);
+        let mut emitter = ContractEmitter::new(self.state);
         emitter.emit(contract, &file_identifier)?;
 
         let mut method_identifiers = BTreeMap::new();

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -165,7 +165,7 @@ impl Frontend for Slang {
 
             let evm_version = input_json.settings.evm_version.unwrap_or_default();
             let mut context = solx_mlir::Context::new(&melior_context, evm_version);
-            let mut emitter = AstEmitter::new(&semantic, &mut context);
+            let mut emitter = AstEmitter::new(&mut context);
             let Some((contract_name, method_identifiers)) = emitter.emit(&source_unit)? else {
                 continue;
             };


### PR DESCRIPTION
The `SemanticAnalysis` was being used to obtain the type of `Expression` variants, but most nodes have a `get_type()` member for that purpose. This simplifies the emitters and makes the implementation more compatible with the upcoming slang v2 where the `SemanticAnalysis`/`SemanticContext` will not be accessible through the public API.
