### PR TITLE
feat(slang): support packed state variable slots

### DIFF
--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -1154,6 +1154,7 @@ impl<'context> Builder<'context> {
         &self,
         name: &str,
         slot: U256,
+        byte_offset: u32,
         element_type: Type<'context>,
         block: &B,
     ) where
@@ -1167,7 +1168,7 @@ impl<'context> Builder<'context> {
                 .expect("slot literal is an integer attribute");
         let byte_offset_attribute = IntegerAttribute::new(
             IntegerType::new(self.context, solx_utils::BIT_LENGTH_X32 as u32).into(),
-            0,
+            byte_offset.into(),
         );
         block.append_operation(
             StateVarOperation::builder(self.context, self.unknown_location)

--- a/solx-mlir/tests/lit/state_var_initializer.sol
+++ b/solx-mlir/tests/lit/state_var_initializer.sol
@@ -1,15 +1,23 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*constructor.*}}
+// CHECK: sol.state_var @x_{{[0-9]+}} slot 0 offset 0 : ui256
+// CHECK: sol.state_var @s_{{[0-9]+}} slot 1 offset 0 : !sol.string<Storage>
+// CHECK: sol.state_var @small_{{[0-9]+}} slot 2 offset 0 : ui8
+// CHECK: sol.state_var @flag_{{[0-9]+}} slot 2 offset 1 : i1
+
+// CHECK: sol.func @{{.*}} attributes {kind = #Constructor
+// CHECK:   sol.addr_of @x_{{[0-9]+}} : !sol.ptr<ui256, Storage>
 // CHECK:   sol.constant 42
-// CHECK:   sol.addr_of @{{.*}} : !sol.ptr<ui256, Storage>
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+// CHECK:   sol.addr_of @s_{{[0-9]+}} : !sol.string<Storage>
 // CHECK:   sol.string_lit "hello" -> !sol.string<Memory>
