### PR TITLE
feat(slang): wire abi.encode, abi.encodePacked, abi.encodeWithSelector, abi.encodeWithSignature, abi.decode

### DIFF
--- a/solx-mlir/tests/lit/abi_coding.sol
+++ b/solx-mlir/tests/lit/abi_coding.sol
@@ -1,0 +1,32 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s --check-prefixes=CHECK,CHECK-SOLX
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s --check-prefixes=CHECK,CHECK-SOLC
+
+// CHECK-SOLX: sol.func @"encode(uint256,address)"
+// CHECK-SOLC: sol.func @encode_{{[0-9]+}}
+// CHECK:   sol.encode {{.*}} : ui256, !sol.address : !sol.string<Memory>
+// CHECK-SOLX: sol.func @"encodePacked(uint256,address)"
+// CHECK-SOLC: sol.func @encodePacked_{{[0-9]+}}
+// CHECK:   sol.encode {{.*}} : ui256, !sol.address : !sol.string<Memory> {packed}
+// CHECK-SOLX: sol.func @"encodeWithSelector(bytes4,uint256)"
+// CHECK-SOLC: sol.func @encodeWithSelector_{{[0-9]+}}
+// CHECK:   sol.encode selector(%{{.*}}) %{{.*}} : !sol.fixedbytes<4> ui256 : !sol.string<Memory>
+// CHECK-SOLX: sol.func @"encodeWithSelectorTwo(bytes4,uint256,address)"
+// CHECK-SOLC: sol.func @encodeWithSelectorTwo_{{[0-9]+}}
+// CHECK:   sol.encode selector(%{{.*}}) %{{.*}}, %{{.*}} : !sol.fixedbytes<4> ui256, !sol.address : !sol.string<Memory>
+// CHECK-SOLX: sol.func @"encodeWithSignature(uint256)"
+// CHECK-SOLC: sol.func @encodeWithSignature_{{[0-9]+}}
+// CHECK:   sol.constant 801029432 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK:   sol.encode selector(%{{.*}}) %{{.*}} : !sol.fixedbytes<4> ui256 : !sol.string<Memory>
+// CHECK-SOLX: sol.func @"decode(bytes)"
+// CHECK-SOLC: sol.func @decode_{{[0-9]+}}
+// CHECK:   sol.decode {{.*}} : !sol.string<Memory> -> ui256
+
+contract C {
+    function encode(uint256 x, address y) public pure returns (bytes memory) { return abi.encode(x, y); }
+    function encodePacked(uint256 x, address y) public pure returns (bytes memory) { return abi.encodePacked(x, y); }
+    function encodeWithSelector(bytes4 s, uint256 x) public pure returns (bytes memory) { return abi.encodeWithSelector(s, x); }
+    function encodeWithSelectorTwo(bytes4 s, uint256 x, address y) public pure returns (bytes memory) { return abi.encodeWithSelector(s, x, y); }
+    function encodeWithSignature(uint256 x) public pure returns (bytes memory) { return abi.encodeWithSignature("foo(uint256)", x); }
+    function decode(bytes memory data) public pure returns (uint256) { return abi.decode(data, (uint256)); }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -2,27 +2,37 @@
 //! Solidity built-in function and EVM intrinsic lowering.
 //!
 
+use melior::ir::Attribute;
 use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Operation;
+use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::attribute::DenseI32ArrayAttribute;
+use melior::ir::operation::OperationMutLike;
+use melior::ir::r#type::IntegerType;
 use slang_solidity::backend::built_ins::BuiltIn;
 use slang_solidity::backend::ir::ast::Expression;
+use slang_solidity::backend::ir::ast::FunctionCallExpression;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
 use slang_solidity::backend::ir::ast::PositionalArguments;
+use slang_solidity::backend::ir::ast::Type as SlangType;
 use solx_mlir::ods::sol::AddModOperation;
 use solx_mlir::ods::sol::BalanceOperation;
 use solx_mlir::ods::sol::BaseFeeOperation;
 use solx_mlir::ods::sol::BlobBaseFeeOperation;
 use solx_mlir::ods::sol::BlockNumberOperation;
+use solx_mlir::ods::sol::BytesCastOperation;
 use solx_mlir::ods::sol::CallValueOperation;
 use solx_mlir::ods::sol::CallerOperation;
 use solx_mlir::ods::sol::ChainIdOperation;
 use solx_mlir::ods::sol::CodeHashOperation;
 use solx_mlir::ods::sol::CodeOperation;
 use solx_mlir::ods::sol::CoinbaseOperation;
+use solx_mlir::ods::sol::DecodeOperation;
 use solx_mlir::ods::sol::DifficultyOperation;
 use solx_mlir::ods::sol::EcrecoverOperation;
+use solx_mlir::ods::sol::EncodeOperation;
 use solx_mlir::ods::sol::GasLeftOperation;
 use solx_mlir::ods::sol::GasLimitOperation;
 use solx_mlir::ods::sol::GasPriceOperation;
@@ -40,6 +50,7 @@ use solx_mlir::ods::sol::TimestampOperation;
 use solx_mlir::ods::sol::TransferOperation;
 
 use crate::ast::contract::function::expression::call::CallEmitter;
+use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
 
 impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context, 'block> {
     /// Tries to emit `callee(arguments)` as a Solidity built-in.
@@ -207,6 +218,29 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         }
     }
 
