### PR TITLE
feat(slang): wire address.send and address.transfer

### DIFF
--- a/solx-mlir/tests/lit/value_transfer.sol
+++ b/solx-mlir/tests/lit/value_transfer.sol
@@ -1,0 +1,12 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}pay_send{{.*}}-> i1
+// CHECK:   sol.send {{.*}}, {{.*}} : !sol.address, ui256 -> i1
+// CHECK: sol.func {{.*}}pay_transfer{{.*}}!sol.address{{.*}}ui256
+// CHECK:   sol.transfer {{.*}}, {{.*}} : !sol.address, ui256
+
+contract C {
+    function pay_send(address payable r, uint256 v) public returns (bool) { return r.send(v); }
+    function pay_transfer(address payable r, uint256 v) public { r.transfer(v); }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -33,9 +33,11 @@ use solx_mlir::ods::sol::MulModOperation;
 use solx_mlir::ods::sol::OriginOperation;
 use solx_mlir::ods::sol::PrevRandaoOperation;
 use solx_mlir::ods::sol::Ripemd160Operation;
+use solx_mlir::ods::sol::SendOperation;
 use solx_mlir::ods::sol::Sha256Operation;
 use solx_mlir::ods::sol::SigOperation;
 use solx_mlir::ods::sol::TimestampOperation;
+use solx_mlir::ods::sol::TransferOperation;
 
 use crate::ast::contract::function::expression::call::CallEmitter;
 
@@ -219,8 +221,9 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
     pub fn emit_built_in_member_access(
         &self,
         access: &MemberAccessExpression,
+        arguments: Option<&PositionalArguments>,
         block: BlockRef<'context, 'block>,
-    ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
+    ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
         let builder = &self.expression_emitter.state.builder;
         match access.member().resolved_built_in() {
             Some(BuiltIn::AddressBalance) => {
@@ -257,6 +260,41 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     .build()
                     .into()
             }),
+            Some(BuiltIn::AddressSend) => {
+                let arguments = arguments.expect("send is a member-access call");
+                let (addr, block) = self
+                    .expression_emitter
+                    .emit_value(&access.operand(), block)?;
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let value = block
+                    .append_operation(
+                        SendOperation::builder(builder.context, builder.unknown_location)
+                            .addr(addr)
+                            .val(values[0])
+                            .status(builder.types.i1)
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("send always produces one result")
+                    .into();
+                Ok((Some(value), block))
+            }
+            Some(BuiltIn::AddressTransfer) => {
+                let arguments = arguments.expect("transfer is a member-access call");
+                let (addr, block) = self
+                    .expression_emitter
+                    .emit_value(&access.operand(), block)?;
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                block.append_operation(
+                    TransferOperation::builder(builder.context, builder.unknown_location)
+                        .addr(addr)
+                        .val(values[0])
+                        .build()
+                        .into(),
+                );
+                Ok((None, block))
+            }
             resolved => {
                 let operation = match resolved {
                     Some(BuiltIn::TxOrigin) => {
@@ -357,7 +395,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                     .result(0)
                     .expect("intrinsic always produces one result")
                     .into();
-                Ok((value, block))
+                Ok((Some(value), block))
             }
         }
     }
@@ -373,7 +411,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         access: &MemberAccessExpression,
         block: BlockRef<'context, 'block>,
         build_op: F,
-    ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)>
+    ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)>
     where
         F: FnOnce(Value<'context, 'block>) -> Operation<'context>,
     {
@@ -385,7 +423,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             .result(0)
             .expect("unary member intrinsic always produces one result")
             .into();
-        Ok((value, block))
+        Ok((Some(value), block))
     }
 
     /// Emits each positional argument and returns the resulting values

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -79,6 +79,10 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             return Ok((value, block));
         }
 
+        if let Expression::MemberAccessExpression(access) = &callee {
+            return self.emit_built_in_member_access(access, Some(positional_arguments), block);
+        }
+
         let Expression::Identifier(callee_identifier) = &callee else {
             anyhow::bail!("unsupported callee expression");
         };
@@ -200,10 +204,7 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         Ok((mlir_name, argument_values, return_types, current_block))
     }
 
-    /// Emits a member access expression (e.g. `tx.origin`, `msg.sender`).
-    ///
-    /// Resolves the member via slang's binder to a specific `BuiltIn` variant
-    /// rather than string-matching the member name.
+    /// Emits a bare member access expression (e.g. `tx.origin`, `msg.sender`).
     ///
     /// # Errors
     ///
@@ -213,6 +214,10 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         access: &MemberAccessExpression,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
-        self.emit_built_in_member_access(access, block)
+        let (value, block) = self.emit_built_in_member_access(access, None, block)?;
+        Ok((
+            value.expect("bare member access always produces a value"),
+            block,
+        ))
     }
 }


### PR DESCRIPTION
Extends the built-in call dispatch in [`built_in.rs`](https://github.com/NomicFoundation/solx/blob/feat-slang-value-transfer/solx-slang/src/ast/contract/function/expression/call/built_in.rs) to recognize `MemberAccessExpression` callees alongside bare identifiers, and wires `BuiltIn::AddressSend` / `BuiltIn::AddressTransfer` to `Sol_SendOp` / `Sol_TransferOp`. `addr.send(amount)` lowers to `sol.send %addr, %amount : !sol.address, ui256 -> i1`; `addr.transfer(amount)` lowers to `sol.transfer %addr, %amount : !sol.address, ui256` (no result).

Until this PR, `addr.send`/`addr.transfer` hit the catch-all `anyhow::bail!(\"unsupported callee expression\")` path in `emit_function_call` because the existing dispatch checked only for `Expression::Identifier` callees.

Depends on #393.

Lit test: `solx-mlir/tests/lit/value_transfer.sol`.

## Test deltas

vs base [`9ca5dd2`](https://github.com/NomicFoundation/solx/commit/9ca5dd2ecdf557e1462c511cbfe5352e74b41817) under `-O M3B3`:

- `tests/solidity/simple/`: 1680 / 7 / 381 unchanged.
- `solx-solidity/test/libsolidity/semanticTests/`: 833 / 372 / 1162 unchanged.

The milestone counts don't move because most semanticTests using `.send`/`.transfer` are gated behind other unsupported features (try-catch, multi-return, etc.). The `unsupported callee expression` panic count drops from 246 to 245 — one site in [`solx-solidity/test/libsolidity/semanticTests/isoltestTesting/balance_other_contract.sol`](https://github.com/NomicFoundation/solx-solidity/blob/main/test/libsolidity/semanticTests/isoltestTesting/balance_other_contract.sol) no longer bails on `.transfer`; it now hits a downstream `Sol pass pipeline failed` error.