### PR TITLE
feat(slang): lower explicit constructor body and wire the deploy module

### DIFF
--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -49,9 +49,10 @@ runs:
 
     - name: Build solx-dev
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
-      # Run from the checkout root that owns solx-solidity
       working-directory: ${{ inputs.working-dir }}/..
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      env:
+        CARGO_TARGET_DIR: target
       run: ${SFW_PREFIX:-} cargo fetch --locked && ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
 
     # ccache is layered behind the SHA-keyed artifact cache: it only runs on

--- a/solx-codegen-evm/src/const.rs
+++ b/solx-codegen-evm/src/const.rs
@@ -8,8 +8,9 @@ pub const LLVM_VERSION: semver::Version = semver::Version::new(19, 1, 0);
 /// The entry function name.
 pub const ENTRY_FUNCTION_NAME: &str = "__entry";
 
-/// The deployed Yul object identifier suffix.
-pub static YUL_OBJECT_DEPLOYED_SUFFIX: &str = "_deployed";
+/// The deployed object identifier suffix used by both the Yul AST and the
+/// Sol-to-LLVM pass output.
+pub static DEPLOYED_OBJECT_SUFFIX: &str = "_deployed";
 
 /// Library deploy address Yul identifier.
 pub static LIBRARY_DEPLOY_ADDRESS_TAG: &str = "library_deploy_address";

