### PR TITLE
chore(cargo): bump workspace resolver to 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
     "solx-solc-test-adapter",
     "solx-compiler-downloader",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = [


### PR DESCRIPTION
## Why

Edition 2024 was already declared at the workspace level, but the explicit `resolver = "2"` in `Cargo.toml:37` overrode the edition's implicit default (`"3"`). Cargo doesn't auto-bump the resolver when the edition flips — the value has to be set by hand. So we've been silently running on the older resolver.

## What resolver 3 brings

MSRV-aware version selection on top of resolver 2's host/target separation: when several semver-compatible versions of a dep satisfy a requirement, cargo prefers the newest one that compiles on the workspace's `rust-version` instead of always picking the absolute latest. Useful for keeping the lockfile reproducible against a fixed minimum rustc.

## Lockfile impact

`Cargo.lock` is unchanged. The workspace doesn't declare a `rust-version`, so the MSRV-aware resolution path has no constraint to filter against, and all existing pins remain valid under resolver 3. The day someone adds `rust-version`, this rule starts doing real work — a follow-up worth doing once we have a single source of truth for the minimum rustc.

## Verification

```
cargo check --workspace --all-targets   # clean
cargo build-slang                        # clean (slang feature set)
```

Both succeed under the new resolver with no lockfile churn.

## Out of scope

- Adding `rust-version` to `[workspace.package]`. Worth doing separately so the resolver bump and the MSRV pin can be reasoned about independently.