### PR TITLE
feat(slang): support a[i] / m[k] assignment targets

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -698,14 +698,16 @@ impl<'context> Builder<'context> {
 
     /// Emits a `sol.load` from a pointer with an explicit result type.
     ///
-    /// Use this when the pointer element type is known at emission time.
+    /// Short-circuits when `address` is already the element (the gep result
+    /// for reference-typed elements in `Storage`/`CallData`), returning it
+    /// unchanged.
     ///
     /// # Errors
     ///
     /// Returns an error if the load operation result cannot be extracted.
     pub fn emit_sol_load<'block, B>(
         &self,
-        pointer: Value<'context, 'block>,
+        address: Value<'context, 'block>,
         result_type: Type<'context>,
         block: &B,
     ) -> anyhow::Result<Value<'context, 'block>>
@@ -713,10 +715,13 @@ impl<'context> Builder<'context> {
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
+        if address.r#type() == result_type {
+            return Ok(address);
+        }
         Ok(block
             .append_operation(
                 LoadOperation::builder(self.context, self.unknown_location)
-                    .addr(pointer)
+                    .addr(address)
                     .out(result_type)
                     .build()
                     .into(),

--- a/solx-mlir/tests/lit/index_access.sol
+++ b/solx-mlir/tests/lit/index_access.sol
@@ -16,6 +16,14 @@
 // CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui256, !sol.ptr<ui256, Storage>
 // CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
 
+// CHECK: sol.func {{.*}}writeArray
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.array<? x ui256, Memory>, ui256, !sol.ptr<ui256, Memory>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Memory>
+
+// CHECK: sol.func {{.*}}writeMapping
+// CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui256, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
 contract C {
     mapping(uint256 => uint256) m;
 
@@ -29,5 +37,13 @@ contract C {
 
     function readMapping(uint256 k) public view returns (uint256) {
         return m[k];
+    }
+
+    function writeArray(uint256[] memory a, uint256 i, uint256 v) public pure {
+        a[i] = v;
+    }
+
+    function writeMapping(uint256 k, uint256 v) public {
+        m[k] = v;
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -5,12 +5,10 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
-use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::IndexAccessExpression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 use slang_solidity::backend::types::DataLocation as SlangDataLocation;
 
-use solx_mlir::Builder;
 use solx_utils::DataLocation;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
@@ -26,13 +24,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
         let (address, element_type, block) = self.emit_index_access_address(index_access, block)?;
-        let value = if address.r#type() == element_type {
-            address
-        } else {
-            self.state
-                .builder
-                .emit_sol_load(address, element_type, &block)?
-        };
+        let value = self
+            .state
+            .builder
+            .emit_sol_load(address, element_type, &block)?;
         Ok((Some(value), block))
     }
 
@@ -105,30 +100,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 "index access on a value-typed base is not yet wired: {:?}",
                 std::mem::discriminant(base_slang_type)
             ),
-        }
-    }
-
-    /// Picks the MLIR type of the address yielded by `sol.gep` / `sol.map`.
-    ///
-    /// Mirrors `Sol_GepOp::build`'s non-ptr-ref-in-storage rule: when the
-    /// element is itself a reference type and lives in `Storage` or
-    /// `CallData`, the result address IS the element type rather than a
-    /// pointer to it.
-    fn address_type(
-        builder: &Builder<'context>,
-        element_type: Type<'context>,
-        base_location: DataLocation,
-        result_slang_type: &SlangType,
-    ) -> Type<'context> {
-        if result_slang_type.is_reference_type()
-            && matches!(
-                base_location,
-                DataLocation::Storage | DataLocation::CallData
-            )
-        {
-            element_type
-        } else {
-            builder.types.pointer(element_type, base_location)
         }
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -5,6 +5,7 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::IndexAccessExpression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 use slang_solidity::backend::types::DataLocation as SlangDataLocation;
@@ -24,6 +25,32 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         index_access: &IndexAccessExpression,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Option<Value<'context, 'block>>, BlockRef<'context, 'block>)> {
+        let (address, element_type, block) = self.emit_index_access_address(index_access, block)?;
+        let value = if address.r#type() == element_type {
+            address
+        } else {
+            self.state
+                .builder
+                .emit_sol_load(address, element_type, &block)?
+        };
+        Ok((Some(value), block))
+    }
+
+    /// Emits the address yielded by `a[i]` / `m[k]` together with the element
+    /// MLIR type, without the trailing `sol.load`.
+    ///
+    /// Shared between the value-producing read path
+    /// ([`Self::emit_index_access`]) and the lvalue write path in
+    /// `emit_assignment`.
+    pub fn emit_index_access_address(
+        &self,
+        index_access: &IndexAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<(
+        Value<'context, 'block>,
+        Type<'context>,
+        BlockRef<'context, 'block>,
+    )> {
         if index_access.end().is_some() {
             unimplemented!("range index (a[i:j]) is not yet supported");
         }
@@ -63,15 +90,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 .builder
                 .emit_sol_gep(base_value, index_value, address_type, &block),
         };
-        let value = if address_type == element_type {
-            address
-        } else {
-            self.state
-                .builder
-                .emit_sol_load(address, element_type, &block)?
-        };
-
-        Ok((Some(value), block))
+        Ok((address, element_type, block))
     }
 
     /// Maps a slang container type's data location to the dialect-side

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -8,6 +8,7 @@ use melior::ir::BlockLike;
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 
@@ -63,6 +64,11 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             Expression::IndexAccessExpression(index_access) => {
                 let (address, element_type, block) =
                     self.emit_index_access_address(index_access, block)?;
+                if address.r#type() == element_type {
+                    unimplemented!(
+                        "assignment to a reference-typed `a[i]` element in storage/calldata is not yet supported"
+                    );
+                }
                 (AssignmentTarget::Pointer(address, element_type), block)
             }
             _ => anyhow::bail!("unsupported assignment target"),

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -56,8 +56,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                         let (pointer, element_type) = self.environment.variable_with_type(&name);
                         AssignmentTarget::Pointer(pointer, element_type)
                     }