--- a/solx-core/src/build/contract/mod.rs
+++ b/solx-core/src/build/contract/mod.rs
@@ -42,10 +42,9 @@ pub struct Contract {
     pub legacy_assembly: Option<solx_evm_assembly::Assembly>,
     /// solc Yul IR.
     pub yul: Option<String>,
-    /// MLIR stages captured during the Sol → LLVM pipeline, in pipeline
-    /// order (`Sol` first, `Llvm` last).
+    /// MLIR pipeline output.
     #[cfg(feature = "mlir")]
-    pub mlir: Option<Vec<(solx_mlir::Dialect, String)>>,
+    pub mlir: Option<solx_mlir::MlirOutput>,
 }
 
 impl Contract {
@@ -65,7 +64,7 @@ impl Contract {
         transient_storage_layout: Option<serde_json::Value>,
         legacy_assembly: Option<solx_evm_assembly::Assembly>,
         yul: Option<String>,
-        #[cfg(feature = "mlir")] mlir: Option<Vec<(solx_mlir::Dialect, String)>>,
+        #[cfg(feature = "mlir")] mlir: Option<solx_mlir::MlirOutput>,
     ) -> Self {
         Self {
             name,
@@ -228,10 +227,24 @@ impl Contract {
             self.name.path.as_str(),
             self.name.name.as_deref(),
             solx_standard_json::InputSelector::MLIR,
-        ) && let Some(stages) = self.mlir.take()
+        ) && let Some(output) = self.mlir.take()
         {
-            for (dialect, mlir_text) in stages.iter() {
-                writeln!(std::io::stdout(), "MLIR Dialect {dialect}:\n{mlir_text}")?;
+            if let Some(sol_source) = output.sol_source.as_deref() {
+                writeln!(std::io::stdout(), "MLIR Dialect sol:\n{sol_source}")?;
+            }
+            if !output.deploy_source.is_empty() {
+                writeln!(
+                    std::io::stdout(),
+                    "MLIR Dialect llvm (deploy):\n{}",
+                    output.deploy_source
+                )?;
+            }
+            if !output.runtime_source.is_empty() {
+                writeln!(
+                    std::io::stdout(),
+                    "MLIR Dialect llvm (runtime):\n{}",
+                    output.runtime_source
+                )?;
             }
         }
 
@@ -791,17 +804,32 @@ impl Contract {
             self.name.path.as_str(),
             self.name.name.as_deref(),
             solx_standard_json::InputSelector::MLIR,
-        ) && let Some(stages) = self.mlir.take()
+        ) && let Some(output) = self.mlir.take()
         {
-            for (dialect, mlir_text) in stages.into_iter() {
+            let base_name = self.name.name.as_deref().unwrap_or(contract_name);
+            let write = |suffix: &str, text: &str| -> anyhow::Result<()> {
                 let output_name = format!(
-                    "{contract_path}_{}.{dialect}.{}",
-                    self.name.name.as_deref().unwrap_or(contract_name),
+                    "{contract_path}_{base_name}.{suffix}.{}",
                     solx_utils::EXTENSION_MLIR,
                 );
                 let mut output_path = output_directory.to_owned();
                 output_path.push(output_name.as_str());
-                Self::write_to_file(output_path.as_path(), mlir_text, overwrite)?;
+                Self::write_to_file(output_path.as_path(), text, overwrite)
+            };
+            if let Some(sol_source) = output.sol_source.as_deref() {
+                write("sol", sol_source)?;
+            }
+            if !output.deploy_source.is_empty() {
+                write(
+                    &format!("llvm.{}", solx_utils::CodeSegment::Deploy),
+                    &output.deploy_source,
+                )?;
+            }
+            if !output.runtime_source.is_empty() {
+                write(
+                    &format!("llvm.{}", solx_utils::CodeSegment::Runtime),
+                    &output.runtime_source,
+                )?;
             }
         }
         if let (Some(deploy_object_result), Some(runtime_object_result)) =

--- a/solx-core/src/build/mod.rs
+++ b/solx-core/src/build/mod.rs
@@ -162,8 +162,16 @@ impl Build {
     #[cfg(feature = "mlir")]
     pub fn retain_mlir_dialect(&mut self, dialect: solx_mlir::Dialect) {
         for contract in self.contracts.values_mut() {
-            if let Some(stages) = contract.mlir.as_mut() {
-                stages.retain(|(captured, _)| *captured == dialect);
+            if let Some(output) = contract.mlir.as_mut() {
+                match dialect {
+                    solx_mlir::Dialect::Sol => {
+                        output.deploy_source.clear();
+                        output.runtime_source.clear();
+                    }
+                    solx_mlir::Dialect::Llvm => {
+                        output.sol_source = None;
+                    }
+                }
             }
         }
     }

--- a/solx-core/src/project/contract/ir/mlir.rs
+++ b/solx-core/src/project/contract/ir/mlir.rs
@@ -7,6 +7,9 @@
 ///
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct MLIR {
-    /// MLIR source code.
+    /// LLVM dialect text of this code segment.
     pub source: String,
+    /// Runtime code object that is only set in deploy code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_code: Option<Box<Self>>,
 }

--- a/solx-core/src/project/contract/mod.rs
+++ b/solx-core/src/project/contract/mod.rs
@@ -44,10 +44,9 @@ pub struct Contract {
     pub legacy_assembly: Option<solx_evm_assembly::Assembly>,
     /// solc Yul IR.
     pub yul: Option<String>,
-    /// MLIR stages captured during the Sol → LLVM pipeline, in pipeline
-    /// order (`Sol` first, `Llvm` last).
+    /// MLIR pipeline output.
     #[cfg(feature = "mlir")]
-    pub mlir: Option<Vec<(solx_mlir::Dialect, String)>>,
+    pub mlir: Option<solx_mlir::MlirOutput>,
 }
 
 impl Contract {
@@ -66,7 +65,7 @@ impl Contract {
         transient_storage_layout: Option<serde_json::Value>,
         legacy_assembly: Option<solx_evm_assembly::Assembly>,
         yul: Option<String>,
-        #[cfg(feature = "mlir")] mlir: Option<Vec<(solx_mlir::Dialect, String)>>,
+        #[cfg(feature = "mlir")] mlir: Option<solx_mlir::MlirOutput>,
     ) -> Self {
         Self {
             name,
@@ -105,7 +104,13 @@ impl Contract {
             }
             Some(IR::LLVMIR(llvm_ir)) => llvm_ir.source.len(),
             #[cfg(feature = "mlir")]
-            Some(IR::MLIR(mlir)) => mlir.source.len(),
+            Some(IR::MLIR(mlir)) => {
+                mlir.source.len()
+                    + mlir
+                        .runtime_code
+                        .as_ref()
+                        .map_or(0, |runtime| runtime.source.len())
+            }
             None => 0,
         }
     }
@@ -506,10 +511,33 @@ impl Contract {
             }
             #[cfg(feature = "mlir")]
             (IR::MLIR(mlir), code_segment) => {
+                // TODO: bare contract names match what the Sol-to-LLVM pass
+                // embeds in `evm.datasize` / `evm.dataoffset` metadata, but
+                // collide if two contracts share a name across files. Fuse
+                // with the `<full_path>` convention used by EVMLA/LLVMIR via
+                // post-pass metadata substitution or by honoring the existing
+                // `ContextYulData::resolve_path` mapping in `data_size` /
+                // `data_offset` emission so the link symbols hash to the
+                // disambiguated full paths.
+                let bare_name = contract_name
+                    .name
+                    .as_deref()
+                    .expect("MLIR pipeline contracts always have a name");
+                let runtime_identifier =
+                    format!("{bare_name}{}", solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX);
                 let code_identifier = match code_segment {
-                    solx_utils::CodeSegment::Deploy => contract_name.full_path.to_owned(),
+                    solx_utils::CodeSegment::Deploy => bare_name.to_owned(),
+                    solx_utils::CodeSegment::Runtime => runtime_identifier.clone(),
+                };
+                let dependencies = match code_segment {
+                    solx_utils::CodeSegment::Deploy => {
+                        let mut dependencies =
+                            solx_codegen_evm::Dependencies::new(code_identifier.as_str());
+                        dependencies.push(runtime_identifier, true);
+                        dependencies
+                    }
                     solx_utils::CodeSegment::Runtime => {
-                        format!("{}.{code_segment}", contract_name.full_path)
+                        solx_codegen_evm::Dependencies::new(code_identifier.as_str())
                     }
                 };
 
@@ -519,6 +547,7 @@ impl Contract {
                         .context("MLIR translation")?;
                 let context = unsafe { inkwell::context::Context::new(raw_llvm.context) };
                 let module = unsafe { inkwell::module::Module::new(raw_llvm.module) };
+                module.set_name(code_identifier.as_str());
 
                 let (selector_llvm_ir_unoptimized, selector_llvm_ir, selector_llvm_assembly) =
                     match code_segment {
@@ -588,7 +617,7 @@ impl Contract {
                     code_segment,
                     immutables_out,
                     metadata_out,
-                    solx_codegen_evm::Dependencies::new(code_identifier.as_str()),
+                    dependencies,
                     build.is_size_fallback,
                     build.warnings,
                     profiler.to_vec(),

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -164,21 +164,16 @@ impl Project {
                     .and_then(|evm| evm.legacy_assembly.take());
 
                 #[cfg(feature = "mlir")]
-                let result = contract.mlir.as_ref().map(|stages| {
-                    stages
-                        .iter()
-                        .find_map(|(dialect, source)| {
-                            (*dialect == solx_mlir::Dialect::Llvm).then_some(source.as_str())
-                        })
-                        .map(|source| {
-                            ContractIR::from(ContractMLIR {
-                                source: source.to_owned(),
-                            })
-                        })
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("MLIR stages present but no LLVM dialect entry")
-                        })
-                        .map(Some)
+                let result = contract.mlir.as_ref().map(|output| {
+                    let runtime_code = ContractMLIR {
+                        source: output.runtime_source.clone(),
+                        runtime_code: None,
+                    };
+                    let deploy_code = ContractMLIR {
+                        source: output.deploy_source.clone(),
+                        runtime_code: Some(Box::new(runtime_code)),
+                    };
+                    Ok::<_, anyhow::Error>(Some(ContractIR::from(deploy_code)))
                 });
                 #[cfg(feature = "mlir")]
                 let mlir_stages = contract.mlir.take();
@@ -594,22 +589,10 @@ impl Project {
                         (deploy_code.into(), runtime_code.into())
                     }
                     #[cfg(feature = "mlir")]
-                    Some(ContractIR::MLIR(mlir)) => {
-                        let deploy_code_identifier = contract.name.full_path.to_owned();
-                        let runtime_code_identifier = format!(
-                            "{deploy_code_identifier}.{}",
-                            solx_utils::CodeSegment::Runtime
-                        );
-
-                        let deploy_code = ContractLLVMIR::new(
-                            deploy_code_identifier.clone(),
-                            solx_utils::CodeSegment::Deploy,
-                            solx_codegen_evm::minimal_deploy_code(
-                                deploy_code_identifier.as_str(),
-                                runtime_code_identifier.as_str(),
-                            ),
-                        );
-                        (deploy_code.into(), ContractIR::MLIR(mlir))
+                    Some(ContractIR::MLIR(mut deploy_code)) => {
+                        let runtime_code: ContractMLIR =
+                            *deploy_code.runtime_code.take().expect("Always exists");
+                        (deploy_code.into(), runtime_code.into())
                     }
                     None => {
                         let build = EVMContractBuild::new(

--- a/solx-dev/src/solc/mod.rs
+++ b/solx-dev/src/solc/mod.rs
@@ -17,8 +17,8 @@ pub const SOLIDITY_DIR: &str = "solx-solidity";
 /// The build directory name.
 pub const BUILD_DIR: &str = "build";
 
-/// The LLVM build directory (where cmake configs are located).
-pub const LLVM_BUILD_DIR: &str = "target-llvm/build-final";
+/// The LLVM install tree (where the MLIR/LLD CMake config files live).
+pub const LLVM_BUILD_DIR: &str = "target-llvm/target-final";
 
 ///
 /// Builds the solc libraries using cmake.

--- a/solx-dev/src/solc/platforms/shared.rs
+++ b/solx-dev/src/solc/platforms/shared.rs
@@ -66,15 +66,14 @@ pub fn mlir_cmake_args(llvm_build_dir: &Path) -> Vec<String> {
     let llvm_build_dir = llvm_build_dir
         .canonicalize()
         .unwrap_or_else(|_| llvm_build_dir.to_path_buf());
-    let mlir_dir = llvm_build_dir.join("lib/cmake/mlir");
-    let lld_dir = llvm_build_dir.join("lib/cmake/lld");
-
-    let mut args = Vec::new();
-    if mlir_dir.exists() {
-        args.push(format!("-DMLIR_DIR={}", mlir_dir.display()));
-    }
-    if lld_dir.exists() {
-        args.push(format!("-DLLD_DIR={}", lld_dir.display()));
-    }
-    args
+    vec![
+        format!(
+            "-DMLIR_DIR={}",
+            llvm_build_dir.join("lib/cmake/mlir").display()
+        ),
+        format!(
+            "-DLLD_DIR={}",
+            llvm_build_dir.join("lib/cmake/lld").display()
+        ),
+    ]
 }

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -22,9 +22,9 @@ use melior::ir::Module;
 use melior::ir::Type;
 use melior::ir::attribute::StringAttribute;
 use melior::ir::operation::OperationLike;
+use melior::ir::operation::OperationMutLike;
 use melior::pass::PassManager;
 
-use crate::dialect::Dialect;
 use crate::llvm_module::RawLlvmModule;
 
 use self::builder::Builder;
@@ -266,75 +266,74 @@ impl<'context> Context<'context> {
     }
 
     /// Consumes the context, runs the Sol-to-LLVM pass pipeline, and returns
-    /// labeled MLIR representations captured at each pipeline stage.
+    /// the deploy and runtime modules as separate LLVM dialect strings.
     ///
-    /// Returns a `Vec` of `(dialect, mlir_text)` pairs in pipeline order:
-    /// - [`Dialect::Sol`] — Full module in Sol dialect (only when
-    ///   `capture_sol` is true).
-    /// - [`Dialect::Llvm`] — Runtime module only in LLVM dialect (always
-    ///   present; the LLVM IR translation step consumes it).
-    ///
-    /// The Sol conversion pass produces a nested module structure:
+    /// The Sol conversion pass produces a nested module:
     /// ```text
     /// module @Contract { deploy __entry + module @Contract_deployed { runtime __entry } }
     /// ```
-    /// `solx-core` provides its own deploy wrapper, so this method extracts
-    /// only the inner module whose `sym_name` matches
-    /// `runtime_code_identifier` (the LLVM module identifier that
-    /// `minimal_deploy_code` references).
+    /// The inner module (matched by `runtime_code_identifier`) is detached
+    /// from the outer and stringified separately, so each can be translated
+    /// to its own LLVM IR module by `solx-codegen-evm` and emit its own
+    /// bytecode segment. The Sol-pass-generated outer carries the deploy
+    /// entry that runs the constructor and returns the runtime bytecode —
+    /// it replaces the synthetic `minimal_deploy_code` wrapper that
+    /// `solx-core` uses for non-MLIR pipelines.
     ///
     /// # Errors
     ///
-    /// Returns an error if the pass pipeline fails or the deployed module
+    /// Returns an error if the pass pipeline fails or the runtime module
     /// is not found.
     pub fn finalize_module(
         self,
         runtime_code_identifier: &str,
         capture_sol: bool,
-    ) -> anyhow::Result<Vec<(Dialect, String)>> {
+    ) -> anyhow::Result<crate::output::MlirOutput> {
         let mut module = self.module;
 
-        let mut stages = Vec::with_capacity(2);
-
-        // Capture the Sol dialect MLIR before lowering (only when requested).
-        if capture_sol {
-            stages.push((Dialect::Sol, module.as_operation().to_string()));
-        }
+        // Capture the Sol dialect MLIR before lowering, if requested.
+        let sol_source = capture_sol.then(|| module.as_operation().to_string());
 
         // Lower Sol → LLVM dialect.
         Self::run_sol_passes(self.builder.context, &mut module)?;
 
-        // Walk the outer module's body to find the inner module whose
-        // `sym_name` matches `runtime_code_identifier` and extract it as
-        // the runtime code.
+        // Detach the inner runtime module so the deploy text doesn't carry
+        // a duplicate copy and the deploy LLVM IR translation doesn't redo
+        // runtime codegen. The deploy entry still references the runtime
+        // via `evm.datasize`/`evm.dataoffset` metadata, which the linker
+        // resolves through the runtime object's identifier.
+        let runtime_llvm = Self::take_nested_module_text(&mut module, runtime_code_identifier)?;
+        let deploy_llvm = module.as_operation().to_string();
+
+        Ok(crate::output::MlirOutput {
+            sol_source,
+            deploy_source: deploy_llvm,
+            runtime_source: runtime_llvm,
+        })
+    }
+
+    /// Finds a nested `builtin.module` in `module`'s body whose `sym_name`
+    /// matches `target`, removes it from the parent, and returns its
+    /// textual form.
+    fn take_nested_module_text(module: &mut Module, target: &str) -> anyhow::Result<String> {
         let body = module.body();
-        let mut deployed_operation = None;
-        let mut operation = body.first_operation();
-        while let Some(current) = operation {
-            if current.name().as_string_ref().as_str().unwrap_or("") == Self::BUILTIN_MODULE
-                && let Ok(symbol) = current.attribute("sym_name")
-            {
-                let symbol_name: StringAttribute = symbol
-                    .try_into()
-                    .map_err(|_| anyhow::anyhow!("sym_name is not a StringAttribute"))?;
-                let symbol_name = symbol_name.value();
-                if symbol_name == runtime_code_identifier {
-                    deployed_operation = Some(current);
-                    break;
-                }
+        std::iter::successors(body.first_operation_mut(), |operation| {
+            operation.next_in_block_mut()
+        })
+        .find_map(|mut operation| {
+            if operation.name().as_string_ref().as_str().unwrap_or("") != Self::BUILTIN_MODULE {
+                return None;
             }
-            operation = current.next_in_block();
-        }
-
-        let runtime_operation = deployed_operation.ok_or_else(|| {
-            anyhow::anyhow!(
-                "no module with sym_name `{runtime_code_identifier}` in Sol pass output"
-            )
-        })?;
-
-        stages.push((Dialect::Llvm, runtime_operation.to_string()));
-
-        Ok(stages)
+            let symbol = operation.attribute("sym_name").ok()?;
+            let symbol_name: StringAttribute = symbol.try_into().ok()?;
+            if symbol_name.value() != target {
+                return None;
+            }
+            let text = operation.to_string();
+            operation.remove_from_parent();
+            Some(text)
+        })
+        .ok_or_else(|| anyhow::anyhow!("no module with sym_name `{target}` in Sol pass output"))
     }
 
     // ==== Phase 4: LLVM translation ====

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dialect;
 pub mod ffi;
 pub mod llvm_module;
 pub mod ods;
+pub mod output;
 
 pub use self::attributes::cmp_predicate::CmpPredicate;
 pub use self::attributes::contract_kind::ContractKind;
@@ -28,3 +29,4 @@ pub use self::context::builder::Builder;
 pub use self::context::builder::type_factory::TypeFactory;
 pub use self::context::environment::Environment;
 pub use self::dialect::Dialect;
+pub use self::output::MlirOutput;

--- a/solx-mlir/src/output.rs
+++ b/solx-mlir/src/output.rs
@@ -1,0 +1,19 @@
+//!
+//! MLIR pipeline output produced by [`crate::Context::finalize_module`].
+//!
+
+///
+/// Captured MLIR text for a single contract.
+///
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MlirOutput {
+    /// Pre-pass Sol dialect text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sol_source: Option<String>,
+    /// LLVM dialect text of the deploy module.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub deploy_source: String,
+    /// LLVM dialect text of the runtime module.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub runtime_source: String,
+}

--- a/solx-mlir/tests/lit/constructor_body.sol
+++ b/solx-mlir/tests/lit/constructor_body.sol
@@ -1,0 +1,17 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*}} attributes {{.*}}kind = #{{.*}}Constructor
+// CHECK: sol.store %arg0
+// CHECK: sol.store %arg1
+// CHECK: sol.cadd
+// CHECK: sol.store {{.*}}!sol.ptr<ui256, Storage>
+// CHECK: sol.return
+
+contract CtorTest {
+    uint256 c;
+
+    constructor(uint256 a, uint256 b) {
+        c = a + b;
+    }
+}

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -71,19 +71,26 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
                 .emit_sol_state_var(&format!("slot_{slot}"), *slot, &contract_body);
         }
 
-        // Emit the constructor first to align with solc's MLIR layout. The
-        // explicit-constructor body is not yet lowered, so we emit an empty
-        // stub regardless of whether the source defines one.
-        let entry = self.state.builder.emit_sol_func(
-            "constructor()",
-            &[],
-            &[],
-            None,
-            solx_mlir::StateMutability::NonPayable,
-            Some(solx_mlir::FunctionKind::Constructor),
-            &contract_body,
-        );
-        self.state.builder.emit_sol_return(&[], &entry);
+        // Emit the constructor first to align with solc's MLIR layout. Lower
+        // the explicit constructor body when the source defines one, otherwise
+        // emit an empty stub.
+        if let Some(constructor) = contract.constructor() {
+            self.state.current_contract_type = Some(contract_type);
+            let emitter = FunctionEmitter::new(self.state, &storage_layout);
+            emitter.emit_sol(&constructor, &contract_body)?;
+            self.state.current_contract_type = None;
+        } else {
+            let entry = self.state.builder.emit_sol_func(
+                "constructor()",
+                &[],
+                &[],
+                None,
+                solx_mlir::StateMutability::NonPayable,
+                Some(solx_mlir::FunctionKind::Constructor),
+                &contract_body,
+            );
+            self.state.builder.emit_sol_return(&[], &entry);
+        }
 
         // Slang's `functions()` filters out Constructor and Modifier kinds.
         for function in contract.functions() {

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -170,7 +170,10 @@ impl Frontend for Slang {
                 continue;
             };
 
-            let runtime_code_identifier = format!("{contract_name}_deployed");
+            let runtime_code_identifier = format!(
+                "{contract_name}{}",
+                solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX
+            );
             let capture_sol_dialect = input_json.settings.output_selection.check_selection(
                 file_identifier,
                 Some(contract_name.as_str()),

--- a/solx-standard-json/src/output/contract/mod.rs
+++ b/solx-standard-json/src/output/contract/mod.rs
@@ -33,11 +33,11 @@ pub struct Contract {
     /// The contract Yul IR code.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ir: Option<String>,
-    /// MLIR stages captured during the Sol → LLVM pipeline, in pipeline
-    /// order (`Sol` first, `Llvm` last).
+    /// MLIR pipeline output: optional pre-pass Sol dialect snapshot plus
+    /// the deploy and runtime LLVM dialect modules.
     #[cfg(feature = "mlir")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mlir: Option<Vec<(solx_mlir::Dialect, String)>>,
+    pub mlir: Option<solx_mlir::MlirOutput>,
     /// The EVM data of the contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evm: Option<EVM>,

--- a/solx/tests/cli/emit_mlir.rs
+++ b/solx/tests/cli/emit_mlir.rs
@@ -20,12 +20,15 @@ fn default() -> anyhow::Result<()> {
     let sol_index = stdout
         .find("MLIR Dialect sol:")
         .expect("sol dialect header missing");
-    let llvm_index = stdout
-        .find("MLIR Dialect llvm:")
-        .expect("llvm dialect header missing");
+    let deploy_index = stdout
+        .find("MLIR Dialect llvm (deploy):")
+        .expect("llvm deploy dialect header missing");
+    let runtime_index = stdout
+        .find("MLIR Dialect llvm (runtime):")
+        .expect("llvm runtime dialect header missing");
     assert!(
-        sol_index < llvm_index,
-        "expected sol stage before llvm stage in pipeline order"
+        sol_index < deploy_index && deploy_index < runtime_index,
+        "expected sol stage before llvm deploy and runtime stages in pipeline order"
     );
     assert!(stdout.contains("sol.contract"));
     assert!(stdout.contains("llvm.func"));
@@ -48,7 +51,7 @@ fn filter_sol_only() -> anyhow::Result<()> {
         .success()
         .stdout(predicate::str::contains("MLIR Dialect sol:"))
         .stdout(predicate::str::contains("sol.contract"))
-        .stdout(predicate::str::contains("MLIR Dialect llvm:").not());
+        .stdout(predicate::str::contains("MLIR Dialect llvm").not());
 
     Ok(())
 }
@@ -66,7 +69,8 @@ fn filter_llvm_only() -> anyhow::Result<()> {
     let result = crate::cli::execute_solx(args)?;
     result
         .success()
-        .stdout(predicate::str::contains("MLIR Dialect llvm:"))
+        .stdout(predicate::str::contains("MLIR Dialect llvm (deploy):"))
+        .stdout(predicate::str::contains("MLIR Dialect llvm (runtime):"))
         .stdout(predicate::str::contains("llvm.func"))
         .stdout(predicate::str::contains("MLIR Dialect sol:").not());
 

--- a/solx/tests/cli/output_dir.rs
+++ b/solx/tests/cli/output_dir.rs
@@ -283,8 +283,8 @@ fn emit_mlir() -> anyhow::Result<()> {
         .collect();
 
     assert!(
-        entries.len() >= 2,
-        "Expected at least 2 .mlir files (one per dialect stage)"
+        entries.len() >= 3,
+        "Expected at least 3 .mlir files (sol + llvm deploy + llvm runtime)"
     );
 
     let filenames: Vec<_> = entries
@@ -296,8 +296,16 @@ fn emit_mlir() -> anyhow::Result<()> {
         "Expected a .sol.mlir file, found: {filenames:?}"
     );
     assert!(
-        filenames.iter().any(|name| name.contains(".llvm.mlir")),
-        "Expected a .llvm.mlir file, found: {filenames:?}"
+        filenames
+            .iter()
+            .any(|name| name.contains(".llvm.deploy.mlir")),
+        "Expected a .llvm.deploy.mlir file, found: {filenames:?}"
+    );
+    assert!(
+        filenames
+            .iter()
+            .any(|name| name.contains(".llvm.runtime.mlir")),
+        "Expected a .llvm.runtime.mlir file, found: {filenames:?}"
     );
 
     Ok(())
@@ -333,8 +341,16 @@ fn emit_mlir_filter_sol() -> anyhow::Result<()> {
         "Expected a .sol.mlir file, found: {filenames:?}"
     );
     assert!(
-        !filenames.iter().any(|name| name.contains(".llvm.mlir")),
-        "Did not expect a .llvm.mlir file, found: {filenames:?}"
+        !filenames
+            .iter()
+            .any(|name| name.contains(".llvm.deploy.mlir")),
+        "Did not expect a .llvm.deploy.mlir file, found: {filenames:?}"
+    );
+    assert!(
+        !filenames
+            .iter()
+            .any(|name| name.contains(".llvm.runtime.mlir")),
+        "Did not expect a .llvm.runtime.mlir file, found: {filenames:?}"
     );
 
     Ok(())


### PR DESCRIPTION
Replace the empty-stub constructor in `solx-slang` with a real lowering: when the contract defines a constructor, dispatch to the existing `FunctionEmitter` so its parameters, body, and require/emit semantics land in the Sol dialect alongside the regular functions.

The Sol-to-LLVM pass already produces an outer module that runs the constructor and returns the runtime bytecode; this PR plumbs that through to bytecode codegen instead of relying on `solx_codegen_evm::minimal_deploy_code`. `Context::finalize_module` now detaches the inner runtime submodule from the outer and hands `deploy_source` / `runtime_source` (plus an optional `sol_source`) out as a pair via the new `solx_mlir::MlirOutput` carrier. solx-core wires the slang/MLIR pipeline to consume both segments by mirroring Yul's nesting (`MLIR { source, runtime_code: Option<Box<Self>> }`), so the deploy/runtime split at compile time is a structural `runtime_code.take()` rather than a string clone.

Identifiers follow what the Sol pass embeds in `evm.datasize` / `evm.dataoffset` metadata — bare contract name and `{name}_deployed` — matching solc's Yul convention so the existing assemble step's `__datasize__$<hash>$__` resolution works without changes. Renamed the relevant constant from `YUL_OBJECT_DEPLOYED_SUFFIX` to the neutral `DEPLOYED_OBJECT_SUFFIX` since the slang/MLIR path uses it too.

`--emit-mlir` now prints up to three pieces per contract: pre-pass Sol dialect (when requested), post-pass LLVM dialect for the deploy module, and post-pass LLVM dialect for the runtime module. The detach in `finalize_module` keeps the deploy text from re-embedding the runtime bytes and prevents the deploy LLVM IR translation from doing redundant runtime codegen.

## Test deltas

Net delta on `tests/solidity/simple/ -O M3B3` against the `ci-slang-mlir-lit-tests` baseline:

- **+2 PASSED** (1650 → 1652)
- **-9 FAILED** (16 → 7)
- **+4 INVALID** (382 → 386)

Newly passing:
- `constructor/simple.sol::success`, `::failure`
- `constructor/call_public.sol::success`
- `events/function_inside_event4.sol::first`, `events/function_inside_event5.sol::first`

Moved from FAILED to INVALID (constructors with features not yet supported by the slang frontend — multi-return, function pointers, try-catch):
- `destructuring/tuple_priority1.sol`
- `function/function_type/f6.sol`
- `linearity/linearity3.sol`
- `try_catch/this_in_constructor.sol`

## Out of scope

- **Bare-name link identifier collision risk**: matches the Sol pass's metadata convention (and Yul's, per `yul.object.identifier`), but two contracts with the same bare name across different files would collide. Tracked via `TODO` at `solx-core/src/project/contract/mod.rs` — fuse with the `<full_path>` convention via post-pass metadata substitution or by honoring `ContextYulData::resolve_path` in `data_size` / `data_offset` emission.