### PR TITLE
ci(llvm): disable LLVM tools on all platforms via install-distribution

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -62,19 +62,28 @@ runs:
       working-directory: ${{ inputs.working-dir }}
       run: |
         SHA=$(git -C solx-llvm rev-parse HEAD)
+        # solx-dev owns LLVM-build cmake args (shared.rs + platforms/*.rs).
+        # Hash that tree into the key so any Rust-side flag change invalidates
+        # stale artifact-cache entries automatically. Truncate for readability.
+        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir)) }}' | head -c 8)
         KEY="v1-llvm-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
-        # `enable-tests` implies `enable-utils` (LLVM CMake requires it),
-        # so normalize before keying to avoid splitting identical artifacts.
+        # `enable-utils` extends the install-distribution whitelist with
+        # FileCheck (see solx-dev's `build_opts_distribution`), so the install
+        # prefix actually differs by this flag. `enable-tests` is kept
+        # defensively even though no current workflow sets it; if one later
+        # does, LLVM_BUILD_TESTS=On could leak test artifacts into the prefix
+        # or change cmake-exports content.
+        # Normalize tests→utils because `--enable-tests` implies `--enable-utils`.
         UTILS='${{ inputs.enable-utils }}'
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
         [ '${{ inputs.enable-tests }}' = 'true' ] && KEY="${KEY}-tests"
-        KEY="${KEY}-${SHA}"
+        KEY="${KEY}-dev${DEV_HASH}-${SHA}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Restore LLVM artifact cache

--- a/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
@@ -70,6 +70,10 @@ pub fn build(
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_split_dwarf(build_type))
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::build_opts_distribution(
+                enable_mlir,
+                enable_utils,
+            ))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -80,6 +84,10 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
+    crate::llvm::platforms::shared::build_and_install_llvm_config(
+        llvm_build_final.as_ref(),
+        llvm_target_final.as_ref(),
+    )?;
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/aarch64_macos.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_macos.rs
@@ -62,6 +62,10 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::build_opts_distribution(
+                enable_mlir,
+                enable_utils,
+            ))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -70,7 +74,11 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
+    crate::llvm::platforms::shared::build_and_install_llvm_config(
+        llvm_build_final.as_ref(),
+        llvm_target_final.as_ref(),
+    )?;
 
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -2,6 +2,9 @@
 //! The shared options for building various platforms.
 //!
 
+use std::path::Path;
+use std::process::Command;
+
 use crate::build_type::BuildType;
 use crate::llvm::platforms::Platform;
 use crate::llvm::sanitizer::Sanitizer;
@@ -184,6 +187,107 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
         "-DLLVM_BUILD_INSTRUMENTED_COVERAGE='{}'",
         if enabled { "On" } else { "Off" },
     )]
