### PR TITLE
fix(ci): fetch reference solc directly from raw.githubusercontent.com

### DIFF
--- a/solx-compiler-downloader/dev-compilers.json
+++ b/solx-compiler-downloader/dev-compilers.json
@@ -3,7 +3,7 @@
     {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/argotorg/solc-bin/raw/refs/heads/gh-pages/${PLATFORM}/solc-${PLATFORM}-v0.8.34+commit.80d5c536",
+      "source": "https://raw.githubusercontent.com/argotorg/solc-bin/gh-pages/${PLATFORM}/solc-${PLATFORM}-v0.8.34+commit.80d5c536",
       "destination": "./temp-compilers/solc-0.8.34",
       "version": "0.8.34",
       "platforms": {


### PR DESCRIPTION
The integration job has been intermittently failing on the solc-0.8.34 download with `client error (Connect)` — for example, on PR #384 at run https://github.com/NomicFoundation/solx/actions/runs/25415956893/job/74547493034 (`error sending request for url (https://github.com/argotorg/solc-bin/raw/refs/heads/gh-pages/linux-amd64/solc-linux-amd64-v0.8.34+commit.80d5c536) — client error (Connect)`).

The URL in `solx-compiler-downloader/dev-compilers.json` goes through `github.com/argotorg/solc-bin/raw/refs/heads/gh-pages/...`, which redirects to `raw.githubusercontent.com`; the redirect step is what flakes.

Switch to the direct `raw.githubusercontent.com` form, matching what `solc-upstream.json` already uses for the `ethereum/solc-bin` `list.json` fetch — so the pattern is consistent across both downloader configs. The downloader's existing 8-attempt exponential-backoff retry stays in place; this just removes a layer of network indirection that the retry couldn't always rescue.