### PR TITLE
feat(mlir): emit wide integer constants without parser round-trip

### DIFF
--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -10,9 +10,14 @@
 
 #include "mlir/Dialect/Sol/Sol.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <vector>
 
@@ -48,6 +53,16 @@ MlirAttribute solxCreateEvmVersionAttr(MlirContext ctx, uint32_t version) {
     auto attr = mlir::sol::EvmVersionAttr::get(
         context, static_cast<mlir::sol::EvmVersion>(version));
     return wrap(attr);
+}
+
+MlirAttribute solxCreateIntegerAttr(MlirType ty, bool isNegative,
+                                    size_t numWords, const uint64_t *magnitude) {
+    unsigned bitWidth = unwrap(ty).getIntOrFloatBitWidth();
+    llvm::APInt value = numWords == 0
+        ? llvm::APInt::getZero(bitWidth)
+        : llvm::APInt(bitWidth, llvm::ArrayRef<uint64_t>(magnitude, numWords));
+    if (isNegative) value.negate();
+    return mlirIntegerAttrGetFromWords(ty, value.getNumWords(), value.getRawData());
 }
 
 MlirType solxCreatePointerType(MlirContext ctx, MlirType elementType, uint32_t dataLocation) {

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -239,13 +239,6 @@ impl<'context> Builder<'context> {
     /// other integer type is signed or unsigned and belongs to the sol
     /// dialect. This is the single entry point for MLIR integer constants
     /// that carry a `BigInt`-sized value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the MLIR attribute parser rejects the `{value} : {type}`
-    /// rendering. For well-typed callers this is unreachable because the
-    /// type is a melior `IntegerType` and the value is a `BigInt` that
-    /// always has a canonical decimal representation.
     pub fn emit_constant<'block, B>(
         &self,
         value: &BigInt,
@@ -267,11 +260,15 @@ impl<'context> Builder<'context> {
                 .emit_constant_operation(boolean_attribute, result_type, block)
                 .expect("well-typed boolean constant never fails emission");
         }
-        // melior does not expose a `BigInt`-accepting attribute constructor,
-        // so we round-trip through the MLIR attribute parser to avoid
-        // truncating values wider than 64 bits.
-        let attribute = Attribute::parse(self.context, &format!("{value} : {result_type}"))
-            .expect("BigInt value and melior integer type always parse as an MLIR attribute");
+        let (sign, words) = value.to_u64_digits();
+        let attribute = unsafe {
+            Attribute::from_raw(crate::ffi::solxCreateIntegerAttr(
+                result_type.to_raw(),
+                sign == num::bigint::Sign::Minus,
+                words.len(),
+                words.as_ptr(),
+            ))
+        };
         self.emit_constant_operation(attribute, result_type, block)
             .expect("well-typed BigInt constant never fails emission")
     }

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -84,6 +84,17 @@ unsafe extern "C" {
     /// Creates an `EvmVersionAttr`.
     pub fn solxCreateEvmVersionAttr(context: MlirContext, version: u32) -> mlir_sys::MlirAttribute;
 
+    /// Creates an MLIR `IntegerAttr` of `ty` from an LSB-first array of
+    /// `num_words` 64-bit chunks describing the unsigned magnitude. When
+    /// `is_negative` is true the result is the two's-complement of that
+    /// magnitude within the type's bit width.
+    pub fn solxCreateIntegerAttr(
+        ty: mlir_sys::MlirType,
+        is_negative: bool,
+        num_words: usize,
+        magnitude: *const u64,
+    ) -> mlir_sys::MlirAttribute;
+
     // ---- Sol type constructors (from sol_attr_stubs.cpp) ----
 
     /// Creates a `sol::PointerType` with the given element type and data location.


### PR DESCRIPTION
Replaces the `BigInt → decimal → MLIR attribute parser` round-trip in `Builder::emit_constant` with a direct APInt-based construction via a new `solxCreateIntegerAttr` C wrapper in `sol_attr_stubs.cpp`. The Rust side passes the BigInt magnitude as LSB-first `u64` words plus a sign flag; the wrapper builds the APInt and negates it when the value is negative.

Bumps the solx-llvm submodule to bring in the upstream cherry-pick of `mlirIntegerAttrGetFromWords` and the matching accessors from llvm/llvm-project#177733 (matter-labs/solx-llvm#80).