### PR TITLE
feat(slang): read and write struct fields in memory, calldata, and storage

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -1048,8 +1048,13 @@ impl<'context> Builder<'context> {
     /// # Panics
     ///
     /// Panics if the MLIR operation cannot be constructed.
-    pub fn emit_sol_state_var<'block, B>(&self, name: &str, slot: u64, block: &B)
-    where
+    pub fn emit_sol_state_var<'block, B>(
+        &self,
+        name: &str,
+        slot: u64,
+        element_type: Type<'context>,
+        block: &B,
+    ) where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
@@ -1065,7 +1070,7 @@ impl<'context> Builder<'context> {
         block.append_operation(
             StateVarOperation::builder(self.context, self.unknown_location)
                 .sym_name(StringAttribute::new(self.context, name))
-                .r#type(TypeAttribute::new(self.types.ui256))
+                .r#type(TypeAttribute::new(element_type))
                 .slot(slot_attribute)
                 .byte_offset(byte_offset_attribute)
                 .build()

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -25,6 +25,7 @@ use melior::ir::attribute::TypeAttribute;
 use melior::ir::operation::OperationLike;
 use melior::ir::r#type::FunctionType;
 use melior::ir::r#type::IntegerType;
+use melior::ir::r#type::TypeLike;
 use num::BigInt;
 
 use crate::CmpPredicate;
@@ -36,6 +37,7 @@ use crate::ods::sol::AllocaOperation;
 use crate::ods::sol::ArrayLitOperation;
 use crate::ods::sol::AssertOperation;
 use crate::ods::sol::BreakOperation;
+use crate::ods::sol::BytesCastOperation;
 use crate::ods::sol::CallOperation;
 use crate::ods::sol::CastOperation;
 use crate::ods::sol::CmpOperation;
@@ -754,21 +756,29 @@ impl<'context> Builder<'context> {
         );
     }
 
-    /// Emits a `sol.gep` for array / `bytes` / `string` element access.
-    ///
-    /// `address_type` is the result address type the caller has computed
-    /// (typically `!sol.ptr<element, location>` for primitive elements).
+    /// Emits a `sol.gep` for array / `bytes` / `string` / struct field
+    /// access. `element_type` is the pointee the caller wants to address.
+    /// The gep's result type is derived from `(base_address.r#type(),
+    /// element_type)` via `GepOp::getResultType` on the C++ side.
     pub fn emit_sol_gep<'block, B>(
         &self,
         base_address: Value<'context, 'block>,
         index: Value<'context, 'block>,
-        address_type: Type<'context>,
+        element_type: Type<'context>,
         block: &B,
     ) -> Value<'context, 'block>
     where
         B: BlockLike<'context, 'block>,
         'context: 'block,
     {
+        // SAFETY: `mlirSolGepGetResultType` returns a valid MlirType from
+        // `sol::GepOp::getResultType` on the C++ side.
+        let address_type = unsafe {
+            Type::from_raw(crate::ffi::mlirSolGepGetResultType(
+                base_address.r#type().to_raw(),
+                element_type.to_raw(),
+            ))
+        };
         block
             .append_operation(
                 GepOperation::builder(self.context, self.unknown_location)
@@ -1010,6 +1020,37 @@ impl<'context> Builder<'context> {
             )
             .result(0)
             .expect("sol.cast always produces one result")
+            .into()
+    }
+
+    /// Emits a `sol.bytes_cast` between byte / fixedbytes / integer types.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MLIR operation cannot be constructed, indicating a bug in the builder.
+    pub fn emit_sol_bytes_cast<'block, B>(
+        &self,
+        value: Value<'context, 'block>,
+        to_type: Type<'context>,
+        block: &B,
+    ) -> Value<'context, 'block>
+    where
+        B: BlockLike<'context, 'block>,
+        'context: 'block,
+    {
+        if value.r#type() == to_type {
+            return value;
+        }
+        block
+            .append_operation(
+                BytesCastOperation::builder(self.context, self.unknown_location)
+                    .inp(value)
+                    .out(to_type)
+                    .build()
+                    .into(),
+            )
+            .result(0)
+            .expect("sol.bytes_cast always produces one result")
             .into()
     }
 

