### PR TITLE
refactor(slang): route boundary casts through TypeConversion

### DIFF
--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -189,11 +189,9 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         // For implicit zero-initialization, alloca is emitted first.
         let (block, initial_value) = if let Some(ref initializer_expression) = declaration.value() {
             let (initial_value, block) = emitter.emit_value(initializer_expression, block)?;
-            let cast_value =
-                emitter
-                    .state
-                    .builder
-                    .emit_sol_cast(initial_value, declared_type, &block);
+            let builder = &emitter.state.builder;
+            let cast_value = TypeConversion::from_target_type(declared_type, builder)
+                .emit(initial_value, builder, &block);
             (block, Some(cast_value))
         } else {
             (block, None)
@@ -258,8 +256,10 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 .first()
                 .copied()
                 .unwrap_or(self.state.builder.types.ui256);
-            let return_value = self.state.builder.emit_sol_cast(value, return_type, &block);
-            self.state.builder.emit_sol_return(&[return_value], &block);
+            let builder = &self.state.builder;
+            let return_value =
+                TypeConversion::from_target_type(return_type, builder).emit(value, builder, &block);
+            builder.emit_sol_return(&[return_value], &block);
         } else {
             self.state.builder.emit_sol_return(&[], &block);
         }


### PR DESCRIPTION
The two remaining `Builder::emit_sol_cast` boundary call sites in `solx-slang/src/ast/contract/function/statement/mod.rs` — variable-declaration initializer casting and single-value `emit_return` — now go through `TypeConversion::from_target_type(target, builder).emit(value, ...)`, the same entry point already used by function-call args, revert args, and event args.

For integer types the two paths produce identical MLIR (the `Cast` arm of `TypeConversion::emit` is literally `builder.emit_sol_cast(value, target, block)`). The difference matters only when the declared type is `bool` (TypeConversion emits `sol.constant 0; sol.cmp ne` for the proper "is non-zero" semantics) or `address` (TypeConversion appends a `sol.address_cast` step). The current 23-test lit suite passes unchanged.

This is the third and last call site of this pattern; the two slang-stack PRs that touch the surrounding region (#388 and #389) are also harmonized in their amended commits.