+}
+
+///
+/// Configure an `install-distribution` that ships only what solx needs,
+/// skipping the ~200 LLVM tool binaries (`opt`, `llc`, ...).
+///
+/// solx never invokes any LLVM tool at runtime — it consumes LLVM as a
+/// library via inkwell — so linking those tools is pure wall-clock waste in
+/// CI. `LLVM_BUILD_TOOLS=Off` marks every tool `EXCLUDE_FROM_ALL`;
+/// `LLVM_INCLUDE_TOOLS=On` keeps `tools/` in the configure pass so the
+/// umbrella targets (`llvm-libraries`, `lld-libraries`, etc.) stay defined.
+/// `LLVM_DISTRIBUTION_COMPONENTS` whitelists what `install-distribution`
+/// actually copies into the install prefix — see #364.
+///
+/// `llvm-config` is deliberately **not** in the distribution list: with
+/// `LLVM_BUILD_TOOLS=Off`, cmake's `llvm_add_tool` skips creation of the
+/// `install-llvm-config` target, so referencing it here errors at configure
+/// time. `llvm-sys` still needs `llvm-config` at Rust build time —
+/// `build_and_install_llvm_config` builds it directly via `ninja
+/// llvm-config` and copies the binary into the install prefix afterwards.
+/// `lld-*` is always included because `shared_build_opts_projects` always
+/// enables `lld`. `mlir-*` is included only when `enable_mlir` is true.
+///
+/// When `enable_utils` is true, `FileCheck` is added to the whitelist —
+/// `solx-mlir/tests/lit/*.sol` uses it in RUN lines, so it must land in the
+/// install prefix's `bin/`. LLVM's `add_llvm_utility` registers each utility
+/// under its own install component (named after the target). The component
+/// only exists when `LLVM_BUILD_UTILS=On` (set by `shared_build_opts_utils`
+/// when `--enable-utils` is passed); listing it without that flag errors at
+/// configure time.
+///
+/// `llvm-lit` is **not** listed here despite being needed by the slang-tests
+/// workflow runner: upstream LLVM has no install rule for `llvm-lit` (it's
+/// only `configure_file`'d into the build dir), so referencing it as a
+/// distribution component errors at configure time. How `target-final/bin/
+/// llvm-lit` reaches the install prefix today is independent of this PR.
+///
+pub fn build_opts_distribution(enable_mlir: bool, enable_utils: bool) -> Vec<String> {
+    let mut components = vec![
+        "llvm-libraries",
+        "llvm-headers",
+        "cmake-exports",
+        "lld-libraries",
+        "lld-headers",
+        "lld-cmake-exports",
+    ];
+    if enable_mlir {
+        components.extend(["mlir-libraries", "mlir-headers", "mlir-cmake-exports"]);
+    }
+    if enable_utils {
+        components.push("FileCheck");
+    }
+    vec![
+        "-DLLVM_BUILD_TOOLS='Off'".to_owned(),
+        "-DLLVM_INCLUDE_TOOLS='On'".to_owned(),
+        format!("-DLLVM_DISTRIBUTION_COMPONENTS='{}'", components.join(";")),
+    ]
+}
+
+///
+/// Build `llvm-config` directly (it has no install target under
+/// `LLVM_BUILD_TOOLS=Off`) and copy it into the install prefix's `bin/`.
+///
+/// `llvm-sys` invokes `llvm-config` at Rust build time to discover libs and
+/// flags. Both ninja args and the destination path use forward-slash form on
+/// Windows; callers are expected to pass already-normalized paths (existing
+/// Windows code uses `path_windows_to_unix` for this).
+///
+/// `overwrite: true` lets a second `solx-dev llvm build` against the same
+/// target prefix succeed; `fs_extra::file::copy`'s default would error on
+/// `AlreadyExists` for the second run.
+///
+pub fn build_and_install_llvm_config(build_dir: &Path, target_dir: &Path) -> anyhow::Result<()> {
+    let exe_suffix = if cfg!(target_os = "windows") {
+        ".exe"
+    } else {
+        ""
+    };
+    let bin_name = format!("llvm-config{exe_suffix}");
+    let build_dir_str = build_dir.to_string_lossy();
+
+    crate::utils::command(
+        Command::new("ninja")
+            .arg("-C")
+            .arg(&*build_dir_str)
+            .arg("llvm-config"),
+        "Building llvm-config",
+    )?;
+
+    let source = build_dir.join("bin").join(&bin_name);
+    let dest_dir = target_dir.join("bin");
+    std::fs::create_dir_all(&dest_dir)?;
+    fs_extra::file::copy(
+        &source,
+        dest_dir.join(&bin_name),
+        &fs_extra::file::CopyOptions {
+            overwrite: true,
+            ..Default::default()
+        },
+    )?;
+    Ok(())
 }
 
 ///

--- a/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
@@ -71,6 +71,10 @@ pub fn build(
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_split_dwarf(build_type))
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::build_opts_distribution(
+                enable_mlir,
+                enable_utils,
+            ))
             .args(extra_args)
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
             .args(crate::llvm::platforms::shared::shared_build_opts_sanitizers(sanitizer))
