### PR TITLE
fix(slang): allocate named return parameters

### DIFF
--- a/solx-mlir/tests/lit/named_returns.sol
+++ b/solx-mlir/tests/lit/named_returns.sol
@@ -1,0 +1,30 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// Named return: `_out` gets a zero-initialized slot, the body assigns to it,
+// and the implicit return at the end loads from the slot.
+// CHECK: sol.func @{{.*identity.*}}
+// CHECK:   %[[IN:.*]] = sol.alloca : !sol.ptr<i1, Stack>
+// CHECK:   sol.store %{{.*}}, %[[IN]]
+// CHECK:   %[[OUT:.*]] = sol.alloca : !sol.ptr<i1, Stack>
+// CHECK:   sol.store %{{.*}}, %[[OUT]]
+// CHECK:   sol.load %[[IN]]
+// CHECK:   sol.store %{{.*}}, %[[OUT]]
+// CHECK:   sol.load %[[OUT]]
+// CHECK:   sol.return
+
+// Unnamed return: no slot allocation; only the parameter alloca.
+// CHECK-LABEL: sol.func @{{.*plus_one.*}}
+// CHECK:   sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK-NOT: sol.alloca
+// CHECK: sol.return
+
+contract C {
+    function identity(bool _in) public pure returns (bool _out) {
+        _out = _in;
+    }
+
+    function plus_one(uint256 x) public pure returns (uint256) {
+        return x + 1;
+    }
+}

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -8,7 +8,10 @@ pub mod statement;
 use std::collections::HashMap;
 
 use melior::ir::BlockLike;
+use melior::ir::BlockRef;
 use melior::ir::Type;
+use melior::ir::Value;
+use melior::ir::r#type::IntegerType;
 use slang_solidity::backend::abi::AbiEntry;
 use slang_solidity::backend::ir::ast::ElementaryType;
 use slang_solidity::backend::ir::ast::Expression;
@@ -58,7 +61,7 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
     pub fn emit_sol(
         &self,
         function: &FunctionDefinition,
-        contract_body: &melior::ir::BlockRef<'context, '_>,
+        contract_body: &BlockRef<'context, '_>,
     ) -> anyhow::Result<String> {
         let Some(ref body) = function.body() else {
             // Abstract or interface function — no codegen needed.
@@ -104,8 +107,7 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
                 .map(|id| id.name())
                 .unwrap_or_else(|| "_".to_owned());
             let parameter_type = mlir_parameter_types[index];
-            let parameter_value: melior::ir::Value<'context, '_> =
-                function_entry_block.argument(index)?.into();
+            let parameter_value: Value<'context, '_> = function_entry_block.argument(index)?.into();
             let pointer = self
                 .state
                 .builder
@@ -115,6 +117,38 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
                 .emit_sol_store(parameter_value, pointer, &function_entry_block);
 
             environment.define_variable(parameter_name, pointer, parameter_type);
+        }
+
+        let mut return_slots: Vec<Option<Value<'context, '_>>> = Vec::new();
+        if let Some(returns) = function.returns() {
+            for (index, parameter) in returns.iter().enumerate() {
+                let Some(identifier) = parameter.name() else {
+                    return_slots.push(None);
+                    continue;
+                };
+                let return_type = result_types[index];
+                let pointer = self
+                    .state
+                    .builder
+                    .emit_sol_alloca(return_type, &function_entry_block);
+                // TODO: replace with a typed-zero helper covering address, fixed-bytes, and
+                // memory-resident types (e.g. `0x60` for empty `string`/`bytes` memory).
+                if IntegerType::try_from(return_type).is_ok() {
+                    let zero =
+                        self.state
+                            .builder
+                            .emit_sol_constant(0, return_type, &function_entry_block);
+                    self.state
+                        .builder
+                        .emit_sol_store(zero, pointer, &function_entry_block);
+                } else {
+                    unimplemented!(
+                        "zero-initialization for non-integer named return: {return_type}"
+                    );
+                }
+                environment.define_variable(identifier.name(), pointer, return_type);
+                return_slots.push(Some(pointer));
+            }
         }
 
         let region = function_entry_block
@@ -140,7 +174,7 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
         }
 
         if !terminated {
-            self.emit_default_return(&result_types, &current_block);
+            self.emit_default_return(&result_types, &return_slots, &current_block);
         }
 
         Ok(mlir_name)
@@ -225,20 +259,31 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
 
     /// Emits a default `sol.return` if the block lacks a terminator.
     ///