+    /// Tries to emit a built-in that needs the full [`FunctionCallExpression`]
+    /// context — typically because the result type comes from `call.get_type()`
+    /// rather than from the operands (e.g. `abi.decode(payload, (T))`).
+    ///
+    /// Resolves the callee's member access to a [`BuiltIn`] variant and
+    /// dispatches to the matching handler. Returns `Ok(Some((value, block)))`
+    /// on match, `Ok(None)` if no handler matched and the caller should
+    /// fall through to other dispatch.
+    pub fn try_emit_built_in_call_expression(
+        &self,
+        call: &FunctionCallExpression,
+        arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<(Value<'context, 'block>, BlockRef<'context, 'block>)>> {
+        let Expression::MemberAccessExpression(access) = call.operand() else {
+            return Ok(None);
+        };
+        match access.member().resolved_built_in() {
+            Some(BuiltIn::AbiDecode) => self.emit_abi_decode(call, arguments, block).map(Some),
+            _ => Ok(None),
+        }
+    }
+
     /// Emits a member access expression as an EVM intrinsic.
     ///
     /// Resolves the member via slang's binder to a specific `BuiltIn` variant
@@ -294,6 +328,68 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                         .into(),
                 );
                 Ok((None, block))
+            }
+            Some(BuiltIn::AbiEncode) => {
+                let arguments = arguments.expect("abi.encode is a member-access call");
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let result = self.emit_sol_encode(&values, None, false, &block);
+                Ok((Some(result), block))
+            }
+            Some(BuiltIn::AbiEncodePacked) => {
+                let arguments = arguments.expect("abi.encodePacked is a member-access call");
+                let (values, block) = self.emit_argument_values(arguments, block)?;
+                let result = self.emit_sol_encode(&values, None, true, &block);
+                Ok((Some(result), block))
+            }
+            Some(BuiltIn::AbiEncodeWithSelector) => {
+                let arguments = arguments.expect("abi.encodeWithSelector is a member-access call");
+                let (mut values, block) = self.emit_argument_values(arguments, block)?;
+                let selector =
+                    builder.emit_sol_cast(values.remove(0), builder.types.fixed_bytes(4), &block);
+                let result = self.emit_sol_encode(&values, Some(selector), false, &block);
+                Ok((Some(result), block))
+            }
+            Some(BuiltIn::AbiEncodeWithSignature) => {
+                let arguments = arguments.expect("abi.encodeWithSignature is a member-access call");
+                let mut iter = arguments.iter();
+                let signature_expression =
+                    iter.next().expect("slang validates non-empty arguments");
+                let Expression::StringExpression(string_expression) = signature_expression else {
+                    unimplemented!(
+                        "abi.encodeWithSignature with a non-literal signature is not yet supported"
+                    );
+                };
+                let signature_bytes = string_expression.value();
+                let hash = solx_utils::Keccak256Hash::from_slice(&signature_bytes);
+                let selector_bytes: [u8; 4] = hash.as_bytes()[..4]
+                    .try_into()
+                    .expect("keccak256 always yields 32 bytes");
+                let selector_word = u32::from_be_bytes(selector_bytes);
+                let selector_int = builder.emit_sol_constant(
+                    i64::from(selector_word),
+                    Type::from(IntegerType::unsigned(builder.context, 32)),
+                    &block,
+                );
+                let selector_value = block
+                    .append_operation(
+                        BytesCastOperation::builder(builder.context, builder.unknown_location)
+                            .inp(selector_int)
+                            .out(builder.types.fixed_bytes(4))
+                            .build()
+                            .into(),
+                    )
+                    .result(0)
+                    .expect("sol.bytes_cast always produces one result")
+                    .into();
+                let mut values = Vec::with_capacity(arguments.len() - 1);
+                let mut current = block;
+                for argument in iter {
+                    let (value, next) = self.expression_emitter.emit_value(&argument, current)?;
+                    values.push(value);
+                    current = next;
+                }
+                let result = self.emit_sol_encode(&values, Some(selector_value), false, &current);
+                Ok((Some(result), current))
             }
             resolved => {
                 let operation = match resolved {
@@ -441,6 +537,89 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             current = next;
         }
         Ok((values, current))
+    }
+
+    /// Emits a `sol.encode` operation producing a `bytes memory` payload.
+    ///
+    /// `selector`, when present, is prepended as the first 4 bytes of the
+    /// payload and must already be of `!sol.fixed_bytes<4>` type. `packed`
+    /// emits the ABI-packed encoding (no per-element padding).
+    ///
+    /// Sets `operand_segment_sizes` manually because melior's ODS-generated
+    /// builder does not synthesize the attribute for `AttrSizedOperandSegments`
+    /// ops; the dialect verifier rejects the op without it.
+    fn emit_sol_encode(
+        &self,
+        ins: &[Value<'context, 'block>],
+        selector: Option<Value<'context, 'block>>,
+        packed: bool,
+        block: &BlockRef<'context, 'block>,
+    ) -> Value<'context, 'block> {
+        let builder = &self.expression_emitter.state.builder;
+        let mut op_builder = EncodeOperation::builder(builder.context, builder.unknown_location)
+            .ins(ins)
+            .res(builder.types.sol_string_memory);
+        if let Some(selector_value) = selector {
+            op_builder = op_builder.selector(selector_value);
+        }
+        if packed {
+            op_builder = op_builder.packed(Attribute::unit(builder.context));
+        }
+        let mut operation: Operation = op_builder.build().into();
+        // TODO: drop this manual segment-sizes plumbing once the melior op-builder
+        // macro emits `operand_segment_sizes` automatically for ops with variadic
+        // or optional operand groups.
+        let ins_count = i32::try_from(ins.len()).expect("encode argument count fits in i32");
+        let segment_sizes = DenseI32ArrayAttribute::new(
+            builder.context,
+            &[ins_count, i32::from(selector.is_some())],
+        );
+        operation.set_inherent_attribute("operand_segment_sizes", segment_sizes.into());
+        block
+            .append_operation(operation)
+            .result(0)
+            .expect("sol.encode always produces one result")
+            .into()
+    }
+
+    /// Emits `abi.decode(payload, (T))` as a `sol.decode` operation.
+    ///
+    /// The result type comes from the call's slang type (`call.get_type()`);
+    /// multi-result decode requires the multi-result-call dispatch and is
+    /// not yet supported.
+    fn emit_abi_decode(
+        &self,
+        call: &FunctionCallExpression,
+        arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
+        let payload_expression = arguments
+            .iter()
+            .next()
+            .expect("slang validates the payload argument");
+        let (payload_value, block) = self
+            .expression_emitter
+            .emit_value(&payload_expression, block)?;
+        let return_slang_type = call
+            .get_type()
+            .expect("abi.decode call is typed by the binder");
+        if matches!(return_slang_type, SlangType::Tuple(_)) {
+            unimplemented!("abi.decode returning multiple values is not yet supported");
+        }
+        let builder = &self.expression_emitter.state.builder;
+        let result_type = TypeConversion::resolve_slang_type(&return_slang_type, None, builder);
+        let value = block
+            .append_operation(
+                DecodeOperation::builder(builder.context, builder.unknown_location)
+                    .addr(payload_value)
+                    .outs(&[result_type])
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("abi.decode single-result always produces one value")
+            .into();
+        Ok((value, block))
     }
 
     /// Emits an `assert(condition)` built-in via `sol.assert`.

--- a/solx-slang/src/ast/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/mod.rs
@@ -79,6 +79,12 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             return Ok((value, block));
         }
 
