### PR TITLE
feat(slang): resolve UserDefinedValue types via target-type lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,8 +2570,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaslang_bindings"
-version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -2582,8 +2582,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_cst"
-version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
 dependencies = [
  "nom 8.0.0",
  "serde",
@@ -2592,8 +2592,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_graph_builder"
-version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -2606,8 +2606,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_stack_graphs"
-version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
 dependencies = [
  "bitvec",
  "controlled-option",
@@ -4276,8 +4276,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slang_solidity"
-version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
+version = "1.3.5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
 dependencies = [
  "indexmap 2.14.0",
  "metaslang_bindings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "metaslang_bindings"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "metaslang_cst"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
 dependencies = [
  "nom 8.0.0",
  "serde",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "metaslang_graph_builder"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "metaslang_stack_graphs"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
 dependencies = [
  "bitvec",
  "controlled-option",
@@ -4277,7 +4277,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity"
 version = "1.3.4"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=d8388d6bf696383627ece31ba3551880d0b9eafc#d8388d6bf696383627ece31ba3551880d0b9eafc"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8754a8fc4b11f66ef022c4cc7864714f09106297#8754a8fc4b11f66ef022c4cc7864714f09106297"
 dependencies = [
  "indexmap 2.14.0",
  "metaslang_bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ features = [
 [workspace.dependencies.slang_solidity]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "8754a8fc4b11f66ef022c4cc7864714f09106297"
+rev = "0a0ba100ef74c1001e256bea94c5a285c93170ca"
 # `__private_testing_utils` is required by `__private_backend_api` internals
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 features = ["__private_backend_api", "__private_testing_utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ features = [
 [workspace.dependencies.slang_solidity]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "d8388d6bf696383627ece31ba3551880d0b9eafc"
+rev = "8754a8fc4b11f66ef022c4cc7864714f09106297"
 # `__private_testing_utils` is required by `__private_backend_api` internals
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 features = ["__private_backend_api", "__private_testing_utils"]

--- a/solx-mlir/tests/lit/user_defined_value_type.sol
+++ b/solx-mlir/tests/lit/user_defined_value_type.sol
@@ -1,0 +1,19 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*id_u.*}}: ui256) -> ui256
+// CHECK: sol.func @{{.*id_s.*}}: si8) -> si8
+// CHECK: sol.func @{{.*id_a.*}}: !sol.address) -> !sol.address
+// CHECK: sol.func @{{.*id_b.*}}: i1) -> i1
+
+contract C {
+    type U is uint256;
+    type S is int8;
+    type A is address;
+    type B is bool;
+
+    function id_u(U x) public pure returns (U) { return x; }
+    function id_s(S x) public pure returns (S) { return x; }
+    function id_a(A x) public pure returns (A) { return x; }
+    function id_b(B x) public pure returns (B) { return x; }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -197,6 +197,12 @@ impl<'context> TypeConversion<'context> {
                 let max = u8::try_from(member_count - 1).expect("enum member count fits in u8");
                 builder.types.enumeration(max.into())
             }
+            SlangType::UserDefinedValue(udvt) => {
+                let target_type = udvt
+                    .target_type()
+                    .expect("UDVT target type resolved by semantic analysis");
+                Self::resolve_slang_type(&target_type, inherited_location, builder)
+            }
             _ => unimplemented!("unsupported Slang type"),
         }
     }


### PR DESCRIPTION
Adds Slang→Sol-dialect resolution for the `UserDefinedValue` variant by following the binder's `target_type_id` to the wrapped elementary type and recursing through `TypeConversion::resolve_slang_type`. UDVT-typed parameters and returns lower to the underlying integer/address/bool MLIR type instead of panicking at the catch-all `unimplemented!("unsupported Slang type")` arm.

Reaches the resolved target via a new `UserDefinedValueType::target_type()` AST accessor in slang ([NomicFoundation/slang `feat-udvt-target-type`](https://github.com/NomicFoundation/slang/commit/8754a8fc4b11f66ef022c4cc7864714f09106297)). CI fetches that rev directly off the fork's branch — no upstream slang PR yet.

Depends on #390.

Lit test: `solx-mlir/tests/lit/user_defined_value_type.sol`.

## Test deltas

`tests/solidity/simple/ -O M3B3` vs base [`71e9071`](https://github.com/NomicFoundation/solx/commit/71e9071859f1a0a13b95ab8352069762835120e9): unchanged at 1662 / 7 / 383 (no UDVT-using fixtures).

`solx-solidity/test/libsolidity/semanticTests/`: 803 / 375 / 1173 → 805 / 377 / 1171.

`.sol` files moved from INVALID to FAILED:

- `solx-solidity/test/libsolidity/semanticTests/operators/userDefined/fixed_point_udvt_with_operators.sol` — `applyInterest:1` produces wrong runtime output.
- `solx-solidity/test/libsolidity/semanticTests/operators/userDefined/operator_parameter_and_return_cleanup_between_calls.sol` — `divAddNoOverflow:1` produces wrong runtime output.