### PR TITLE
feat(slang): wire IndexAccessExpression to sol.gep / sol.map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3491,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
+checksum = "11353f234577a63048066df974d8a56e8c090d4de8b5f7d5f2a0d0c3a1ffaa2d"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3510,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf",
@@ -3522,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "15.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3539,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "16.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3555,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "12.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3569,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -3583,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
+checksum = "f18b03319aee860ecc4631c9180abb0828480f5a4c39507fc735a417bd906984"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3602,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
+checksum = "f33e8327376dff859eb18dea3623aa55ef5d580fe38fa0fd4bb92bd95ace60ad"
 dependencies = [
  "auto_impl",
  "either",
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
+checksum = "8e5f438f47d40d9830c0498fa3ca16a447b3148ab7b78742cbb1b27a51a50963"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3633,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "1c07bfcc9361f7b23970a68cbd17bfe255e70182cfb1a8896d06832217fc5439"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3649,6 +3649,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
@@ -3657,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3669,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -3830,7 +3831,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4704,7 +4705,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4886,17 +4887,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4909,24 +4910,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5568,6 +5578,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2570,8 +2570,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaslang_bindings"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
+version = "1.3.4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=eaf0bb3b9ef6359dd5f3769575993f0311340f21#eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -2582,8 +2582,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_cst"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
+version = "1.3.4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=eaf0bb3b9ef6359dd5f3769575993f0311340f21#eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 dependencies = [
  "nom 8.0.0",
  "serde",
@@ -2592,8 +2592,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_graph_builder"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
+version = "1.3.4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=eaf0bb3b9ef6359dd5f3769575993f0311340f21#eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -2606,8 +2606,8 @@ dependencies = [
 
 [[package]]
 name = "metaslang_stack_graphs"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
+version = "1.3.4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=eaf0bb3b9ef6359dd5f3769575993f0311340f21#eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 dependencies = [
  "bitvec",
  "controlled-option",
@@ -3491,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "37.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11353f234577a63048066df974d8a56e8c090d4de8b5f7d5f2a0d0c3a1ffaa2d"
+checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3510,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "10.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf",
@@ -3522,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3539,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3555,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3569,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
 dependencies = [
  "auto_impl",
  "either",
@@ -3583,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18b03319aee860ecc4631c9180abb0828480f5a4c39507fc735a417bd906984"
+checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3602,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "18.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33e8327376dff859eb18dea3623aa55ef5d580fe38fa0fd4bb92bd95ace60ad"
+checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
 dependencies = [
  "auto_impl",
  "either",
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5f438f47d40d9830c0498fa3ca16a447b3148ab7b78742cbb1b27a51a50963"
+checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3633,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "33.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c07bfcc9361f7b23970a68cbd17bfe255e70182cfb1a8896d06832217fc5439"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3649,7 +3649,6 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
@@ -3658,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "23.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3670,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "11.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -3831,7 +3830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4276,8 +4275,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slang_solidity"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=0a0ba100ef74c1001e256bea94c5a285c93170ca#0a0ba100ef74c1001e256bea94c5a285c93170ca"
+version = "1.3.4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=eaf0bb3b9ef6359dd5f3769575993f0311340f21#eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 dependencies = [
  "indexmap 2.14.0",
  "metaslang_bindings",
@@ -4705,7 +4704,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4887,17 +4886,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -4910,33 +4909,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -5578,12 +5568,6 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ features = [
 [workspace.dependencies.slang_solidity]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "0a0ba100ef74c1001e256bea94c5a285c93170ca"
+rev = "eaf0bb3b9ef6359dd5f3769575993f0311340f21"
 # `__private_testing_utils` is required by `__private_backend_api` internals
 # (binder/types access in node_extensions). Both are unstable Slang APIs.
 features = ["__private_backend_api", "__private_testing_utils"]

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -45,8 +45,10 @@ use crate::ods::sol::ContractOperation;
 use crate::ods::sol::DoWhileOperation;
 use crate::ods::sol::ForOperation;
 use crate::ods::sol::FuncOperation;
+use crate::ods::sol::GepOperation;
 use crate::ods::sol::IfOperation;
 use crate::ods::sol::LoadOperation;
+use crate::ods::sol::MapOperation;
 use crate::ods::sol::RequireOperation;
 use crate::ods::sol::ReturnOperation;
 use crate::ods::sol::RevertOperation;
@@ -742,6 +744,64 @@ impl<'context> Builder<'context> {
                 .build()
                 .into(),
         );
+    }
+
+    /// Emits a `sol.gep` for array / `bytes` / `string` element access.
+    ///
+    /// `address_type` is the result address type the caller has computed
+    /// (typically `!sol.ptr<element, location>` for primitive elements).
+    pub fn emit_sol_gep<'block, B>(
+        &self,
+        base_address: Value<'context, 'block>,
+        index: Value<'context, 'block>,
+        address_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block
+            .append_operation(
+                GepOperation::builder(self.context, self.unknown_location)
+                    .base_addr(base_address)
+                    .idx(index)
+                    .addr(address_type)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.gep always produces one result")
+            .into()
+    }
+
+    /// Emits a `sol.map` for mapping value access by key.
+    ///
+    /// `address_type` is the result address type the caller has computed
+    /// (typically `!sol.ptr<value, Storage>` for primitive value types).
+    pub fn emit_sol_map<'block, B>(
+        &self,
+        mapping: Value<'context, 'block>,
+        key: Value<'context, 'block>,
+        address_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block
+            .append_operation(
+                MapOperation::builder(self.context, self.unknown_location)
+                    .mapping(mapping)
+                    .key(key)
+                    .addr(address_type)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.map always produces one result")
+            .into()
     }
 
     // ==== Calls ====

--- a/solx-mlir/tests/lit/index_access.sol
+++ b/solx-mlir/tests/lit/index_access.sol
@@ -1,0 +1,33 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s --check-prefixes=CHECK,CHECK-SOLX
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s --check-prefixes=CHECK,CHECK-SOLC
+
+// CHECK: sol.func {{.*}}readArray{{.*}}-> ui256
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.array<? x ui256, Memory>, ui256, !sol.ptr<ui256, Memory>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Memory>, ui256
+
+// CHECK: sol.func {{.*}}readBytes{{.*}}-> !sol.fixedbytes<1>
+// CHECK-SOLX:   sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui256, !sol.ptr<!sol.fixedbytes<1>, Memory>
+// CHECK-SOLX:   sol.load %{{.*}} : !sol.ptr<!sol.fixedbytes<1>, Memory>, !sol.fixedbytes<1>
+// CHECK-SOLC:   sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui256, !sol.ptr<!sol.byte, Memory>
+// CHECK-SOLC:   sol.load %{{.*}} : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK-SOLC:   sol.bytes_cast %{{.*}} : !sol.byte to !sol.fixedbytes<1>
+
+// CHECK: sol.func {{.*}}readMapping{{.*}}-> ui256
+// CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui256, !sol.ptr<ui256, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+
+contract C {
+    mapping(uint256 => uint256) m;
+
+    function readArray(uint256[] memory a, uint256 i) public pure returns (uint256) {
+        return a[i];
+    }
+
+    function readBytes(bytes memory data, uint256 i) public pure returns (bytes1) {
+        return data[i];
+    }
+
+    function readMapping(uint256 k) public view returns (uint256) {
+        return m[k];
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -1,0 +1,112 @@
+//!
+//! Index access expression lowering: `a[i]`, `m[k]`, `s[i]`.
+//!
+
+use melior::ir::BlockRef;
+use melior::ir::Type;
+use melior::ir::Value;
+use slang_solidity::backend::ir::ast::IndexAccessExpression;
+use slang_solidity::backend::ir::ast::Type as SlangType;
+use slang_solidity::backend::types::DataLocation as SlangDataLocation;
+
+use solx_mlir::Builder;
+use solx_utils::DataLocation;
+
+use crate::ast::contract::function::expression::ExpressionEmitter;
+use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
+
+impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
+    /// Lowers `a[i]` / `m[k]` for arrays, dynamic `bytes`, mappings, and
+    /// strings to `sol.gep` (sequential containers) or `sol.map` (mappings),
+    /// followed by a `sol.load` of the addressed element.
+    pub fn emit_index_access(
+        &self,
+        index_access: &IndexAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        if index_access.end().is_some() {
+            unimplemented!("range index (a[i:j]) is not yet supported");
+        }
+
+        let base = index_access.operand();
+        let index_expression = index_access
+            .start()
+            .expect("slang validates a[i] has an index expression");
+        let base_slang_type = base
+            .get_type()
+            .ok_or_else(|| anyhow::anyhow!("base of index access has no resolved type"))?;
+        let result_slang_type = index_access
+            .get_type()
+            .expect("slang types every index-access expression");
+
+        let (base_value, block) = self.emit_value(&base, block)?;
+        let (index_value, block) = self.emit_value(&index_expression, block)?;
+
+        let element_type =
+            TypeConversion::resolve_slang_type(&result_slang_type, None, &self.state.builder);
+        let base_location = Self::resolve_base_location(&base_slang_type);
+        let address_type = Self::address_type(
+            &self.state.builder,
+            element_type,
+            base_location,
+            &result_slang_type,
+        );
+
+        let address = match &base_slang_type {
+            SlangType::Mapping(_) => {
+                self.state
+                    .builder
+                    .emit_sol_map(base_value, index_value, address_type, &block)
+            }
+            _ => self
+                .state
+                .builder
+                .emit_sol_gep(base_value, index_value, address_type, &block),
+        };
+        let value = self
+            .state
+            .builder
+            .emit_sol_load(address, element_type, &block)?;
+
+        Ok((Some(value), block))
+    }
+
+    /// Maps a slang container type's data location to the dialect-side
+    /// `DataLocation`.
+    fn resolve_base_location(base_slang_type: &SlangType) -> DataLocation {
+        match base_slang_type.data_location() {
+            Some(SlangDataLocation::Inherited) => unimplemented!(
+                "index access through Inherited (struct-field) location is not yet supported"
+            ),
+            Some(other) => DataLocation::from_slang(other, None),
+            None => unimplemented!(
+                "index access base of unsupported type kind: {:?}",
+                std::mem::discriminant(base_slang_type)
+            ),
+        }
+    }
+
+    /// Picks the MLIR type of the address yielded by `sol.gep` / `sol.map`.
+    ///
+    /// Mirrors `Sol_GepOp::build`'s non-ptr-ref-in-storage rule: when the
+    /// element is itself a reference type and lives in `Storage` or
+    /// `CallData`, the result address IS the element type rather than a
+    /// pointer to it.
+    fn address_type(
+        builder: &Builder<'context>,
+        element_type: Type<'context>,
+        base_location: DataLocation,
+        result_slang_type: &SlangType,
+    ) -> Type<'context> {
+        if result_slang_type.is_reference_type()
+            && matches!(
+                base_location,
+                DataLocation::Storage | DataLocation::CallData
+            )
+        {
+            element_type
+        } else {
+            builder.types.pointer(element_type, base_location)
+        }
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -63,10 +63,13 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 .builder
                 .emit_sol_gep(base_value, index_value, address_type, &block),
         };
-        let value = self
-            .state
-            .builder
-            .emit_sol_load(address, element_type, &block)?;
+        let value = if address_type == element_type {
+            address
+        } else {
+            self.state
+                .builder
+                .emit_sol_load(address, element_type, &block)?
+        };
 
         Ok((Some(value), block))
     }
@@ -75,12 +78,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// `DataLocation`.
     fn resolve_base_location(base_slang_type: &SlangType) -> DataLocation {
         match base_slang_type.data_location() {
-            Some(SlangDataLocation::Inherited) => unimplemented!(
-                "index access through Inherited (struct-field) location is not yet supported"
-            ),
+            Some(SlangDataLocation::Inherited) => {
+                unreachable!("slang should not surface Inherited at an index-access base")
+            }
             Some(other) => DataLocation::from_slang(other, None),
             None => unimplemented!(
-                "index access base of unsupported type kind: {:?}",
+                "index access on a value-typed base is not yet wired: {:?}",
                 std::mem::discriminant(base_slang_type)
             ),
         }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -2,6 +2,7 @@
 //! Expression lowering to MLIR SSA values.
 //!
 
+pub mod access;
 pub mod arithmetic;
 pub mod assignment;
 pub mod call;
@@ -329,6 +330,9 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .emit_sol_load(result_slot, result_type, &block)?;
 
                 Ok((Some(result), block))
+            }
+            Expression::IndexAccessExpression(index_access) => {
+                self.emit_index_access(index_access, block)
             }
             _ => anyhow::bail!(
                 "unsupported expression: {:?}",


### PR DESCRIPTION
Lowers `a[i]` / `m[k]` for arrays, dynamic `bytes`, mappings, and strings, branched off `feat-slang-extend-type-resolution`.

Not yet wired: range slicing `a[i:j]`, struct-field index, nested-ref element types, and the assignment-target lvalue path.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1662 | 1722 | +60 |
| FAILED | 7 | 13 | +6 |
| INVALID | 383 | 367 | −16 |
| Total | 2052 | 2102 | +50 |

The +6 FAILED are tests that previously couldn't compile and now compile but trip a runtime semantic check.

Newly passing:

- tests/solidity/simple/array/store_load_nested_witness_array_witness_index.sol
- tests/solidity/simple/array/store_load_witness_array_witness_index.sol
- tests/solidity/simple/conditional/nested_gates_mutating.sol
- tests/solidity/simple/conditional/nested_gates.sol
- tests/solidity/simple/loop/array/inclusive_lower_half.sol
- tests/solidity/simple/loop/array/inclusive_middle_half.sol
- tests/solidity/simple/loop/array/inclusive_upper_half.sol
- tests/solidity/simple/loop/array/simple_lower_half.sol
- tests/solidity/simple/loop/array/simple_middle_half.sol
- tests/solidity/simple/loop/array/simple_upper_half.sol
- tests/solidity/simple/storage/aligned/array/product.sol
- tests/solidity/simple/storage/aligned/array/sum.sol
- tests/solidity/simple/storage/unaligned/array/default_init.sol
- tests/solidity/simple/storage/unaligned/array/mutating_one_element.sol
- tests/solidity/simple/storage/unaligned/array/product.sol
- tests/solidity/simple/storage/unaligned/array/sum.sol
