### PR TITLE
feat(slang): allow runtime require message via Error(string) call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,16 +4237,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
-]
-
-[[package]]
-name = "sha3"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
@@ -4303,7 +4293,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4316,14 +4306,14 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "num-bigint",
  "num-rational",
  "paste",
  "ruint",
  "serde",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",
  "slang_solidity_v2_semantic",
@@ -4332,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "itertools 0.14.0",
  "semver 1.0.28",
@@ -4344,12 +4334,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4358,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4372,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=47238e294b9e0b9fc7889bd748a5b528baed3c2b#47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
 dependencies = [
  "indexmap 2.14.0",
  "num-bigint",
@@ -4380,7 +4370,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "ruint",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,4 +99,5 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "47238e294b9e0b9fc7889bd748a5b528baed3c2b"
+# Temporary: points at NomicFoundation/slang#1801 until it lands on main.
+rev = "af822aba9d748e1053c79cccec079f27bc54860c"

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -377,6 +377,8 @@ impl<'context> Builder<'context> {
         &self,
         condition: Value<'context, 'block>,
         msg: Option<&str>,
+        args: &[Value<'context, 'block>],
+        is_call: bool,
         block: &B,
     ) where
         B: BlockLike<'context, 'block>,
@@ -384,9 +386,12 @@ impl<'context> Builder<'context> {
     {
         let mut builder = RequireOperation::builder(self.context, self.unknown_location)
             .cond(condition)
-            .args(&[]);
+            .args(args);
         if let Some(msg) = msg {
             builder = builder.msg(StringAttribute::new(self.context, msg));
+        }
+        if is_call {
+            builder = builder.call(Attribute::unit(self.context));
         }
         block.append_operation(builder.build().into());
     }

--- a/solx-mlir/tests/lit/require_runtime_message.sol
+++ b/solx-mlir/tests/lit/require_runtime_message.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// CHECK: sol.func @{{.*check.*}}
+// CHECK:   sol.require %{{.*}}, "Error(string)"(%{{.*}} : !sol.string<Memory>) {call}
+
+contract C {
+    function check(bool cond, string memory message) public pure {
+        require(cond, message);
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/call/built_in.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/built_in.rs
@@ -87,17 +87,10 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
             BuiltIn::Require if matches!(arguments.len(), 1 | 2) => {
                 let mut iter = arguments.iter();
                 let condition = iter.next().expect("argument count verified");
-                let message = match iter.next() {
-                    Some(Expression::StringExpression(string_expression)) => {
-                        let bytes = string_expression.value();
-                        Some(String::from_utf8(bytes).expect("require message is valid UTF-8"))
-                    }
-                    Some(_) => anyhow::bail!("require message must be a string literal"),
-                    None => None,
-                };
+                let message = iter.next();
                 Ok(Some((
                     None,
-                    self.emit_require(&condition, message.as_deref(), block)?,
+                    self.emit_require(&condition, message.as_ref(), block)?,
                 )))
             }
             BuiltIn::Gasleft if arguments.is_empty() => {
@@ -712,22 +705,49 @@ impl<'emitter, 'state, 'context, 'block> CallEmitter<'emitter, 'state, 'context,
         Ok(block)
     }
 
-    /// Emits a `require(condition)` or `require(condition, "message")` built-in
+    /// Emits a `require(condition)` or `require(condition, message)` built-in
     /// via `sol.require`.
+    ///
+    /// Literal string messages lower to `sol.require %cond, "msg" : ()`. A
+    /// non-literal expression evaluates at runtime and is ABI-encoded under
+    /// the `Error(string)` selector via the `call` form of `sol.require`.
     fn emit_require(
         &self,
         condition: &Expression,
-        message: Option<&str>,
+        message: Option<&Expression>,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<BlockRef<'context, 'block>> {
         let (condition_value, block) = self.expression_emitter.emit_value(condition, block)?;
         let condition_boolean = self
             .expression_emitter
             .emit_is_nonzero(condition_value, &block);
-        self.expression_emitter
-            .state
-            .builder
-            .emit_sol_require(condition_boolean, message, &block);
-        Ok(block)
+        let builder = &self.expression_emitter.state.builder;
+        match message {
+            Some(Expression::StringExpression(string_expression)) => {
+                let bytes = string_expression.value();
+                let literal = String::from_utf8(bytes).expect("require message is valid UTF-8");
+                builder.emit_sol_require(condition_boolean, Some(&literal), &[], false, &block);
+                Ok(block)
+            }
+            Some(expression) => {
+                let (message_value, block) =
+                    self.expression_emitter.emit_value(expression, block)?;
+                let string_memory_type = builder.types.string(solx_utils::DataLocation::Memory);
+                let message_value = TypeConversion::from_target_type(string_memory_type, builder)
+                    .emit(message_value, builder, &block);
+                builder.emit_sol_require(
+                    condition_boolean,
+                    Some("Error(string)"),
+                    &[message_value],
+                    true,
+                    &block,
+                );
+                Ok(block)
+            }
+            None => {
+                builder.emit_sol_require(condition_boolean, None, &[], false, &block);
+                Ok(block)
+            }
+        }
     }
 }

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -55,15 +55,11 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
     /// # Errors
     ///
     /// Returns an error if any function body contains unsupported constructs.
-    pub fn emit(
-        &mut self,
-        contract: &ContractDefinition,
-        file_identifier: &str,
-    ) -> anyhow::Result<()> {
+    pub fn emit(&mut self, contract: &ContractDefinition) -> anyhow::Result<()> {
         let contract_name = contract.name().name();
 
         self.pre_register_functions(contract);
-        let storage_layout = Self::compute_storage_layout(contract, file_identifier);
+        let storage_layout = Self::compute_storage_layout(contract);
 
         let contract_type = self
             .state
@@ -155,11 +151,8 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
     ///
     /// Returns a mapping from state variable node ID to storage slot.
     /// Returns an empty map if the ABI is unavailable.
-    fn compute_storage_layout(
-        contract: &ContractDefinition,
-        file_identifier: &str,
-    ) -> HashMap<NodeId, U256> {
-        let Some(abi) = contract.compute_abi_with_file_id(file_identifier.to_owned()) else {
+    fn compute_storage_layout(contract: &ContractDefinition) -> HashMap<NodeId, U256> {
+        let Some(abi) = contract.compute_abi() else {
             return HashMap::new();
         };
         abi.storage_layout()

--- a/solx-slang/src/ast/mod.rs
+++ b/solx-slang/src/ast/mod.rs
@@ -51,9 +51,8 @@ impl<'state, 'context> AstEmitter<'state, 'context> {
         };
 
         let name = contract.name().name();
-        let file_identifier = unit.file_id();
         let mut emitter = ContractEmitter::new(self.state);
-        emitter.emit(contract, file_identifier)?;
+        emitter.emit(contract)?;
 
         let mut method_identifiers = BTreeMap::new();
         for contract_member in contract.members().iter() {

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -147,7 +147,7 @@ impl Frontend for Slang {
         for file_identifier in &unit.file_ids() {
             if let Some(output_source) = output.sources.get_mut(file_identifier) {
                 output_source.ast = Some(
-                    serde_json::to_value(unit.get_file_ast_root(file_identifier).as_ref())
+                    serde_json::to_value(unit.file(file_identifier).map(|file| file.ast()))
                         .map_err(|error| anyhow::anyhow!("AST serialization: {error}"))?,
                 );
             }
@@ -160,9 +160,10 @@ impl Frontend for Slang {
         let file_identifiers = unit.file_ids();
 
         for file_identifier in &file_identifiers {
-            let Some(source_unit) = unit.get_file_ast_root(file_identifier) else {
+            let Some(file) = unit.file(file_identifier) else {
                 continue;
             };
+            let source_unit = file.ast();
             let melior_context = solx_mlir::Context::create_mlir_context();
 
             let evm_version = input_json.settings.evm_version.unwrap_or_default();


### PR DESCRIPTION
Lowers `require(cond, expr)` where `expr` is not a string literal. The expression is evaluated at runtime, converted to `string memory` via `sol.cast` (no-op when the source is already memory), and emitted as `sol.require %cond, "Error(string)"(%msg : !sol.string<memory>) {call}`, mirroring the per-argument type conversion the custom-error revert path uses.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1895 | 1899 | +4 |
| FAILED | 8 | 8 | 0 |
| INVALID | 306 | 304 | −2 |
| Total | 2209 | 2211 | +2 |