@@ -80,6 +84,10 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
+    crate::llvm::platforms::shared::build_and_install_llvm_config(
+        llvm_build_final.as_ref(),
+        llvm_target_final.as_ref(),
+    )?;
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/x86_64_macos.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_macos.rs
@@ -62,6 +62,10 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::build_opts_distribution(
+                enable_mlir,
+                enable_utils,
+            ))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -70,7 +74,11 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
+    crate::llvm::platforms::shared::build_and_install_llvm_config(
+        llvm_build_final.as_ref(),
+        llvm_target_final.as_ref(),
+    )?;
 
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -69,6 +69,10 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
+            .args(crate::llvm::platforms::shared::build_opts_distribution(
+                enable_mlir,
+                enable_utils,
+            ))
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -76,7 +80,11 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref())?;
+    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
+    crate::llvm::platforms::shared::build_and_install_llvm_config(
+        llvm_build_final.as_ref(),
+        llvm_target_final.as_ref(),
+    )?;
 
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
         Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
@@ -89,7 +97,10 @@ pub fn build(
     fs_extra::file::copy(
         crate::utils::path_windows_to_unix(libstdcpp_source_path)?,
         crate::utils::path_windows_to_unix(libstdcpp_destination_path)?,
-        &fs_extra::file::CopyOptions::default(),
+        &fs_extra::file::CopyOptions {
+            overwrite: true,
+            ..Default::default()
+        },
     )?;
 
     Ok(())

--- a/solx-dev/src/utils.rs
+++ b/solx-dev/src/utils.rs
@@ -219,16 +219,27 @@ pub fn remove(project_directory: &Path, project_name: &str) -> anyhow::Result<()
 }
 
 ///
-/// Call ninja to build and install the LLVM. When `llvm-lit` exists in the
-/// build tree (produced by either `--enable-utils` or `--enable-tests`), also
-/// copy it into the install prefix so it is part of the cached artifact like
-/// the rest of the toolchain.
+/// Call ninja to build and install LLVM via the given install target.
 ///