-    /// Emits one typed zero constant per return type and terminates the block.
+    /// For each return position, loads the current value from the named-return
+    /// slot when one was allocated, otherwise materializes a typed zero
+    /// constant.
     fn emit_default_return(
         &self,
         result_types: &[Type<'context>],
-        block: &melior::ir::BlockRef<'context, '_>,
+        return_slots: &[Option<Value<'context, '_>>],
+        block: &BlockRef<'context, '_>,
     ) {
         if block.terminator().is_some() {
             return;
         }
-        let zeros: Vec<_> = result_types
-            .iter()
-            .map(|ty| self.state.builder.emit_sol_constant(0, *ty, block))
-            .collect();
-        self.state.builder.emit_sol_return(&zeros, block);
+        let mut values: Vec<Value<'context, '_>> = Vec::with_capacity(result_types.len());
+        for (index, result_type) in result_types.iter().enumerate() {
+            let value = match return_slots.get(index).copied().flatten() {
+                Some(pointer) => self
+                    .state
+                    .builder
+                    .emit_sol_load(pointer, *result_type, block)
+                    .expect("named return slot loads with the declared type"),
+                None => self.state.builder.emit_sol_constant(0, *result_type, block),
+            };
+            values.push(value);
+        }
+        self.state.builder.emit_sol_return(&values, block);
     }
 
     /// Maps Slang's `FunctionMutability` to the Sol dialect's `StateMutability`.


### PR DESCRIPTION
Functions with named returns (`function f() returns (uint256 r) { r = 5; }`) panicked at the `unregistered local variable` arm in [`expression/mod.rs:171`](https://github.com/NomicFoundation/solx/blob/9ca5dd2ecdf557e1462c511cbfe5352e74b41817/solx-slang/src/ast/contract/function/expression/mod.rs#L171), [`assignment.rs:55`](https://github.com/NomicFoundation/solx/blob/9ca5dd2ecdf557e1462c511cbfe5352e74b41817/solx-slang/src/ast/contract/function/expression/assignment.rs#L55), and [`arithmetic.rs:219`](https://github.com/NomicFoundation/solx/blob/9ca5dd2ecdf557e1462c511cbfe5352e74b41817/solx-slang/src/ast/contract/function/expression/arithmetic.rs#L219). The function emitter at [`function/mod.rs:101`](https://github.com/NomicFoundation/solx/blob/9ca5dd2ecdf557e1462c511cbfe5352e74b41817/solx-slang/src/ast/contract/function/mod.rs#L101) only allocated and bound parameters, never named returns, so the binder resolved `r` to a `Definition::Variable`/`Definition::Parameter` but the lookup in the local environment returned `None`.

`emit_default_return` then needed updating: a function that falls off the end of its body must yield the current named-return values, not zeros, so the implicit return path now loads from each named-return slot when one was allocated.

Depends on #393.

Lit test: `solx-mlir/tests/lit/named_returns.sol`.

## Test deltas

vs base [`9ca5dd2`](https://github.com/NomicFoundation/solx/commit/9ca5dd2ecdf557e1462c511cbfe5352e74b41817) under `-O M3B3`:

| Suite | base | tip | Δ |
|---|---|---|---|
| `tests/solidity/simple/` | 1680 / 7 / 381 | 1684 / 7 / 379 | +4 PASSED, −2 INVALID, +2 newly discovered |
| `solx-solidity/test/libsolidity/semanticTests/` | 833 / 372 / 1162 | 1177 / 400 / 1123 | **+344 PASSED**, +28 FAILED, −39 INVALID, +333 newly discovered |

The `unregistered local variable` panic count drops from 104 (102 semantic + 2 simple) to 0.

Newly fully passing (39 files, 2 simple + 37 semantic):

<details>
<summary>List of newly fully passing files</summary>

- solx-solidity/test/libsolidity/semanticTests/cleanup/bool_conversion_v2.sol
- solx-solidity/test/libsolidity/semanticTests/expressions/conditional_expression_with_return_values.sol
- solx-solidity/test/libsolidity/semanticTests/expressions/inc_dec_operators.sol
- solx-solidity/test/libsolidity/semanticTests/functionCall/calling_other_functions.sol
- solx-solidity/test/libsolidity/semanticTests/functionCall/external_function.sol
- solx-solidity/test/libsolidity/semanticTests/functionCall/multiple_return_values.sol
- solx-solidity/test/libsolidity/semanticTests/integer/many_local_variables.sol
- solx-solidity/test/libsolidity/semanticTests/literals/ternary_operator_with_literal_types_overflow.sol
- solx-solidity/test/libsolidity/semanticTests/operators/shifts/shift_cleanup.sol
- solx-solidity/test/libsolidity/semanticTests/operators/shifts/shift_constant_left_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/operators/shifts/shift_constant_right_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/scoping/c99_scoping_activation.sol
- solx-solidity/test/libsolidity/semanticTests/statements/empty_for_loop.sol
- solx-solidity/test/libsolidity/semanticTests/types/packing_unpacking_types.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/assert.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/assert_and_require.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_cast_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_cast_local_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_add_overflow.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_add_overflow_signed.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_div_overflow.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_mod_zero.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_mod_zero_signed.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_mul_overflow.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_mul_overflow_signed.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_sub_overflow.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/detect_sub_overflow_signed.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/if.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/local_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/local_bool_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/loops/break.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/loops/continue.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/loops/return.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/loops/simple.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/short_circuit.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/simple_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/storage/simple_storage.sol
- tests/solidity/simple/function/many_arguments_1.sol
- tests/solidity/simple/function/many_arguments_1_types.sol

</details>