-                    None => anyhow::bail!("unresolved identifier: {name}"),
-                    Some(_) => anyhow::bail!("unsupported assignment target: {name}"),
+                    None => unreachable!("slang resolves every identifier reference"),
+                    Some(_) => unimplemented!(
+                        "assignment to non-variable definition '{name}' is not yet supported"
+                    ),
                 };
                 (target, block)
             }
@@ -71,7 +73,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 }
                 (AssignmentTarget::Pointer(address, element_type), block)
             }
-            _ => anyhow::bail!("unsupported assignment target"),
+            _ => unimplemented!(
+                "assignment target {:?} is not yet supported",
+                std::mem::discriminant(&left)
+            ),
         };
 
         let operator = assign.operator();

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -17,8 +17,11 @@ use crate::ast::contract::function::expression::operator::Operator;
 
 /// Assignment target resolved from the Slang binder.
 enum AssignmentTarget<'context, 'block> {
-    /// Local variable — alloca'd pointer and its declared element type.
-    Local(Value<'context, 'block>, Type<'context>),
+    /// Address-typed pointer with its declared element type.
+    ///
+    /// Covers local variables, function parameters, and the result of an
+    /// `a[i]` / `m[k]` index-access expression on the left-hand side.
+    Pointer(Value<'context, 'block>, Type<'context>),
     /// State variable — storage slot and declared element type.
     Storage(u64, Type<'context>),
 }
@@ -31,29 +34,38 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
         let left = assign.left_operand();
-        let Expression::Identifier(identifier) = &left else {
-            anyhow::bail!("unsupported assignment target");
-        };
-        let name = identifier.name();
-
-        let target = match identifier.resolve_to_definition() {
-            Some(Definition::StateVariable(state_variable)) => {
-                let slot = self
-                    .storage_layout
-                    .get(&state_variable.node_id())
-                    .ok_or_else(|| anyhow::anyhow!("unregistered state variable: {name}"))?;
-                let element_type = TypeConversion::resolve_state_variable_type(
-                    &state_variable,
-                    &self.state.builder,
-                )?;
-                AssignmentTarget::Storage(*slot, element_type)
+        let (target, block) = match &left {
+            Expression::Identifier(identifier) => {
+                let name = identifier.name();
+                let target = match identifier.resolve_to_definition() {
+                    Some(Definition::StateVariable(state_variable)) => {
+                        let slot = self
+                            .storage_layout
+                            .get(&state_variable.node_id())
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("unregistered state variable: {name}")
+                            })?;
+                        let element_type = TypeConversion::resolve_state_variable_type(
+                            &state_variable,
+                            &self.state.builder,
+                        )?;
+                        AssignmentTarget::Storage(*slot, element_type)
+                    }
+                    Some(Definition::Variable(_) | Definition::Parameter(_)) => {
+                        let (pointer, element_type) = self.environment.variable_with_type(&name);
+                        AssignmentTarget::Pointer(pointer, element_type)
+                    }
+                    None => anyhow::bail!("unresolved identifier: {name}"),
+                    Some(_) => anyhow::bail!("unsupported assignment target: {name}"),
+                };
+                (target, block)
             }
-            Some(Definition::Variable(_) | Definition::Parameter(_)) => {
-                let (pointer, element_type) = self.environment.variable_with_type(&name);
-                AssignmentTarget::Local(pointer, element_type)
+            Expression::IndexAccessExpression(index_access) => {
+                let (address, element_type, block) =
+                    self.emit_index_access_address(index_access, block)?;
+                (AssignmentTarget::Pointer(address, element_type), block)
             }
-            None => anyhow::bail!("unresolved identifier: {name}"),
-            Some(_) => anyhow::bail!("unsupported assignment target: {name}"),
+            _ => anyhow::bail!("unsupported assignment target"),
         };
 
         let operator = assign.operator();
@@ -63,7 +75,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             self.emit_value(&right, block)?
         } else {
             let (old, target_type) = match target {
-                AssignmentTarget::Local(pointer, element_type) => {
+                AssignmentTarget::Pointer(pointer, element_type) => {
                     let old = self
                         .state
                         .builder
@@ -102,7 +114,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         };
 
         let result = match target {
-            AssignmentTarget::Local(pointer, element_type) => {
+            AssignmentTarget::Pointer(pointer, element_type) => {
                 let stored_value = TypeConversion::from_target_type(
                     element_type,
                     &self.state.builder,

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -22,10 +22,12 @@ use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 use slang_solidity::cst::NodeId;
 
+use solx_mlir::Builder;
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
 use solx_mlir::Environment;
 use solx_mlir::ods::sol::ThisOperation;
+use solx_utils::DataLocation;
 
 use self::call::type_conversion::TypeConversion;
 
@@ -409,5 +411,29 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             None,
             &self.state.builder,
         ))
+    }
+
+    /// Picks the MLIR type of the address yielded by `sol.gep` / `sol.map`.
+    ///
+    /// Mirrors `Sol_GepOp::build`'s non-ptr-ref-in-storage rule: when the
+    /// element is itself a reference type and lives in `Storage` or
+    /// `CallData`, the result address IS the element type rather than a
+    /// pointer to it.
+    fn address_type(
+        builder: &Builder<'context>,
+        element_type: Type<'context>,
+        base_location: DataLocation,
+        result_type: &SlangType,
+    ) -> Type<'context> {
+        if result_type.is_reference_type()
+            && matches!(
+                base_location,
+                DataLocation::Storage | DataLocation::CallData
+            )
+        {
+            element_type
+        } else {
+            builder.types.pointer(element_type, base_location)
+        }
     }
 }


### PR DESCRIPTION
Extends index-access lowering to handle the left-hand side, branched off `feat-slang-index-access`. `a[i] = v` and `m[k] = v` now compile, along with compound forms (`+=`, `-=`, ...). Range slicing, struct-field index, and nested-ref element types remain out of scope.

Integration test delta (M3B3), vs base [`3a4aad9`](https://github.com/NomicFoundation/solx/commit/3a4aad9):

| Suite | base | tip | Δ |
|---|---|---|---|
| `tests/solidity/simple/` | 1770 / 17 / 346 | 1810 / 23 / 327 | **+40 PASSED**, +6 FAILED, −19 INVALID, +27 newly discovered |
| `solx-solidity/test/libsolidity/semanticTests/` | 1287 / 414 / 1079 | 1416 / 483 / 1058 | **+129 PASSED**, +69 FAILED, −21 INVALID, +177 newly discovered |

Newly fully passing (19 + 21 files):

- tests/solidity/simple/algorithm/cryptography/book_cypher.sol
- tests/solidity/simple/algorithm/cryptography/caesar_cypher.sol
- tests/solidity/simple/algorithm/cryptography/vigenere_cypher.sol
- tests/solidity/simple/array/mutating_assignment.sol
- tests/solidity/simple/array/store_load_nested_witness_array_constant_index.sol
- tests/solidity/simple/array/store_load_witness_array_constant_index.sol
- tests/solidity/simple/storage/aligned/array/assign.sol
- tests/solidity/simple/storage/aligned/array/assign_nested.sol
- tests/solidity/simple/storage/aligned/array/reassign.sol
- tests/solidity/simple/storage/aligned/array/reassign_nested.sol
- tests/solidity/simple/storage/mapping/multiple.sol
- tests/solidity/simple/storage/mapping/mutating_one_element.sol
- tests/solidity/simple/storage/mapping/mutating_one_element_nested.sol
- tests/solidity/simple/storage/mapping/nested.sol
- tests/solidity/simple/storage/mapping/simple.sol
- tests/solidity/simple/storage/unaligned/array/assign.sol
- tests/solidity/simple/storage/unaligned/array/assign_nested.sol
- tests/solidity/simple/storage/unaligned/array/reassign.sol
- tests/solidity/simple/storage/unaligned/array/reassign_nested.sol
- solx-solidity/test/libsolidity/semanticTests/array/copying/array_storage_multi_items_per_slot.sol
- solx-solidity/test/libsolidity/semanticTests/array/fixed_out_of_bounds_array_access.sol
- solx-solidity/test/libsolidity/semanticTests/functionCall/mapping_array_internal_argument.sol
- solx-solidity/test/libsolidity/semanticTests/functionCall/mapping_internal_argument.sol
- solx-solidity/test/libsolidity/semanticTests/getters/mapping.sol
- solx-solidity/test/libsolidity/semanticTests/getters/mapping_of_string.sol
- solx-solidity/test/libsolidity/semanticTests/getters/mapping_with_names.sol
- solx-solidity/test/libsolidity/semanticTests/storage/mapping_state.sol
- solx-solidity/test/libsolidity/semanticTests/storage/mapping_string_key.sol
- solx-solidity/test/libsolidity/semanticTests/storageLayoutSpecifier/mapping_storage_end.sol
- solx-solidity/test/libsolidity/semanticTests/types/mapping_contract_key.sol
- solx-solidity/test/libsolidity/semanticTests/types/mapping_enum_key_v1.sol
- solx-solidity/test/libsolidity/semanticTests/types/mapping_enum_key_v2.sol
- solx-solidity/test/libsolidity/semanticTests/types/mapping_simple.sol
- solx-solidity/test/libsolidity/semanticTests/variables/mapping_local_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/variables/mapping_local_compound_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/variables/mapping_local_tuple_assignment.sol
- solx-solidity/test/libsolidity/semanticTests/various/erc20.sol
- solx-solidity/test/libsolidity/semanticTests/various/storage_string_as_mapping_key_without_variable.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/mapping_enum_key_getter.sol
- solx-solidity/test/libsolidity/semanticTests/viaYul/mapping_getters.sol