-// CHECK:   sol.addr_of @{{.*}} : !sol.string<Storage>
 // CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.string<Storage>
 // CHECK:   sol.return
 
 contract C {
     uint256 x = 42;
     string s = "hello";
+    uint8 small;
+    bool flag;
 }

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -179,7 +179,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
 
         match identifier.resolve_to_definition() {
             Some(Definition::StateVariable(state_variable)) => {
-                let slot = *self
+                let slot = self
                     .storage_layout
                     .get(&state_variable.node_id())
                     .ok_or_else(|| anyhow::anyhow!("unregistered state variable: {name}"))?;
@@ -200,7 +200,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                     .result(0)
                     .expect("binary operation always produces one result")
                     .into();
-                self.emit_storage_store(slot, new_value, block);
+                self.emit_storage_store(slot, new_value, element_type, block);
                 Ok((old, new_value))
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {

--- a/solx-slang/src/ast/contract/function/expression/assignment.rs
+++ b/solx-slang/src/ast/contract/function/expression/assignment.rs
@@ -7,7 +7,6 @@ use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::ValueLike;
-use ruint::aliases::U256;
 use slang_solidity_v2::ast;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Expression;
@@ -15,6 +14,7 @@ use slang_solidity_v2::ast::Expression;
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
 use crate::ast::contract::function::expression::operator::Operator;
+use crate::ast::contract::function::storage_slot::StorageSlot;
 
 /// Assignment target resolved from the Slang binder.
 enum AssignmentTarget<'context, 'block> {
@@ -24,7 +24,7 @@ enum AssignmentTarget<'context, 'block> {
     /// `a[i]` / `m[k]` index-access expression on the left-hand side.
     Pointer(Value<'context, 'block>, Type<'context>),
     /// State variable — storage slot and declared element type.
-    Storage(U256, Type<'context>),
+    Storage(StorageSlot, Type<'context>),
 }
 
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
@@ -51,15 +51,14 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                         let slot = self
                             .storage_layout
                             .get(&state_variable.node_id())
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("unregistered state variable: {name}")
-                            })?;
+                            .ok_or_else(|| anyhow::anyhow!("unregistered state variable: {name}"))?
+                            .clone();
                         let element_type = TypeConversion::resolve_slang_type(
                             &declared_type,
                             None,
                             &self.state.builder,
                         );
-                        AssignmentTarget::Storage(*slot, element_type)
+                        AssignmentTarget::Storage(slot, element_type)
                     }
                     Some(Definition::Variable(_) | Definition::Parameter(_)) => {
                         let (pointer, element_type) = self.environment.variable_with_type(&name);
@@ -126,17 +125,17 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 ast::AssignmentExpressionOperator::PlusEqual(_) => Operator::Add,
                 ast::AssignmentExpressionOperator::SlashEqual(_) => Operator::Divide,
             };
-            let (old, target_type) = match target {
+            let (old, target_type) = match &target {
                 AssignmentTarget::Pointer(pointer, element_type) => {
                     let old = self
                         .state
                         .builder
-                        .emit_sol_load(pointer, element_type, &block)?;
-                    (old, element_type)
+                        .emit_sol_load(*pointer, *element_type, &block)?;
+                    (old, *element_type)
                 }
                 AssignmentTarget::Storage(slot, element_type) => {
-                    let old = self.emit_storage_load(slot, element_type, &block)?;
-                    (old, element_type)
+                    let old = self.emit_storage_load(slot, *element_type, &block)?;
+                    (old, *element_type)
                 }
             };
             let (rhs, block) = self.emit_value(&right, block)?;
@@ -164,25 +163,25 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             (result, block)
         };
 
-        let result = match target {
+        let result = match &target {
             AssignmentTarget::Pointer(pointer, element_type) => {
                 let stored_value = TypeConversion::from_target_type(
-                    element_type,
+                    *element_type,
                     &self.state.builder,
                 )
                 .emit(value, &self.state.builder, &block);
                 self.state
                     .builder
-                    .emit_sol_store(stored_value, pointer, &block);
+                    .emit_sol_store(stored_value, *pointer, &block);
                 stored_value
             }
             AssignmentTarget::Storage(slot, element_type) => {
                 let stored_value = TypeConversion::from_target_type(
-                    element_type,
+                    *element_type,
                     &self.state.builder,
                 )
                 .emit(value, &self.state.builder, &block);
-                self.emit_storage_store(slot, stored_value, &block);
+                self.emit_storage_store(slot, stored_value, *element_type, &block);
                 stored_value
             }
         };

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -19,7 +19,6 @@ use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::ValueLike;
 use operator::Operator;
-use ruint::aliases::U256;
 use slang_solidity_v2::ast;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Expression;
@@ -34,6 +33,7 @@ use solx_mlir::ods::sol::ThisOperation;
 use solx_utils::DataLocation;
 
 use self::call::type_conversion::TypeConversion;
+use crate::ast::contract::function::storage_slot::StorageSlot;
 
 /// Lowers Solidity expressions to MLIR SSA values.
 pub struct ExpressionEmitter<'state, 'context, 'block> {
@@ -42,7 +42,7 @@ pub struct ExpressionEmitter<'state, 'context, 'block> {
     /// Variable environment.
     pub environment: &'state Environment<'context, 'block>,
     /// State variable node ID to storage slot mapping.
-    pub storage_layout: &'state HashMap<NodeId, U256>,
+    pub storage_layout: &'state HashMap<NodeId, StorageSlot>,
     /// Whether arithmetic operations use checked variants (`sol.cadd` etc.).
     ///
     /// `true` by default (Solidity 0.8+). Set to `false` inside `unchecked {}`
@@ -55,7 +55,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     pub fn new(
         state: &'state Context<'context>,
         environment: &'state Environment<'context, 'block>,
-        storage_layout: &'state HashMap<NodeId, U256>,
+        storage_layout: &'state HashMap<NodeId, StorageSlot>,
         checked: bool,
     ) -> Self {
         Self {
@@ -174,7 +174,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                             &self.state.builder,
                         );
                         let address = self.state.builder.emit_sol_addr_of(
-                            &format!("slot_{slot}"),
+                            &slot.name,
                             Self::address_type(
                                 &self.state.builder,
                                 element_type,

--- a/solx-slang/src/ast/contract/function/expression/storage.rs
+++ b/solx-slang/src/ast/contract/function/expression/storage.rs
@@ -5,9 +5,7 @@
 use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
-use melior::ir::ValueLike;
 
-use ruint::aliases::U256;
 use slang_solidity_v2::ast::ContractDefinition;
 use slang_solidity_v2::ast::ContractMember;
 use slang_solidity_v2::ast::Expression;
@@ -15,12 +13,13 @@ use solx_utils::DataLocation;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
+use crate::ast::contract::function::storage_slot::StorageSlot;
 
 impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Emits a storage load via `sol.addr_of` + `sol.load`.
     pub fn emit_storage_load(
         &self,
-        slot: U256,
+        slot: &StorageSlot,
         element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) -> anyhow::Result<Value<'context, 'block>> {
@@ -33,11 +32,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Emits a storage store via `sol.addr_of` + `sol.store`.
     pub fn emit_storage_store(
         &self,
-        slot: U256,
+        slot: &StorageSlot,
         value: Value<'context, 'block>,
+        element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) {
-        let pointer = self.emit_storage_addr_of(slot, value.r#type(), block);
+        let pointer = self.emit_storage_addr_of(slot, element_type, block);
         self.state.builder.emit_sol_store(value, pointer, block);
     }
 
@@ -78,12 +78,11 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             })?;
             let builder = &self.state.builder;
             let element_type = TypeConversion::resolve_slang_type(&declared_type, None, builder);
-            let (value, next_block) = self.emit_value(&initializer, block)?;
-            block = next_block;
             let address_type =
                 Self::address_type(builder, element_type, DataLocation::Storage, &declared_type);
-            let storage_ref =
-                builder.emit_sol_addr_of(&format!("slot_{slot}"), address_type, &block);
+            let storage_ref = builder.emit_sol_addr_of(&slot.name, address_type, &block);
+            let (value, next_block) = self.emit_value(&initializer, block)?;
+            block = next_block;
             if declared_type.is_reference_type() {
                 builder.emit_sol_copy(value, storage_ref, &block);
             } else {
@@ -98,7 +97,7 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
     /// Returns a `!sol.ptr<element_type, Storage>` pointer via `sol.addr_of`.
     fn emit_storage_addr_of(
         &self,
-        slot: U256,
+        slot: &StorageSlot,
         element_type: Type<'context>,
         block: &BlockRef<'context, 'block>,
     ) -> Value<'context, 'block> {
@@ -109,6 +108,6 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
             .pointer(element_type, DataLocation::Storage);
         self.state
             .builder
-            .emit_sol_addr_of(&format!("slot_{slot}"), pointer_type, block)
+            .emit_sol_addr_of(&slot.name, pointer_type, block)
     }
 }

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod expression;
 pub mod statement;
+pub mod storage_slot;
 
 use std::collections::HashMap;
 
@@ -12,7 +13,6 @@ use melior::ir::BlockRef;
 use melior::ir::Type;
 use melior::ir::Value;
 use melior::ir::r#type::IntegerType;
-use ruint::aliases::U256;
 use slang_solidity_v2::abi::AbiEntry;
 use slang_solidity_v2::ast::ContractDefinition;
 use slang_solidity_v2::ast::ElementaryType;
@@ -29,6 +29,7 @@ use solx_mlir::StateMutability;
 use self::expression::ExpressionEmitter;
 use self::expression::call::type_conversion::TypeConversion;
 use self::statement::StatementEmitter;
+use self::storage_slot::StorageSlot;
 
 /// Lowers a Solidity function definition to a `sol.func` operation.
 pub struct FunctionEmitter<'state, 'context> {
@@ -36,8 +37,10 @@ pub struct FunctionEmitter<'state, 'context> {
     state: &'state Context<'context>,
     /// Containing contract.
     contract: &'state ContractDefinition,
-    /// State variable node ID to storage slot mapping.
-    storage_layout: &'state HashMap<NodeId, U256>,
+    /// State variable node ID to `(slot, byte_offset)` mapping. The byte
+    /// offset is zero for unpacked variables and non-zero for variables
+    /// packed into a shared slot.
+    storage_layout: &'state HashMap<NodeId, StorageSlot>,
 }
 
 impl<'state, 'context> FunctionEmitter<'state, 'context> {
@@ -45,7 +48,7 @@ impl<'state, 'context> FunctionEmitter<'state, 'context> {
     pub fn new(
         state: &'state Context<'context>,
         contract: &'state ContractDefinition,
-        storage_layout: &'state HashMap<NodeId, U256>,
+        storage_layout: &'state HashMap<NodeId, StorageSlot>,
     ) -> Self {
         Self {
             state,

--- a/solx-slang/src/ast/contract/function/statement/mod.rs
+++ b/solx-slang/src/ast/contract/function/statement/mod.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use melior::ir::BlockRef;
 use melior::ir::Region;
 use melior::ir::Type;
-use ruint::aliases::U256;
 use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::NodeId;
 use slang_solidity_v2::ast::Statement;
@@ -23,6 +22,7 @@ use solx_mlir::Environment;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
+use crate::ast::contract::function::storage_slot::StorageSlot;
 
 /// Lowers Solidity statements to MLIR operations with control flow.
 ///
@@ -38,7 +38,7 @@ pub struct StatementEmitter<'state, 'context, 'block> {
     /// without lifetime conflicts.
     region_pointer: *const Region<'context>,
     /// State variable node ID to storage slot mapping.
-    storage_layout: &'state HashMap<NodeId, U256>,
+    storage_layout: &'state HashMap<NodeId, StorageSlot>,
     /// The function's declared return types, for `emit_return` to cast to.
     return_types: &'state [Type<'context>],
     /// Whether arithmetic operations use checked variants (`sol.cadd` etc.).
@@ -53,7 +53,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         state: &'state Context<'context>,
         environment: &'state mut Environment<'context, 'block>,
         region: &Region<'context>,
-        storage_layout: &'state HashMap<NodeId, U256>,
+        storage_layout: &'state HashMap<NodeId, StorageSlot>,
         return_types: &'state [Type<'context>],
     ) -> Self {
         Self {

--- a/solx-slang/src/ast/contract/function/storage_slot.rs
+++ b/solx-slang/src/ast/contract/function/storage_slot.rs
@@ -1,0 +1,30 @@
+//!
+//! Storage location of a state variable.
+//!
+
+use ruint::aliases::U256;
+
+/// Storage location of a state variable in contract storage.
+#[derive(Debug, Clone)]
+pub struct StorageSlot {
+    /// 256-bit storage slot index.
+    pub slot: U256,
+    /// Byte offset within the slot. Non-zero only for variables packed
+    /// into a shared slot.
+    pub byte_offset: u32,
+    /// MLIR symbol name, formatted as `{label}_{node_id}` to match solc.
+    /// The slang AST node id disambiguates like-named variables across
+    /// inherited contracts.
+    pub name: String,
+}
+
+impl StorageSlot {
+    /// Creates a slot with `{label}_{node_id}` as the MLIR symbol name.
+    pub fn new(slot: U256, byte_offset: u32, label: &str, node_id: impl std::fmt::Display) -> Self {
+        Self {
+            slot,
+            byte_offset,
+            name: format!("{label}_{node_id}"),
+        }
+    }
+}

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -7,7 +7,6 @@ pub mod function;
 
 use std::collections::HashMap;
 
-use ruint::aliases::U256;
 use slang_solidity_v2::ast::ContractDefinition;
 use slang_solidity_v2::ast::ContractMember;
 use slang_solidity_v2::ast::FunctionKind;
@@ -18,6 +17,7 @@ use solx_mlir::Context;
 
 use self::function::FunctionEmitter;
 use self::function::expression::call::type_conversion::TypeConversion;
+use self::function::storage_slot::StorageSlot;
 
 /// Lowers a Solidity contract to Sol dialect MLIR.
 ///
@@ -89,8 +89,9 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
             let element_type =
                 TypeConversion::resolve_state_variable_type(&state_variable, &self.state.builder)?;
             self.state.builder.emit_sol_state_var(
-                &format!("slot_{slot}"),
-                *slot,
+                &slot.name,
+                slot.slot,
+                slot.byte_offset,
                 element_type,
                 &contract_body,
             );
@@ -134,15 +135,26 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
 
     /// Computes the storage layout using slang-solidity's ABI computation.
     ///
-    /// Returns a mapping from state variable node ID to storage slot.
-    /// Returns an empty map if the ABI is unavailable.
-    fn compute_storage_layout(contract: &ContractDefinition) -> HashMap<NodeId, U256> {
+    /// Returns a mapping from state variable node ID to its storage slot
+    /// (slot index and byte offset within the slot). Returns an empty map
+    /// if the ABI is unavailable.
+    fn compute_storage_layout(contract: &ContractDefinition) -> HashMap<NodeId, StorageSlot> {
         let Some(abi) = contract.compute_abi() else {
             return HashMap::new();
         };
         abi.storage_layout()
             .iter()
-            .map(|item| (item.node_id(), item.slot()))
+            .map(|item| {
+                (
+                    item.node_id(),
+                    StorageSlot::new(
+                        item.slot(),
+                        item.offset() as u32,
+                        item.label(),
+                        item.node_id(),
+                    ),
+                )
+            })
             .collect()
     }
 }


### PR DESCRIPTION
Aligns `sol.state_var` emission and storage `sol.addr_of` with solc's MLIR for contracts with packed state variables, branched off `feat-slang-state-var-initializers`. Two pre-existing bugs surfaced once state vars stopped being hard-coded to `ui256`:

- Every state variable's MLIR symbol was named `slot_{N}` keyed by slot number, so two variables packed into the same slot collided with `error: redefinition of symbol named 'slot_N'`. Now the name is `{label}_{node_id}` (solc convention), unique per definition.
- `sol.state_var` always emitted `offset 0`, ignoring the byte offset within a packed slot. Now the slang ABI's offset carries through.
- `emit_storage_addr_of` returned a hard-coded `!sol.ptr<ui256, Storage>` regardless of the variable's declared element type. Now it builds `!sol.ptr<{element_type}, Storage>` so the verifier accepts addressing a `ui8` slot.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1901 | 1905 | +4 |
| FAILED | 6 | 6 | 0 |
| INVALID | 304 | 302 | −2 |
| Total | 2211 | 2213 | +2 |

Newly fully passing:

- tests/solidity/simple/storage/unaligned/complex_operator.sol
- tests/solidity/simple/storage/unaligned/simple_operator.sol

