### PR TITLE
feat(slang): bring constant references into the stack

### DIFF
--- a/solx-mlir/tests/lit/constants.sol
+++ b/solx-mlir/tests/lit/constants.sol
@@ -1,0 +1,29 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// Each reference to a contract-level `constant` is inlined as if the
+// initializer expression appeared at the use site, so `FOO` lowers to
+// the same `sol.constant` + `sol.cast` chain as a bare `42` literal.
+
+// CHECK: sol.func @{{.*read.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 42 : ui8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK:      sol.func @{{.*sum.*}}() -> ui256
+// CHECK-DAG:    sol.constant 42 : ui8
+// CHECK-DAG:    sol.constant 42 : ui8
+// CHECK:        sol.cadd %{{.*}}, %{{.*}} : ui256
+// CHECK:        sol.return %{{.*}} : ui256
+
+contract C {
+    uint256 constant FOO = 42;
+
+    function read() public pure returns (uint256) {
+        return FOO;
+    }
+
+    function sum() public pure returns (uint256) {
+        return FOO + FOO;
+    }
+}

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -202,6 +202,12 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                                 .emit_sol_load(pointer, element_type, &block)?;
                         Ok((Some(value), block))
                     }
+                    Some(Definition::Constant(constant)) => {
+                        let initializer = constant
+                            .value()
+                            .ok_or_else(|| anyhow::anyhow!("constant {name} has no initializer"))?;
+                        self.emit(&initializer, block)
+                    }
                     None => anyhow::bail!("unresolved identifier: {name}"),
                     Some(_) => anyhow::bail!("unsupported identifier reference: {name}"),
                 }


### PR DESCRIPTION
Cherry-picks PR #401's commit (`feat(slang): emit contract-level constant references`) on top of `feat-slang-skip-noop-address-cast` so the constants fix is available in this stack. The cherry-picked commit preserves the original author attribution; no logic changes.

When PR #401 lands on `main`, the cherry-picked commit duplicates trivially and the merge resolves to a no-op.

Integration test delta (M3B3), `tests/solidity/simple/`:

| | base | tip | Δ |
|---|---|---|---|
| PASSED | 1803 | 1907 | +104 |
| FAILED | 6 | 8 | +2 |
| INVALID | 338 | 305 | −33 |
| Total | 2147 | 2220 | +73 |

Same delta as the (closed) duplicate PR #429 — that one re-implemented the same fix; this one carries the upstream commit instead.