+        if let Some((value, block)) =
+            self.try_emit_built_in_call_expression(call, positional_arguments, block)?
+        {
+            return Ok((Some(value), block));
+        }
+
         if let Expression::MemberAccessExpression(access) = &callee {
             return self.emit_built_in_member_access(access, Some(positional_arguments), block);
         }

--- a/solx-utils/src/hash/keccak256.rs
+++ b/solx-utils/src/hash/keccak256.rs
@@ -33,6 +33,13 @@ impl Keccak256 {
     }
 
     ///
+    /// Returns a reference to the 32-byte binary representation.
+    ///
+    pub fn as_bytes(&self) -> &[u8; crate::BYTE_LENGTH_FIELD] {
+        &self.bytes
+    }
+
+    ///
     /// Extracts the binary representation.
     ///
     pub fn to_vec(&self) -> Vec<u8> {


### PR DESCRIPTION
Routes the slang `BuiltIn::Abi*` member-access calls to `sol.encode` and `sol.decode` so the front-end can lower bytes-coding intrinsics that previously fell through to `unsupported member access`.

## Encoding

`abi.encode` and `abi.encodePacked` collect each argument value and build a `sol.encode` op with the appropriate `packed` UnitAttr; the result is `!sol.string<Memory>`.

`abi.encodeWithSelector(s, ...)` casts the first argument to `!sol.fixedbytes<4>` and feeds the remaining arguments as the encoded tuple.

`abi.encodeWithSignature("f(...)", ...)` is restricted to literal-string signatures: the selector is computed at compile time as `keccak256(signature)[0..4]`, materialized as a `ui32` constant, then `sol.bytes_cast` to `!sol.fixedbytes<4>`. Runtime-string signatures raise a not-yet-supported error.

`sol.encode` carries `AttrSizedOperandSegments` and melior's ODS-generated builder does not synthesize `operand_segment_sizes` for that trait, so the encode helper sets the attribute manually before appending the op.

## Decoding

`abi.decode(payload, (T))` is dispatched at the call-expression level (`try_emit_call_expression`) because the result type comes from the call's slang type, not from the member identifier. Single-result decode emits `sol.decode %payload : !sol.string<Memory> -> T`. Multi-result decode (Tuple result type) raises a not-yet-supported error pending the multi-result-call dispatch.

## Tests

A new lit test [`solx-mlir/tests/lit/abi_coding.sol`](https://github.com/NomicFoundation/solx/blob/feat-slang-abi-coding/solx-mlir/tests/lit/abi_coding.sol) exercises all five variants in dual-mode against solc and solx. Full lit suite stays 41/41, 200 unit tests + cargo fmt/clippy green under `--features slang`.

| Suite | base | tip | Δ |
|---|---|---|---|
| `tests/solidity/simple/` | 1680 / 7 / 381 | 1684 / 7 / 379 | +4 PASSED, −2 INVALID, +2 newly discovered |
| `solx-solidity/test/libsolidity/semanticTests/` | 833 / 372 / 1162 | 880 / 373 / 1152 | **+47 PASSED**, +1 FAILED, −10 INVALID, +38 newly discovered |

Newly fully passing:

- solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/abi_decode_dynamic_array.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/abi_decode_trivial.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/abi_decode_v2_calldata.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/abi_encode_rational.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV1/memory_dynamic_array_and_calldata_bytes.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_rational_v2.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_static_reencode.sol
- solx-solidity/test/libsolidity/semanticTests/abiEncoderV2/memory_dynamic_array_and_calldata_bytes.sol
- solx-solidity/test/libsolidity/semanticTests/calldata/calldata_bytes_to_memory_encode.sol
- tests/solidity/simple/recursion_keccak.sol
- tests/solidity/simple/recursion/recursion_keccak.sol