--- a/solx-mlir/src/context/builder/type_factory/mod.rs
+++ b/solx-mlir/src/context/builder/type_factory/mod.rs
@@ -22,6 +22,8 @@ pub struct TypeFactory<'context> {
 
     /// 1-bit boolean type (`i1`).
     pub i1: Type<'context>,
+    /// Unsigned 64-bit integer type (`ui64`, struct/array field-index width).
+    pub ui64: Type<'context>,
     /// Unsigned 160-bit integer type (`ui160`, address width).
     pub ui160: Type<'context>,
     /// Unsigned 256-bit integer type (`ui256`).
@@ -43,6 +45,10 @@ impl<'context> TypeFactory<'context> {
         let i1 = Type::from(IntegerType::new(
             context,
             solx_utils::BIT_LENGTH_BOOLEAN as u32,
+        ));
+        let ui64 = Type::from(IntegerType::unsigned(
+            context,
+            solx_utils::BIT_LENGTH_X64 as u32,
         ));
         let ui160 = Type::from(IntegerType::unsigned(
             context,
@@ -76,6 +82,7 @@ impl<'context> TypeFactory<'context> {
         Self {
             context,
             i1,
+            ui64,
             ui160,
             ui256,
             sol_address,

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -144,6 +144,19 @@ unsafe extern "C" {
     /// (one less than the number of enum members).
     pub fn solxCreateEnumType(context: MlirContext, max: u32) -> mlir_sys::MlirType;
 
+    // ---- Sol type inference ----
+
+    /// Returns the element type of a non-mapping reference type. For
+    /// struct types, `struct_field_idx` selects the member.
+    pub fn mlirSolGetEltType(ty: mlir_sys::MlirType, struct_field_idx: u64) -> mlir_sys::MlirType;
+
+    /// Returns the result type of a `sol.gep` whose base has type
+    /// `base_addr_ty` and whose pointee is `element_type`.
+    pub fn mlirSolGepGetResultType(
+        base_addr_ty: mlir_sys::MlirType,
+        element_type: mlir_sys::MlirType,
+    ) -> mlir_sys::MlirType;
+
     // ---- MLIR core (not in mlir-sys) ----
 
     /// Returns the region that owns the given block.

--- a/solx-mlir/tests/lit/index_access.sol
+++ b/solx-mlir/tests/lit/index_access.sol
@@ -1,16 +1,14 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s --check-prefixes=CHECK,CHECK-SOLX
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s --check-prefixes=CHECK,CHECK-SOLC
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func {{.*}}readArray{{.*}}-> ui256
 // CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.array<? x ui256, Memory>, ui256, !sol.ptr<ui256, Memory>
 // CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Memory>, ui256
 
 // CHECK: sol.func {{.*}}readBytes{{.*}}-> !sol.fixedbytes<1>
-// CHECK-SOLX:   sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui256, !sol.ptr<!sol.fixedbytes<1>, Memory>
-// CHECK-SOLX:   sol.load %{{.*}} : !sol.ptr<!sol.fixedbytes<1>, Memory>, !sol.fixedbytes<1>
-// CHECK-SOLC:   sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui256, !sol.ptr<!sol.byte, Memory>
-// CHECK-SOLC:   sol.load %{{.*}} : !sol.ptr<!sol.byte, Memory>, !sol.byte
-// CHECK-SOLC:   sol.bytes_cast %{{.*}} : !sol.byte to !sol.fixedbytes<1>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui256, !sol.ptr<!sol.byte, Memory>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK:   sol.bytes_cast %{{.*}} : !sol.byte to !sol.fixedbytes<1>
 
 // CHECK: sol.func {{.*}}readMapping{{.*}}-> ui256
 // CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui256, !sol.ptr<ui256, Storage>

--- a/solx-mlir/tests/lit/struct_field.sol
+++ b/solx-mlir/tests/lit/struct_field.sol
@@ -1,0 +1,56 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.state_var @{{.*}} slot 0 offset 0 : !sol.struct<(ui256, ui256), Storage>
+
+// CHECK: sol.func {{.*}}readField{{.*}}-> ui256
+// CHECK:   sol.constant 1 : ui64
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Memory>, ui256
+
+// CHECK: sol.func {{.*}}readNested{{.*}}-> ui256
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(!sol.struct<(ui256, ui256), Memory>, ui256), Memory>, ui64, !sol.ptr<!sol.struct<(ui256, ui256), Memory>, Memory>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<!sol.struct<(ui256, ui256), Memory>, Memory>, !sol.struct<(ui256, ui256), Memory>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Memory>, ui256
+
+// CHECK: sol.func {{.*}}readCalldata{{.*}}-> ui256
+// CHECK:   sol.constant 1 : ui64
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), CallData>, ui64, !sol.ptr<ui256, CallData>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, CallData>, ui256
+
+// CHECK: sol.func {{.*}}readStorage{{.*}}-> ui256
+// CHECK:   sol.addr_of @{{.*}} : !sol.struct<(ui256, ui256), Storage>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Storage>, ui64, !sol.ptr<ui256, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+
+// CHECK: sol.func {{.*}}writeStorage
+// CHECK:   sol.addr_of @{{.*}} : !sol.struct<(ui256, ui256), Storage>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Storage>, ui64, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+contract C {
+    struct Inner { uint256 a; uint256 b; }
+    struct Outer { Inner inner; uint256 extra; }
+    Inner data;
+
+    function readField(Inner memory s) public pure returns (uint256) {
+        return s.b;
+    }
+
+    function readNested(Outer memory o) public pure returns (uint256) {
+        return o.inner.b;
+    }
+
+    function readCalldata(Inner calldata s) external pure returns (uint256) {
+        return s.b;
+    }
+
+    function readStorage() public view returns (uint256) {
+        return data.b;
+    }
+
+    function writeStorage(uint256 v) public {
+        data.b = v;
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -5,6 +5,8 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::ValueLike;
+use melior::ir::r#type::TypeLike;
 use slang_solidity::backend::ir::ast::IndexAccessExpression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 use slang_solidity::backend::types::DataLocation as SlangDataLocation;
@@ -17,7 +19,10 @@ use crate::ast::contract::function::expression::call::type_conversion::TypeConve
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Lowers `a[i]` / `m[k]` for arrays, dynamic `bytes`, mappings, and
     /// strings to `sol.gep` (sequential containers) or `sol.map` (mappings),
-    /// followed by a `sol.load` of the addressed element.
+    /// followed by a `sol.load` of the addressed element. For dynamic
+    /// `bytes` the C++ element type is `!sol.byte`; a `sol.bytes_cast`
+    /// widens it to `!sol.fixedbytes<1>` to match Solidity's `bytes1`
+    /// typing. `sol.bytes_cast` is a no-op for matching types.
     pub fn emit_index_access(
         &self,
         index_access: &IndexAccessExpression,
@@ -28,6 +33,15 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             .state
             .builder
             .emit_sol_load(address, element_type, &block)?;
+        let result_type = index_access
+            .get_type()
+            .expect("slang types every index-access expression");
+        let slang_expected =
+            TypeConversion::resolve_slang_type(&result_type, None, &self.state.builder);
+        let value = self
+            .state
+            .builder
+            .emit_sol_bytes_cast(value, slang_expected, &block);
         Ok((Some(value), block))
     }
 
@@ -64,26 +78,39 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let (base_value, block) = self.emit_value(&base, block)?;
         let (index_value, block) = self.emit_value(&index_expression, block)?;
 
-        let element_type =
-            TypeConversion::resolve_slang_type(&result_type, None, &self.state.builder);
-        let base_location = Self::resolve_base_location(&base_type);
-        let address_type = Self::address_type(
-            &self.state.builder,
-            element_type,
-            base_location,
-            &result_type,
-        );
-
-        let address = match &base_type {
+        let (address, element_type) = match &base_type {
             SlangType::Mapping(_) => {
-                self.state
-                    .builder
-                    .emit_sol_map(base_value, index_value, address_type, &block)
+                let element_type =
+                    TypeConversion::resolve_slang_type(&result_type, None, &self.state.builder);
+                let base_location = Self::resolve_base_location(&base_type);
+                let address_type = Self::address_type(
+                    &self.state.builder,
+                    element_type,
+                    base_location,
+                    &result_type,
+                );
+                let address =
+                    self.state
+                        .builder
+                        .emit_sol_map(base_value, index_value, address_type, &block);
+                (address, element_type)
             }
-            _ => self
-                .state
-                .builder
-                .emit_sol_gep(base_value, index_value, address_type, &block),
+            _ => {
+                // SAFETY: `mlirSolGetEltType` returns a valid MlirType from
+                // `sol::getEltType` on the C++ side; the struct-field index
+                // is ignored for non-struct base types.
+                let element_type = unsafe {
+                    Type::from_raw(solx_mlir::ffi::mlirSolGetEltType(
+                        base_value.r#type().to_raw(),
+                        0,
+                    ))
+                };
+                let address =
+                    self.state
+                        .builder
+                        .emit_sol_gep(base_value, index_value, element_type, &block);
+                (address, element_type)
+            }
         };
         Ok((address, element_type, block))
     }

--- a/solx-slang/src/ast/contract/function/expression/access.rs
+++ b/solx-slang/src/ast/contract/function/expression/access.rs
@@ -54,10 +54,10 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let index_expression = index_access
             .start()
             .expect("slang validates a[i] has an index expression");
-        let base_slang_type = base
+        let base_type = base
             .get_type()
             .ok_or_else(|| anyhow::anyhow!("base of index access has no resolved type"))?;
-        let result_slang_type = index_access
+        let result_type = index_access
             .get_type()
             .expect("slang types every index-access expression");
 
@@ -65,16 +65,16 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let (index_value, block) = self.emit_value(&index_expression, block)?;
 
         let element_type =
-            TypeConversion::resolve_slang_type(&result_slang_type, None, &self.state.builder);
-        let base_location = Self::resolve_base_location(&base_slang_type);
+            TypeConversion::resolve_slang_type(&result_type, None, &self.state.builder);
+        let base_location = Self::resolve_base_location(&base_type);
         let address_type = Self::address_type(
             &self.state.builder,
             element_type,
             base_location,
-            &result_slang_type,
+            &result_type,
         );
 
-        let address = match &base_slang_type {
+        let address = match &base_type {
             SlangType::Mapping(_) => {
                 self.state
                     .builder
@@ -90,15 +90,15 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
     /// Maps a slang container type's data location to the dialect-side
     /// `DataLocation`.
-    fn resolve_base_location(base_slang_type: &SlangType) -> DataLocation {
-        match base_slang_type.data_location() {
+    fn resolve_base_location(base_type: &SlangType) -> DataLocation {
+        match base_type.data_location() {
             Some(SlangDataLocation::Inherited) => {
                 unreachable!("slang should not surface Inherited at an index-access base")
             }
             Some(other) => DataLocation::from_slang(other, None),
             None => unimplemented!(
                 "index access on a value-typed base is not yet wired: {:?}",
-                std::mem::discriminant(base_slang_type)
+                std::mem::discriminant(base_type)
             ),
         }
     }

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -40,16 +40,25 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let name = identifier.name();
                 let target = match identifier.resolve_to_definition() {
                     Some(Definition::StateVariable(state_variable)) => {
+                        let declared_type = state_variable.get_type().ok_or_else(|| {
+                            anyhow::anyhow!("unresolved type for state variable: {name}")
+                        })?;
+                        if declared_type.is_reference_type() {
+                            unimplemented!(
+                                "assignment to a reference-typed state variable is not yet supported"
+                            );
+                        }
                         let slot = self
                             .storage_layout
                             .get(&state_variable.node_id())
                             .ok_or_else(|| {
                                 anyhow::anyhow!("unregistered state variable: {name}")
                             })?;
-                        let element_type = TypeConversion::resolve_state_variable_type(
-                            &state_variable,
+                        let element_type = TypeConversion::resolve_slang_type(
+                            &declared_type,
+                            None,
                             &self.state.builder,
-                        )?;
+                        );
                         AssignmentTarget::Storage(*slot, element_type)
                     }
                     Some(Definition::Variable(_) | Definition::Parameter(_)) => {
@@ -69,6 +78,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 if address.r#type() == element_type {
                     unimplemented!(
                         "assignment to a reference-typed `a[i]` element in storage/calldata is not yet supported"
+                    );
+                }
+                (AssignmentTarget::Pointer(address, element_type), block)
+            }
+            Expression::MemberAccessExpression(access) => {
+                let (address, element_type, block) = self
+                    .emit_struct_field_address(access, block)?
+                    .expect("slang validates a member-access lvalue resolves to a struct field");
+                if address.r#type() == element_type {
+                    unimplemented!(
+                        "assignment to a reference-typed struct field in storage/calldata is not yet supported"
                     );
                 }
                 (AssignmentTarget::Pointer(address, element_type), block)

--- a/solx-slang/src/ast/contract/function/expression/member.rs
+++ b/solx-slang/src/ast/contract/function/expression/member.rs
@@ -5,14 +5,13 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::ValueLike;
+use melior::ir::r#type::TypeLike;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::MemberAccessExpression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
 
-use solx_utils::DataLocation;
-
 use crate::ast::contract::function::expression::ExpressionEmitter;
-use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
 
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Lowers `s.field` for a struct base to `sol.gep`, followed by a
@@ -58,36 +57,30 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         let Some(SlangType::Struct(struct_type)) = base.get_type() else {
             return Ok(None);
         };
-        let slang_location = Self::resolved_data_location(&base)
-            .ok_or_else(|| anyhow::anyhow!("cannot resolve struct field data location"))?;
-        let location = DataLocation::from_slang(slang_location, None);
         let Definition::Struct(struct_definition) = struct_type.definition() else {
             unreachable!("slang StructType always references a Struct definition");
         };
 
         let member_name = access.member().name();
-        let (field_index, field_type) = struct_definition
+        let field_index = struct_definition
             .members()
             .iter()
-            .enumerate()
-            .find_map(|(idx, member)| {
-                (member.name().name() == member_name).then(|| (idx, member.get_type()))
-            })
+            .position(|member| member.name().name() == member_name)
             .ok_or_else(|| anyhow::anyhow!("unknown struct member: {member_name}"))?;
-        let field_type = field_type
-            .ok_or_else(|| anyhow::anyhow!("struct member has no resolved type: {member_name}"))?;
 
         let (base_value, block) = self.emit_value(&base, block)?;
         let builder = &self.state.builder;
-        let element_type = TypeConversion::resolve_slang_type(&field_type, Some(location), builder);
 
         let index_value = builder.emit_sol_constant(field_index as i64, builder.types.ui64, &block);
-        let address = builder.emit_sol_gep(
-            base_value,
-            index_value,
-            Self::address_type(builder, element_type, location, &field_type),
-            &block,
-        );
+        // SAFETY: `mlirSolGetEltType` returns a valid MlirType from
+        // `sol::getEltType` on the C++ side.
+        let element_type = unsafe {
+            Type::from_raw(solx_mlir::ffi::mlirSolGetEltType(
+                base_value.r#type().to_raw(),
+                field_index as u64,
+            ))
+        };
+        let address = builder.emit_sol_gep(base_value, index_value, element_type, &block);
         Ok(Some((address, element_type, block)))
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/member.rs
+++ b/solx-slang/src/ast/contract/function/expression/member.rs
@@ -1,0 +1,93 @@
+//!
+//! Member access expression lowering for struct fields: `s.field`.
+//!
+
+use melior::ir::BlockRef;
+use melior::ir::Type;
+use melior::ir::Value;
+use slang_solidity::backend::ir::ast::Definition;
+use slang_solidity::backend::ir::ast::MemberAccessExpression;
+use slang_solidity::backend::ir::ast::Type as SlangType;
+
+use solx_utils::DataLocation;
+
+use crate::ast::contract::function::expression::ExpressionEmitter;
+use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
+
+impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
+    /// Lowers `s.field` for a struct base to `sol.gep`, followed by a
+    /// `sol.load` of the addressed field unless the field already IS the
+    /// value (non-ptr-ref-in-storage rule).
+    ///
+    /// Returns `Ok(None)` when the base is not a struct (e.g. `msg.sender`),
+    /// so the caller can fall back to built-in member access lowering.
+    pub fn emit_struct_field(
+        &self,
+        access: &MemberAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<Option<(Value<'context, 'block>, BlockRef<'context, 'block>)>> {
+        let Some((address, element_type, block)) = self.emit_struct_field_address(access, block)?
+        else {
+            return Ok(None);
+        };
+        let value = self
+            .state
+            .builder
+            .emit_sol_load(address, element_type, &block)?;
+        Ok(Some((value, block)))
+    }
+
+    /// Emits the address yielded by `s.field` together with the field's
+    /// element MLIR type, without the trailing `sol.load`.
+    ///
+    /// Shared between the value-producing read path
+    /// ([`Self::emit_struct_field`]) and the lvalue write path in
+    /// `emit_assignment`. Returns `Ok(None)` when the base is not a struct.
+    pub fn emit_struct_field_address(
+        &self,
+        access: &MemberAccessExpression,
+        block: BlockRef<'context, 'block>,
+    ) -> anyhow::Result<
+        Option<(
+            Value<'context, 'block>,
+            Type<'context>,
+            BlockRef<'context, 'block>,
+        )>,
+    > {
+        let base = access.operand();
+        let Some(SlangType::Struct(struct_type)) = base.get_type() else {
+            return Ok(None);
+        };
+        let slang_location = Self::resolved_data_location(&base)
+            .ok_or_else(|| anyhow::anyhow!("cannot resolve struct field data location"))?;
+        let location = DataLocation::from_slang(slang_location, None);
+        let Definition::Struct(struct_definition) = struct_type.definition() else {
+            unreachable!("slang StructType always references a Struct definition");
+        };
+
+        let member_name = access.member().name();
+        let (field_index, field_type) = struct_definition
+            .members()
+            .iter()
+            .enumerate()
+            .find_map(|(idx, member)| {
+                (member.name().name() == member_name).then(|| (idx, member.get_type()))
+            })
+            .ok_or_else(|| anyhow::anyhow!("unknown struct member: {member_name}"))?;
+        let field_type = field_type
+            .ok_or_else(|| anyhow::anyhow!("struct member has no resolved type: {member_name}"))?;
+
+        let (base_value, block) = self.emit_value(&base, block)?;
+        let builder = &self.state.builder;
+        let element_type = TypeConversion::resolve_slang_type(&field_type, Some(location), builder);
+
+        let index_value = builder.emit_sol_constant(field_index as i64, builder.types.ui64, &block);
+        let address = builder.emit_sol_gep(
+            base_value,
+            index_value,
+            Self::address_type(builder, element_type, location, &field_type),
+            &block,
+        );
+        Ok(Some((address, element_type, block)))
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -7,6 +7,7 @@ pub mod arithmetic;
 pub mod assignment;
 pub mod call;
 pub mod logical;
+pub mod member;
 pub mod operator;
 pub mod storage;
 
@@ -20,6 +21,7 @@ use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
+use slang_solidity::backend::types::DataLocation as SlangDataLocation;
 use slang_solidity::cst::NodeId;
 
 use solx_mlir::Builder;
@@ -161,11 +163,28 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                             .ok_or_else(|| {
                                 anyhow::anyhow!("unregistered state variable: {name}")
                             })?;
-                        let element_type = TypeConversion::resolve_state_variable_type(
-                            &state_variable,
+                        let declared_type = state_variable.get_type().ok_or_else(|| {
+                            anyhow::anyhow!("unresolved type for state variable: {name}")
+                        })?;
+                        let element_type = TypeConversion::resolve_slang_type(
+                            &declared_type,
+                            None,
                             &self.state.builder,
-                        )?;
-                        let value = self.emit_storage_load(*slot, element_type, &block)?;
+                        );
+                        let address = self.state.builder.emit_sol_addr_of(
+                            &format!("slot_{slot}"),
+                            Self::address_type(
+                                &self.state.builder,
+                                element_type,
+                                DataLocation::Storage,
+                                &declared_type,
+                            ),
+                            &block,
+                        );
+                        let value =
+                            self.state
+                                .builder
+                                .emit_sol_load(address, element_type, &block)?;
                         Ok((Some(value), block))
                     }
                     Some(Definition::Variable(_) | Definition::Parameter(_)) => {
@@ -283,9 +302,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             Expression::FunctionCallExpression(call) => {
                 self::call::CallEmitter::new(self).emit_function_call(call, block)
             }
-            Expression::MemberAccessExpression(access) => self::call::CallEmitter::new(self)
-                .emit_member_access(access, block)
-                .map(|(value, block)| (Some(value), block)),
             Expression::TupleExpression(tuple) => {
                 let items = tuple.items();
                 // TODO: support multi-value tuples (e.g. tuple deconstruction)
@@ -362,6 +378,15 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let value = builder.emit_sol_array_lit(&element_values, array_type, &current);
                 Ok((Some(value), current))
             }
+            Expression::MemberAccessExpression(access) => {
+                if let Some((value, block)) = self.emit_struct_field(access, block)? {
+                    Ok((Some(value), block))
+                } else {
+                    self::call::CallEmitter::new(self)
+                        .emit_member_access(access, block)
+                        .map(|(value, block)| (Some(value), block))
+                }
+            }
             Expression::IndexAccessExpression(index_access) => {
                 self.emit_index_access(index_access, block)
             }
@@ -434,6 +459,24 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             element_type
         } else {
             builder.types.pointer(element_type, base_location)
+        }
+    }
+
+    /// Concrete data location of `expression`, walking back through nested
+    /// member/index accesses past slang's `Inherited` marker on nested
+    /// struct fields like `o.inner.b`.
+    fn resolved_data_location(expression: &Expression) -> Option<SlangDataLocation> {
+        match expression.get_type().and_then(|t| t.data_location())? {
+            SlangDataLocation::Inherited => match expression {
+                Expression::MemberAccessExpression(access) => {
+                    Self::resolved_data_location(&access.operand())
+                }
+                Expression::IndexAccessExpression(access) => {
+                    Self::resolved_data_location(&access.operand())
+                }
+                _ => None,
+            },
+            other => Some(other),
         }
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -21,7 +21,6 @@ use melior::ir::ValueLike;
 use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 use slang_solidity::backend::ir::ast::Type as SlangType;
-use slang_solidity::backend::types::DataLocation as SlangDataLocation;
 use slang_solidity::cst::NodeId;
 
 use solx_mlir::Builder;
@@ -459,24 +458,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             element_type
         } else {
             builder.types.pointer(element_type, base_location)
-        }
-    }
-
-    /// Concrete data location of `expression`, walking back through nested
-    /// member/index accesses past slang's `Inherited` marker on nested
-    /// struct fields like `o.inner.b`.
-    fn resolved_data_location(expression: &Expression) -> Option<SlangDataLocation> {
-        match expression.get_type().and_then(|t| t.data_location())? {
-            SlangDataLocation::Inherited => match expression {
-                Expression::MemberAccessExpression(access) => {
-                    Self::resolved_data_location(&access.operand())
-                }
-                Expression::IndexAccessExpression(access) => {
-                    Self::resolved_data_location(&access.operand())
-                }
-                _ => None,
-            },
-            other => Some(other),
         }
     }
 }

--- a/solx-slang/src/ast/contract/function/expression/storage.rs
+++ b/solx-slang/src/ast/contract/function/expression/storage.rs
@@ -5,6 +5,9 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
+use melior::ir::ValueLike;
+
+use solx_utils::DataLocation;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 
@@ -16,7 +19,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) -> anyhow::Result<Value<'context, 'block>> {
-        let pointer = self.emit_storage_addr_of(slot, block);
+        let pointer = self.emit_storage_addr_of(slot, element_type, block);
         self.state
             .builder
             .emit_sol_load(pointer, element_type, block)
@@ -29,19 +32,24 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         value: Value<'context, 'block>,
         block: &BlockRef<'context, 'block>,
     ) {
-        let pointer = self.emit_storage_addr_of(slot, block);
+        let pointer = self.emit_storage_addr_of(slot, value.r#type(), block);
         self.state.builder.emit_sol_store(value, pointer, block);
     }
 
-    /// Returns a `!sol.ptr<ui256, Storage>` pointer via `sol.addr_of`.
+    /// Returns a `!sol.ptr<element_type, Storage>` pointer via `sol.addr_of`.
     fn emit_storage_addr_of(
         &self,
         slot: u64,
+        element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) -> Value<'context, 'block> {
-        let storage_pointer_type = self.state.builder.types.sol_ptr_storage;
+        let pointer_type = self
+            .state
+            .builder
+            .types
+            .pointer(element_type, DataLocation::Storage);
         self.state
             .builder
-            .emit_sol_addr_of(&format!("slot_{slot}"), storage_pointer_type, block)
+            .emit_sol_addr_of(&format!("slot_{slot}"), pointer_type, block)
     }
 }

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -8,6 +8,7 @@ pub mod function;
 use std::collections::HashMap;
 
 use slang_solidity::backend::ir::ast::ContractDefinition;
+use slang_solidity::backend::ir::ast::ContractMember;
 use slang_solidity::backend::ir::ast::FunctionKind;
 use slang_solidity::backend::ir::ast::FunctionMutability;
 use slang_solidity::cst::NodeId;
@@ -78,11 +79,23 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
             &module_body,
         );
 
-        // Emit sol.state_var declarations for each storage slot.
-        for slot in storage_layout.values() {
-            self.state
-                .builder
-                .emit_sol_state_var(&format!("slot_{slot}"), *slot, &contract_body);
+        // TODO: emit declarations for inherited state variables once derived
+        // contracts compile through this path.
+        for member in contract.members().iter() {
+            let ContractMember::StateVariableDefinition(state_variable) = member else {
+                continue;
+            };
+            let Some(slot) = storage_layout.get(&state_variable.node_id()) else {
+                continue;
+            };
+            let element_type =
+                TypeConversion::resolve_state_variable_type(&state_variable, &self.state.builder)?;
+            self.state.builder.emit_sol_state_var(
+                &format!("slot_{slot}"),
+                *slot,
+                element_type,
+                &contract_body,
+            );
         }
 
         // Emit the constructor first to align with solc's MLIR layout. Lower


### PR DESCRIPTION
Reads and writes struct fields in memory, calldata, and storage via `sol.gep` with a `ui64` field index, branched off `feat-slang-index-access-lvalue`. Covers chained access (`s.inner.b`, `s.inner.b = v`, `s.next += x`) by relying on the non-ptr-ref-in-storage rule — intermediate ref-typed addresses are passed straight to the next gep instead of being loaded.

The fix also corrects `sol.state_var` emission, which was previously hard-coded to `ui256` regardless of the source-level declaration. Reference-typed state variables (struct, array, mapping, bytes, string) now declare with their actual type and their use-site emits `sol.addr_of` directly (no spurious `sol.load`), matching solc's MLIR.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1810 | 1869 | +59 |
| FAILED | 23 | 14 | −9 |
| INVALID | 327 | 310 | −17 |
| Total | 2160 | 2193 | +33 |

Newly fully passing:

- tests/solidity/simple/algorithm/floating_point_simulation/geometry/area.sol
- tests/solidity/simple/algorithm/floating_point_simulation/geometry/volume.sol
- tests/solidity/simple/function/many_arguments_3_complex.sol
- tests/solidity/simple/interface/structure_immutable_method.sol
- tests/solidity/simple/storage/aligned/array/product.sol
- tests/solidity/simple/storage/aligned/array/reassign.sol
- tests/solidity/simple/storage/aligned/array/reassign_nested.sol
- tests/solidity/simple/storage/aligned/array/sum.sol
- tests/solidity/simple/storage/aligned/structure/assign.sol
- tests/solidity/simple/storage/aligned/structure/assign_nested.sol
- tests/solidity/simple/storage/aligned/structure/product.sol
- tests/solidity/simple/storage/aligned/structure/reassign.sol
- tests/solidity/simple/storage/aligned/structure/reassign_nested.sol
- tests/solidity/simple/storage/aligned/structure/sum.sol
- tests/solidity/simple/storage/unaligned/array/mutating_one_element.sol
- tests/solidity/simple/storage/unaligned/array/product.sol
- tests/solidity/simple/storage/unaligned/array/reassign.sol
- tests/solidity/simple/storage/unaligned/array/reassign_nested.sol
- tests/solidity/simple/storage/unaligned/array/sum.sol
- tests/solidity/simple/storage/unaligned/structure/assign.sol
- tests/solidity/simple/storage/unaligned/structure/assign_nested.sol
- tests/solidity/simple/storage/unaligned/structure/product.sol
- tests/solidity/simple/storage/unaligned/structure/reassign.sol
- tests/solidity/simple/storage/unaligned/structure/reassign_nested.sol
- tests/solidity/simple/storage/unaligned/structure/sum.sol
- tests/solidity/simple/structure/mutating_assignment.sol