### PR TITLE
feat(slang): inline contract-level constant references

### DIFF
--- a/solx-mlir/tests/lit/constant_reference.sol
+++ b/solx-mlir/tests/lit/constant_reference.sol
@@ -1,0 +1,24 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// CHECK: sol.func {{.*}}get
+// CHECK:   sol.constant 42 : ui8
+// CHECK:   sol.return %{{.*}} : ui8
+
+// CHECK: sol.func {{.*}}getDouble
+// CHECK:   sol.constant 42 : ui8
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.cmul %{{.*}}, %{{.*}} : ui8
+// CHECK:   sol.return %{{.*}} : ui8
+
+contract C {
+    uint8 constant TEST = 42;
+    uint8 constant DOUBLE = TEST * 2;
+
+    function get() public pure returns (uint8) {
+        return TEST;
+    }
+
+    function getDouble() public pure returns (uint8) {
+        return DOUBLE;
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -202,6 +202,24 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                                 .emit_sol_load(pointer, element_type, &block)?;
                         Ok((Some(value), block))
                     }
+                    Some(Definition::Constant(constant_definition)) => {
+                        let initializer = constant_definition.value().ok_or_else(|| {
+                            anyhow::anyhow!("constant '{name}' has no initializer")
+                        })?;
+                        let slang_type = constant_definition.get_type().ok_or_else(|| {
+                            anyhow::anyhow!("unresolved type for constant: {name}")
+                        })?;
+                        let target_type = TypeConversion::resolve_slang_type(
+                            &slang_type,
+                            None,
+                            &self.state.builder,
+                        );
+                        let (value, block) = self.emit_value(&initializer, block)?;
+                        let cast =
+                            TypeConversion::from_target_type(target_type, &self.state.builder)
+                                .emit(value, &self.state.builder, &block);
+                        Ok((Some(cast), block))
+                    }
                     None => anyhow::bail!("unresolved identifier: {name}"),
                     Some(_) => anyhow::bail!("unsupported identifier reference: {name}"),
                 }


### PR DESCRIPTION
Handles `Definition::Constant` in the Identifier branch by inlining the constant's initializer expression at the use site, branched off `feat-slang-skip-noop-address-cast`. Solidity constants are required to be compile-time-evaluable, so emitting the expression directly (`sol.constant 42 : ui8`, or `42 * 2` folded via `sol.cmul`) and then casting to the declared type is functionally equivalent to inlining.

Distinct from #401 in another stack — both fix the same gap; whichever lands later resolves trivially at merge time.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1803 | 1907 | +104 |
| FAILED | 6 | 8 | +2 |
| INVALID | 338 | 305 | −33 |
| Total | 2147 | 2220 | +73 |

32 newly fully passing — full list under the fold. The +2 FAILED is `algorithm/cryptography/book_cypher.sol` going from INVALID to "compiles but trips a runtime semantic check"; the deploy case now passes, the main case fails.

<details>
<summary>Newly fully passing files</summary>

- tests/solidity/simple/algorithm/cryptography/caesar_cypher.sol
- tests/solidity/simple/algorithm/cryptography/vigenere_cypher.sol
- tests/solidity/simple/algorithm/floating_point_simulation/geometry/area.sol
- tests/solidity/simple/algorithm/floating_point_simulation/geometry/lines.sol
- tests/solidity/simple/algorithm/floating_point_simulation/geometry/volume.sol
- tests/solidity/simple/expression/constant_conditional.sol
- tests/solidity/simple/expression/constant_match.sol
- tests/solidity/simple/expression/mixed_item_constantness.sol
- tests/solidity/simple/loop/array/nested_computation.sol
- tests/solidity/simple/loop/array/simple.sol
- tests/solidity/simple/loop/range_bitlength_inference/u8_to_u256_const.sol
- tests/solidity/simple/loop/range_bitlength_inference/u8_to_u64_const.sol
- tests/solidity/simple/order/casted_declared_const.sol
- tests/solidity/simple/order/declared_const.sol
- tests/solidity/simple/storage/aligned/array/assign.sol
- tests/solidity/simple/storage/aligned/array/assign_nested.sol
- tests/solidity/simple/storage/aligned/array/reassign.sol
- tests/solidity/simple/storage/aligned/array/reassign_nested.sol
- tests/solidity/simple/storage/aligned/mixed_data_origin.sol
- tests/solidity/simple/storage/aligned/structure/assign.sol
- tests/solidity/simple/storage/aligned/structure/assign_nested.sol
- tests/solidity/simple/storage/aligned/structure/reassign.sol
- tests/solidity/simple/storage/aligned/structure/reassign_nested.sol
- tests/solidity/simple/storage/unaligned/array/assign.sol
- tests/solidity/simple/storage/unaligned/array/assign_nested.sol
- tests/solidity/simple/storage/unaligned/array/reassign.sol
- tests/solidity/simple/storage/unaligned/array/reassign_nested.sol
- tests/solidity/simple/storage/unaligned/mixed_data_origin.sol
- tests/solidity/simple/storage/unaligned/structure/assign.sol
- tests/solidity/simple/storage/unaligned/structure/assign_nested.sol
- tests/solidity/simple/storage/unaligned/structure/reassign.sol
- tests/solidity/simple/storage/unaligned/structure/reassign_nested.sol

</details>
