### PR TITLE
feat(slang): wire array push/pop and array literals

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -33,6 +33,7 @@ use crate::context::builder::type_factory::TypeFactory;
 use crate::ods::sol::AddrOfOperation;
 use crate::ods::sol::AddressCastOperation;
 use crate::ods::sol::AllocaOperation;
+use crate::ods::sol::ArrayLitOperation;
 use crate::ods::sol::AssertOperation;
 use crate::ods::sol::BreakOperation;
 use crate::ods::sol::CallOperation;
@@ -49,6 +50,8 @@ use crate::ods::sol::GepOperation;
 use crate::ods::sol::IfOperation;
 use crate::ods::sol::LoadOperation;
 use crate::ods::sol::MapOperation;
+use crate::ods::sol::PopOperation;
+use crate::ods::sol::PushOperation;
 use crate::ods::sol::RequireOperation;
 use crate::ods::sol::ReturnOperation;
 use crate::ods::sol::RevertOperation;
@@ -801,6 +804,72 @@ impl<'context> Builder<'context> {
             )
             .result(0)
             .expect("sol.map always produces one result")
+            .into()
+    }
+
+    /// Emits a `sol.push` returning a reference to the newly appended slot.
+    ///
+    /// `address_type` is the result reference type the caller has computed
+    /// (typically `!sol.ptr<element, Storage>` for primitive element types).
+    pub fn emit_sol_push<'block, B>(
+        &self,
+        array: Value<'context, 'block>,
+        address_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block
+            .append_operation(
+                PushOperation::builder(self.context, self.unknown_location)
+                    .inp(array)
+                    .addr(address_type)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.push always produces one result")
+            .into()
+    }
+
+    /// Emits a `sol.pop` removing the last element from the array.
+    pub fn emit_sol_pop<'block, B>(&self, array: Value<'context, 'block>, block: &B)
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block.append_operation(
+            PopOperation::builder(self.context, self.unknown_location)
+                .inp(array)
+                .build()
+                .into(),
+        );
+    }
+
+    /// Emits a `sol.array_lit` constructing an array from `elements` of the
+    /// caller-provided `array_type` (typically `!sol.array<N x T, Memory>`).
+    pub fn emit_sol_array_lit<'block, B>(
+        &self,
+        elements: &[Value<'context, 'block>],
+        array_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        block
+            .append_operation(
+                ArrayLitOperation::builder(self.context, self.unknown_location)
+                    .ins(elements)
+                    .addr(array_type)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.array_lit always produces one result")
             .into()
     }
 

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -1,0 +1,43 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}pushValue
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func {{.*}}pushEmpty
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK-NOT: sol.store
+// CHECK: sol.func {{.*}}popLast
+// CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>
+
+// CHECK: sol.func {{.*}}popByte
+// CHECK:   sol.pop %{{.*}} : !sol.string<Storage>
+
+// CHECK: sol.func {{.*}}makeLiteral{{.*}}-> !sol.array<3 x ui256, Memory>
+// CHECK:   sol.array_lit %{{.*}}, %{{.*}}, %{{.*}} : (ui256, ui256, ui256) -> !sol.array<3 x ui256, Memory>
+
+contract C {
+    uint256[] arr;
+    bytes data;
+
+    function pushValue(uint256 x) public {
+        arr.push(x);
+    }
+
+    function pushEmpty() public {
+        arr.push();
+    }
+
+    function popLast() public {
+        arr.pop();
+    }
+
+    function popByte() public {
+        data.pop();
+    }
+
+    function makeLiteral(uint256 a, uint256 b, uint256 c) public pure returns (uint256[3] memory) {
+        return [a, b, c];
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -535,29 +535,27 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         if value_argument.is_some() && matches!(&base_slang_type, SlangType::Bytes(_)) {
             unimplemented!("bytes.push(x) lowers to sol.push_string, which is not yet wired");
         }
+        let builder = &self.expression_emitter.state.builder;
 
-        let (element_slang_type, slang_location) = match &base_slang_type {
-            SlangType::Array(array_type) => {
-                (Some(array_type.element_type()), array_type.location())
-            }
-            SlangType::Bytes(bytes_type) => (None, bytes_type.location()),
+        let (element_type, slang_location) = match &base_slang_type {
+            SlangType::Array(array_type) => (
+                TypeConversion::resolve_slang_type(&array_type.element_type(), None, builder),
+                array_type.location(),
+            ),
+            SlangType::Bytes(bytes_type) => (builder.types.fixed_bytes(1), bytes_type.location()),
             other => unreachable!(
                 "Solidity's .push is a member of dynamic arrays and bytes only; got {:?}",
                 std::mem::discriminant(other)
             ),
         };
         let base_location = match slang_location {
-            SlangDataLocation::Inherited => unimplemented!(
-                "array push through Inherited (struct-field) location is not yet supported"
-            ),
+            SlangDataLocation::Inherited => {
+                unreachable!("slang's binder should not surface Inherited at an array push base")
+            }
             other => solx_utils::DataLocation::from_slang(other, None),
         };
 
         let (array_value, block) = self.expression_emitter.emit_value(&base, block)?;
-        let builder = &self.expression_emitter.state.builder;
-        let element_type = element_slang_type
-            .map(|slang_type| TypeConversion::resolve_slang_type(&slang_type, None, builder))
-            .unwrap_or_else(|| builder.types.fixed_bytes(1));
         let address_type = builder.types.pointer(element_type, base_location);
         let new_slot = builder.emit_sol_push(array_value, address_type, &block);
 

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -17,6 +17,7 @@ use slang_solidity::backend::ir::ast::FunctionCallExpression;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
 use slang_solidity::backend::ir::ast::PositionalArguments;
 use slang_solidity::backend::ir::ast::Type as SlangType;
+use slang_solidity::backend::types::DataLocation as SlangDataLocation;
 use solx_mlir::ods::sol::AddModOperation;
 use solx_mlir::ods::sol::BalanceOperation;
 use solx_mlir::ods::sol::BaseFeeOperation;
@@ -391,6 +392,11 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 let result = self.emit_sol_encode(&values, Some(selector_value), false, &current);
                 Ok((Some(result), current))
             }
+            Some(BuiltIn::ArrayPop) => self.emit_array_pop(access, block),
+            Some(BuiltIn::ArrayPush(_)) => {
+                let arguments = arguments.expect("array push is a member-access call");
+                self.emit_array_push(access, arguments, block)
+            }
             resolved => {
                 let operation = match resolved {
                     Some(BuiltIn::TxOrigin) => {
@@ -494,6 +500,75 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
                 Ok((Some(value), block))
             }
         }
+    }
+
+    /// Emits `arr.pop()` / `bytes.pop()` as `sol.pop`.
+    fn emit_array_pop(
+        &self,
+        access: &MemberAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        let (array_value, block) = self
+            .expression_emitter
+            .emit_value(&access.operand(), block)?;
+        self.expression_emitter
+            .state
+            .builder
+            .emit_sol_pop(array_value, &block);
+        Ok((None, block))
+    }
+
+    /// Emits `arr.push(x)` / `arr.push()` / `bytes.push()` as `sol.push`,
+    /// followed by `sol.store` of the cast value when one is provided.
+    /// Returns the new slot reference for the no-arg form, otherwise `None`.
+    fn emit_array_push(
+        &self,
+        access: &MemberAccessExpression,
+        arguments: &PositionalArguments,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        let base = access.operand();
+        let base_slang_type = base
+            .get_type()
+            .ok_or_else(|| anyhow::anyhow!("base of array push has no resolved type"))?;
+        let value_argument = arguments.iter().next();
+        if value_argument.is_some() && matches!(&base_slang_type, SlangType::Bytes(_)) {
+            unimplemented!("bytes.push(x) lowers to sol.push_string, which is not yet wired");
+        }
+
+        let (element_slang_type, slang_location) = match &base_slang_type {
+            SlangType::Array(array_type) => {
+                (Some(array_type.element_type()), array_type.location())
+            }
+            SlangType::Bytes(bytes_type) => (None, bytes_type.location()),
+            other => unreachable!(
+                "Solidity's .push is a member of dynamic arrays and bytes only; got {:?}",
+                std::mem::discriminant(other)
+            ),
+        };
+        let base_location = match slang_location {
+            SlangDataLocation::Inherited => unimplemented!(
+                "array push through Inherited (struct-field) location is not yet supported"
+            ),
+            other => solx_utils::DataLocation::from_slang(other, None),
+        };
+
+        let (array_value, block) = self.expression_emitter.emit_value(&base, block)?;
+        let builder = &self.expression_emitter.state.builder;
+        let element_type = element_slang_type
+            .map(|slang_type| TypeConversion::resolve_slang_type(&slang_type, None, builder))
+            .unwrap_or_else(|| builder.types.fixed_bytes(1));
+        let address_type = builder.types.pointer(element_type, base_location);
+        let new_slot = builder.emit_sol_push(array_value, address_type, &block);
+
+        let Some(value_argument) = value_argument else {
+            return Ok((Some(new_slot), block));
+        };
+        let (value, block) = self.expression_emitter.emit_value(&value_argument, block)?;
+        let cast_value =
+            TypeConversion::from_target_type(element_type, builder).emit(value, builder, &block);
+        builder.emit_sol_store(cast_value, new_slot, &block);
+        Ok((None, block))
     }
 
     /// Emits an intrinsic whose single operand is the receiver of a member

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -331,6 +331,35 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
                 Ok((Some(result), block))
             }
+            Expression::ArrayExpression(array_expression) => {
+                let result_slang_type = array_expression
+                    .get_type()
+                    .expect("slang types every array literal");
+                let element_slang_type = match &result_slang_type {
+                    SlangType::FixedSizeArray(fixed_array_type) => fixed_array_type.element_type(),
+                    SlangType::Array(array_type) => array_type.element_type(),
+                    _ => anyhow::bail!(
+                        "array literal has unexpected result type: {:?}",
+                        std::mem::discriminant(&result_slang_type)
+                    ),
+                };
+                let builder = &self.state.builder;
+                let array_type =
+                    TypeConversion::resolve_slang_type(&result_slang_type, None, builder);
+                let element_type =
+                    TypeConversion::resolve_slang_type(&element_slang_type, None, builder);
+                let mut element_values = Vec::new();
+                let mut current = block;
+                for item in array_expression.items().iter() {
+                    let (value, next) = self.emit_value(&item, current)?;
+                    let cast_value = TypeConversion::from_target_type(element_type, builder)
+                        .emit(value, builder, &next);
+                    element_values.push(cast_value);
+                    current = next;
+                }
+                let value = builder.emit_sol_array_lit(&element_values, array_type, &current);
+                Ok((Some(value), current))
+            }
             Expression::IndexAccessExpression(index_access) => {
                 self.emit_index_access(index_access, block)
             }


### PR DESCRIPTION
Three Sol-dialect lowerings for dynamic-array operations, branched off `feat-slang-index-access` (PR #415):

- `arr.push(x)` / `arr.push()` / `bytes.push()` → `sol.push` (+ `sol.store` when a value is provided).
- `arr.pop()` / `bytes.pop()` → `sol.pop`.
- `[a, b, c]` array literal → `sol.array_lit`.

Bytes `.push(x)` is not yet wired — needs `sol.push_string`.

## Test deltas

vs base [`276e7b9`](https://github.com/NomicFoundation/solx/commit/276e7b9) under `-O M3B3`:

| Suite | base | tip | Δ |
|---|---|---|---|
| `tests/solidity/simple/` | 1722 / 13 / 367 | 1723 / 14 / 366 | +1 PASSED, +1 FAILED, −1 INVALID |
| `solx-solidity/test/libsolidity/semanticTests/` | 810 / 376 / 1169 | 834 / 379 / 1159 | **+24 PASSED**, +3 FAILED, −10 INVALID, +17 newly discovered |

Combined cases: 4955 / 389 / 1643 → 4980 / 393 / 1632 (+25 PASSED, +4 FAILED, −11 INVALID).

Newly fully passing (8 files):

- solx-solidity/test/libsolidity/semanticTests/array/array_storage_pop_zero_length.sol
- solx-solidity/test/libsolidity/semanticTests/array/indexAccess/inline_array_index_access_ints.sol
- solx-solidity/test/libsolidity/semanticTests/array/inline_array_singleton.sol
- solx-solidity/test/libsolidity/semanticTests/array/inline_array_strings_from_document.sol
- solx-solidity/test/libsolidity/semanticTests/array/pop/array_pop_empty_exception.sol
- solx-solidity/test/libsolidity/semanticTests/array/pop/byte_array_pop_empty_exception.sol
- solx-solidity/test/libsolidity/semanticTests/isoltestTesting/isoltestFormatting.sol
- solx-solidity/test/libsolidity/semanticTests/various/inline_tuple_with_rational_numbers.sol