### PR TITLE
feat(slang): wire .length on arrays, bytes, and strings

### DIFF
--- a/solx-mlir/tests/lit/length.sol
+++ b/solx-mlir/tests/lit/length.sol
@@ -1,0 +1,15 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}len_bytes{{.*}}!sol.string<Memory>{{.*}}ui256
+// CHECK:   sol.length {{.*}} : !sol.string<Memory>
+// CHECK: sol.func {{.*}}len_arr{{.*}}!sol.array<? x ui256, Memory>{{.*}}ui256
+// CHECK:   sol.length {{.*}} : !sol.array<? x ui256, Memory>
+// CHECK: sol.func {{.*}}len_fixed{{.*}}!sol.array<5 x ui256, Memory>{{.*}}ui256
+// CHECK:   sol.length {{.*}} : !sol.array<5 x ui256, Memory>
+
+contract C {
+    function len_bytes(bytes memory b) public pure returns (uint256) { return b.length; }
+    function len_arr(uint256[] memory a) public pure returns (uint256) { return a.length; }
+    function len_fixed(uint256[5] memory a) public pure returns (uint256) { return a.length; }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -28,6 +28,7 @@ use solx_mlir::ods::sol::GasLimitOperation;
 use solx_mlir::ods::sol::GasPriceOperation;
 use solx_mlir::ods::sol::GetCallDataOperation;
 use solx_mlir::ods::sol::Keccak256Operation;
+use solx_mlir::ods::sol::LengthOperation;
 use solx_mlir::ods::sol::MulModOperation;
 use solx_mlir::ods::sol::OriginOperation;
 use solx_mlir::ods::sol::PrevRandaoOperation;
@@ -223,7 +224,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         let builder = &self.expression_emitter.state.builder;
         match access.member().resolved_built_in() {
             Some(BuiltIn::AddressBalance) => {
-                self.emit_address_base_intrinsic(access, block, |address_value| {
+                self.emit_unary_member_intrinsic(access, block, |address_value| {
                     BalanceOperation::builder(builder.context, builder.unknown_location)
                         .cont_addr(address_value)
                         .out(builder.types.ui256)
@@ -232,7 +233,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 })
             }
             Some(BuiltIn::AddressCodehash) => {
-                self.emit_address_base_intrinsic(access, block, |address_value| {
+                self.emit_unary_member_intrinsic(access, block, |address_value| {
                     CodeHashOperation::builder(builder.context, builder.unknown_location)
                         .cont_addr(address_value)
                         .out(builder.types.ui256)
@@ -241,7 +242,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 })
             }
             Some(BuiltIn::AddressCode) => {
-                self.emit_address_base_intrinsic(access, block, |address_value| {
+                self.emit_unary_member_intrinsic(access, block, |address_value| {
                     CodeOperation::builder(builder.context, builder.unknown_location)
                         .cont_addr(address_value)
                         .out(builder.types.sol_string_memory)
@@ -249,6 +250,13 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                         .into()
                 })
             }
+            Some(BuiltIn::Length) => self.emit_unary_member_intrinsic(access, block, |operand| {
+                LengthOperation::builder(builder.context, builder.unknown_location)
+                    .inp(operand)
+                    .len(builder.types.ui256)
+                    .build()
+                    .into()
+            }),
             resolved => {
                 let operation = match resolved {
                     Some(BuiltIn::TxOrigin) => {
@@ -354,12 +362,13 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         }
     }
 
-    /// Emits an EVM intrinsic that reads from a per-address container, e.g.
-    /// `address.balance` (`sol.balance`) or `address.codehash` (`sol.code_hash`).
+    /// Emits an intrinsic whose single operand is the receiver of a member
+    /// access — e.g. `address.balance` (`sol.balance`), `address.codehash`
+    /// (`sol.code_hash`), or `array.length` (`sol.length`).
     ///
-    /// Evaluates the address operand, builds the operation via `build_op`, and
+    /// Evaluates the receiver, builds the operation via `build_op`, and
     /// extracts its single result.
-    fn emit_address_base_intrinsic<F>(
+    fn emit_unary_member_intrinsic<F>(
         &self,
         access: &MemberAccessExpression,
         block: BlockRef<'context, 'block>,
@@ -374,7 +383,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         let value = block
             .append_operation(build_op(address_value))
             .result(0)
-            .expect("address-base intrinsic always produces one result")
+            .expect("unary member intrinsic always produces one result")
             .into();
         Ok((value, block))
     }


### PR DESCRIPTION
Wires `BuiltIn::Length` to `Sol_LengthOp` via the existing `emit_address_base_intrinsic` helper. `.length` on `bytes`, dynamic arrays (`T[]`), and fixed-size arrays (`T[N]`) now lowers to `sol.length %v : <type>` at [`built_in.rs:252`](https://github.com/NomicFoundation/solx/blob/feat-slang-array-length/solx-slang/src/ast/contract/function/expression/call/built_in.rs#L252) instead of panicking on the catch-all `unsupported member access: length` arm.

Depends on #393.

Lit test: `solx-mlir/tests/lit/length.sol`. Output type signatures match solc's `--mlir-action=print-init` on `bytes` / `T[]` / `T[N]`.

## Test deltas

vs base [`9ca5dd2`](https://github.com/NomicFoundation/solx/commit/9ca5dd2ecdf557e1462c511cbfe5352e74b41817) under `-O M3B3`:

- `tests/solidity/simple/`: 1680 / 7 / 381 unchanged.
- `solx-solidity/test/libsolidity/semanticTests/`: 833 / 372 / 1162 unchanged.

The milestone counts don't move because the 37 sites that previously panicked on `.length` (35 semantic + 2 simple) hit other in-flight errors past the resolved arm (`unsupported assignment target`, `unsupported callee expression`, `Discriminant(18)` — IndexAccessExpression, etc.) — the change peels off one error layer.