-pub fn ninja(build_dir: &Path) -> anyhow::Result<()> {
+/// All platforms pass `"install-distribution"` together with
+/// `LLVM_DISTRIBUTION_COMPONENTS` to skip the ~200 LLVM tool binaries solx
+/// doesn't use (it consumes LLVM as a library via inkwell). See #364.
+///
+/// When `llvm-lit` exists in the build tree (produced by `--enable-utils`),
+/// it is copied into the install prefix's `bin/` afterwards. Upstream LLVM
+/// has no install rule for `llvm-lit` (it's only `configure_file`'d into the
+/// build dir), so listing it in `LLVM_DISTRIBUTION_COMPONENTS` errors at
+/// configure time; the manual copy bridges that gap so the cached artifact
+/// contains `llvm-lit` like the rest of the toolchain.
+///
+pub fn ninja(build_dir: &Path, install_target: &str) -> anyhow::Result<()> {
     let mut ninja = Command::new("ninja");
     let build_dir_str = build_dir.to_string_lossy();
     ninja.args(["-C", &*build_dir_str]);
-    command(ninja.arg("install"), "Running ninja install")?;
+    command(
+        ninja.arg(install_target),
+        &format!("Running ninja {install_target}"),
+    )?;
     let lit_name = if cfg!(windows) {
         "llvm-lit.py"
     } else {
@@ -237,6 +248,7 @@ pub fn ninja(build_dir: &Path) -> anyhow::Result<()> {
     let lit_source = build_dir.join("bin").join(lit_name);
     if lit_source.exists() {
         let install_bin = LlvmPath::llvm_target_final()?.join("bin");
+        std::fs::create_dir_all(&install_bin)?;
         std::fs::copy(&lit_source, install_bin.join(lit_name))?;
     }
     Ok(())


### PR DESCRIPTION
Closes #364. Extends the Windows-only design from #365 to Linux and macOS, since macOS x86 (the macos-15-intel runner) is now also link-bound — see #402's drop to LLVM_PARALLEL_LINK_JOBS=1.

## What

solx never invokes any LLVM tool at runtime; it consumes LLVM as a library through inkwell. So building and linking the ~200 tool binaries (`opt`, `llc`, `lli`, ...) on every cold cache miss is pure wall-clock waste. This applies the install-distribution mechanism across all five platforms, with no Windows-only naming.

`solx-dev/src/llvm/platforms/shared.rs::build_opts_distribution` emits:

- `LLVM_BUILD_TOOLS=Off` — every tool target marked `EXCLUDE_FROM_ALL`.
- `LLVM_INCLUDE_TOOLS=On` — `tools/` stays in the configure pass so the umbrella targets (`llvm-libraries`, `lld-libraries`, optionally `mlir-libraries`) are defined.
- `LLVM_DISTRIBUTION_COMPONENTS` — whitelist of what `install-distribution` actually copies into the prefix: llvm/lld/(optionally mlir) library + header + cmake-export components, plus `FileCheck` when `--enable-utils` is true (used by `solx-mlir/tests/lit/*.sol` RUN lines).

`build_and_install_llvm_config` runs after `install-distribution` on every platform: with tools disabled, cmake doesn't create the `install-llvm-config` target, so `llvm-sys` would have no `llvm-config` to query at Rust build time. The helper invokes `ninja llvm-config` directly and copies the binary into the install prefix's `bin/`. `cfg!(target_os = "windows")` handles the `.exe` suffix; `overwrite: true` makes local reruns succeed (default would error on `AlreadyExists`).

## Wall-clock impact

Build LLVM step, single-sample per cell.

### Warm ccache + cold artifact cache

Both runs went through Build LLVM rather than restoring from artifact cache.

| Platform | Baseline | This PR | Δ |
|---|---:|---:|---:|
| Linux x86 gnu | 6:36 | 3:39 | −45% |
| Linux ARM64 gnu | 6:09 | 2:59 | −52% |
| MacOS x86 | 29:34 | 18:37 | −37% |
| MacOS arm64 | 1:49:28 | 5:31 | −95% |
| Windows | 51:47 | 15:00 | −71% |

Baseline: [run 25415956903](https://github.com/NomicFoundation/solx/actions/runs/25415956903) on `ci-slang-mlir-lit-tests` (no tool-disable). This PR: [run 25407488943](https://github.com/NomicFoundation/solx/actions/runs/25407488943).

The MacOS arm64 95% is genuine and worth flagging: that runner was thrashing under `LLVM_PARALLEL_LINK_JOBS=2` on a 7GB host (this baseline pre-dates the macOS arm64 `LINK_JOBS=1` reduction). Tool-disable cuts total link-phase memory pressure to the point where the host stops swapping. (For macOS x86, this looked like an opportunity to lift `LINK_JOBS=1` back to 2 — but the probe below shows it still thrashes; we keep =1.)

### Cold ccache + cold artifact cache

This PR's cold numbers come from a TEMP cache-key-bust commit forcing both the artifact cache and ccache to miss on every platform. Two samples per platform: the `Slang Tests` and `Tests` workflows running on the same TEMP-bumped SHA.

| Platform | Baseline (cold) | This PR cold, Slang Tests | This PR cold, Tests |
|---|---:|---:|---:|
| Linux x86 gnu | 2h 15min¹ | 2:15:00 | 2:14:40 |
| Linux ARM64 gnu | 1h 29min¹ | 1:16:25 | 1:14:47 |
| MacOS x86 | 3h 33min² | 3:32:09 | 3:04:10 |
| MacOS arm64 | 3h 00min¹ | 1:52:14 | 1:40:11 |
| Windows | 3h 24min¹ | 2:19:16 | 2:40:46 |

Cold runs: Slang Tests [run 25423417125](https://github.com/NomicFoundation/solx/actions/runs/25423417125), Tests [run 25423417118](https://github.com/NomicFoundation/solx/actions/runs/25423417118).

The compile-bound vs link-bound split is the main story:

- **Link-bound platforms** (Windows, MacOS arm64) get the bulk of the savings — these are the ones where tool linking actually dominated cold wall-clock.
- **Compile-bound platforms** (Linux x86, MacOS x86) are essentially flat. Library compilation dominates cold time, and tool-disable doesn't change library compilation. MacOS x86 is also serialised at `LLVM_PARALLEL_LINK_JOBS=1` (see next subsection), so any link-phase savings are serialised anyway.
- **Linux ARM64** is in between — small but real win.

#### macOS x86 LINK_JOBS=2 probe — proves we still need LINK_JOBS=1

A second TEMP commit layered on top of the cache-bust flipped macOS x86 back to `LLVM_PARALLEL_LINK_JOBS=2`, testing the hypothesis that tool-disable's removal of ~200 tool binaries lifts the CPU-bound serialization rationale that motivated #402's drop to 1.

Result: cold time on macOS x86 swings far enough across runs to indicate the runner is thrashing under 2 parallel links, not just running noisier.

| Config (macOS x86 only) | Slang Tests | Tests | Spread |
|---|---:|---:|---:|
| LINK_JOBS=1 | 3:32:09 | 3:04:10 | 28 min |
| LINK_JOBS=2 | 2:46:38 | 4:31:08 | **1h 45min** |

LINK_JOBS=2 produces a 1h 45min spread — over 4× wider than LINK_JOBS=1's 28 min — on the same TEMP-bumped SHA. The fast LJ=2 sample is below LJ=1's range; the slow one is well above it. That bimodality is what thrashing on a CPU-/RAM-marginal runner looks like: 2 parallel `lld` invocations sometimes fit the runner's budget and sometimes overshoot it, producing unpredictable wall-clock.

LINK_JOBS=1 doesn't have that exposure — both samples land within 28 min of each other. **macOS x86 therefore stays at `LLVM_PARALLEL_LINK_JOBS=1` in this PR.** The "tool-disable might let us bump LINK_JOBS back up" hypothesis from the warm-cache narrative above turns out to be wrong for macOS x86; arm64 is untested but should be assumed similar until proven otherwise.

LJ=2 probe runs: Slang Tests [run 25436671658](https://github.com/NomicFoundation/solx/actions/runs/25436671658), Tests [run 25436671659](https://github.com/NomicFoundation/solx/actions/runs/25436671659).

¹ [#396 cold reference](https://github.com/NomicFoundation/solx/actions/runs/25321256321) (post-utils, pre-link-jobs=1 on macOS x86).
² [#402 cold](https://github.com/NomicFoundation/solx/actions/runs/25365589502) — latest macOS x86 baseline, with `LLVM_PARALLEL_LINK_JOBS=1`.

## Cache-key changes (.github/actions/build-llvm/action.yml)

- Added `dev<hash>` dimension (over `solx-dev/src/llvm/**`) to the artifact cache key. Any Rust-side cmake-arg change now invalidates stale artifact-cache entries automatically — previously, modifying `shared.rs` could serve a stale-config-built artifact.
- Kept `-utils` and `-tests` dimensions in **both** the artifact and ccache keys, matching the precedent set by #396. With `--enable-utils=true`, `FileCheck` lands in the install prefix; the cached artifact is materially different.

## First-merge behaviour

The `dev<hash>` dimension is new, so every platform's artifact cache will miss once after this lands on `main`. ccache pools are unchanged (no key dimensions added/removed there). Expect Windows cold rebuild ~3h, others bounded by ccache reuse.

## Out of scope

- `LLVM_BUILD_LLVM_DYLIB` exploration (separate research task).

