### PR TITLE
fix(ci): pin js package managers and ignore pnpm build scripts

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -226,7 +226,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
-      - name: Install Yarn
+      - name: Install JS package managers
         # build-system pin: keep in sync with solx-dev/src/test/hardhat/config/project/build_system.rs::to_npm_spec
         run: ${SFW_PREFIX:-} npm install -g yarn@1.22.22 bun@1.3.13 pnpm@10.17.1
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -227,7 +227,8 @@ jobs:
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Install Yarn
-        run: ${SFW_PREFIX:-} npm install -g yarn bun pnpm
+        # build-system pin: keep in sync with solx-dev/src/test/hardhat/config/project/build_system.rs::to_npm_spec
+        run: ${SFW_PREFIX:-} npm install -g yarn@1.22.22 bun@1.3.13 pnpm@10.17.1
 
       # Some projects might use hardcoded ssh URLs: force git to use https instead.
       - name: Git https settings

--- a/solx-dev/src/test/hardhat/config/project/build_system.rs
+++ b/solx-dev/src/test/hardhat/config/project/build_system.rs
@@ -29,3 +29,19 @@ impl std::fmt::Display for BuildSystem {
         }
     }
 }
+
+impl BuildSystem {
+    /// Argument passed to `npm install --global` to install this build system.
+    /// Pinned to exact versions so behaviour doesn't drift when registry
+    /// `latest` advances under us. `npm` itself is left unpinned because it
+    /// ships with Node and we manage Node via `actions/setup-node`.
+    // build-system pin: keep in sync with .github/workflows/integration-tests.yaml ("Install Yarn" step)
+    pub fn to_npm_spec(&self) -> &'static str {
+        match self {
+            Self::Npm => "npm",
+            Self::Yarn => "yarn@1.22.22",
+            Self::Pnpm => "pnpm@10.17.1",
+            Self::Bun => "bun@1.3.13",
+        }
+    }
+}

--- a/solx-dev/src/test/hardhat/config/project/build_system.rs
+++ b/solx-dev/src/test/hardhat/config/project/build_system.rs
@@ -31,17 +31,19 @@ impl std::fmt::Display for BuildSystem {
 }
 
 impl BuildSystem {
-    /// Argument passed to `npm install --global` to install this build system.
-    /// Pinned to exact versions so behaviour doesn't drift when registry
-    /// `latest` advances under us. `npm` itself is left unpinned because it
-    /// ships with Node and we manage Node via `actions/setup-node`.
-    // build-system pin: keep in sync with .github/workflows/integration-tests.yaml ("Install Yarn" step)
-    pub fn to_npm_spec(&self) -> &'static str {
+    /// Argument passed to `npm install --global` to install this build system,
+    /// or `None` to skip the global install entirely. Pinned to exact versions
+    /// so behaviour doesn't drift when the registry's `latest` tag advances
+    /// under us. `Npm` returns `None` because `npm install -g npm` would
+    /// reinstall the very tool we're bootstrapping from — the Node-bundled
+    /// npm (managed via `actions/setup-node`) is used directly instead.
+    // build-system pin: keep in sync with .github/workflows/integration-tests.yaml ("Install JS package managers" step)
+    pub fn to_npm_spec(&self) -> Option<&'static str> {
         match self {
-            Self::Npm => "npm",
-            Self::Yarn => "yarn@1.22.22",
-            Self::Pnpm => "pnpm@10.17.1",
-            Self::Bun => "bun@1.3.13",
+            Self::Npm => None,
+            Self::Yarn => Some("yarn@1.22.22"),
+            Self::Pnpm => Some("pnpm@10.17.1"),
+            Self::Bun => Some("bun@1.3.13"),
         }
     }
 }

--- a/solx-dev/src/test/hardhat/mod.rs
+++ b/solx-dev/src/test/hardhat/mod.rs
@@ -127,7 +127,7 @@ pub fn test(
             npm_install_build_system.arg("--yes");
             npm_install_build_system.arg("install");
             npm_install_build_system.arg("--global");
-            npm_install_build_system.arg(build_system.as_str());
+            npm_install_build_system.arg(project.build_system.to_npm_spec());
             crate::utils::command_with_retries(
                 &mut npm_install_build_system,
                 format!(
@@ -140,10 +140,16 @@ pub fn test(
             )?;
             let mut build_system_install_command = Command::new(build_system.as_str());
             build_system_install_command.current_dir(project_directory.as_path());
-            if let BuildSystem::Npm = project.build_system {
-                build_system_install_command.args(["--loglevel", "error"]);
-                build_system_install_command.arg("--force");
-                build_system_install_command.arg("--yes");
+            match project.build_system {
+                BuildSystem::Npm => {
+                    build_system_install_command.args(["--loglevel", "error"]);
+                    build_system_install_command.arg("--force");
+                    build_system_install_command.arg("--yes");
+                }
+                BuildSystem::Pnpm => {
+                    build_system_install_command.arg("--ignore-scripts");
+                }
+                _ => {}
             }
             build_system_install_command.arg("install");
             crate::utils::command_with_retries(
@@ -166,6 +172,9 @@ pub fn test(
                 }
                 BuildSystem::Yarn => {
                     dependency_override_command.arg("--silent");
+                }
+                BuildSystem::Pnpm => {
+                    dependency_override_command.arg("--ignore-scripts");
                 }
                 _ => {}
             }

--- a/solx-dev/src/test/hardhat/mod.rs
+++ b/solx-dev/src/test/hardhat/mod.rs
@@ -120,24 +120,26 @@ pub fn test(
             }
 
             let build_system = project.build_system.to_string();
-            let mut npm_install_build_system = Command::new("npm");
-            npm_install_build_system.current_dir(project_directory.as_path());
-            npm_install_build_system.args(["--loglevel", "error"]);
-            npm_install_build_system.arg("--force");
-            npm_install_build_system.arg("--yes");
-            npm_install_build_system.arg("install");
-            npm_install_build_system.arg("--global");
-            npm_install_build_system.arg(project.build_system.to_npm_spec());
-            crate::utils::command_with_retries(
-                &mut npm_install_build_system,
-                format!(
-                    "{} build system {} for Hardhat project {project_name}",
-                    solx_utils::cargo_status_ok("Installing"),
-                    build_system.bright_yellow().bold()
-                )
-                .as_str(),
-                16,
-            )?;
+            if let Some(npm_spec) = project.build_system.to_npm_spec() {
+                let mut npm_install_build_system = Command::new("npm");
+                npm_install_build_system.current_dir(project_directory.as_path());
+                npm_install_build_system.args(["--loglevel", "error"]);
+                npm_install_build_system.arg("--force");
+                npm_install_build_system.arg("--yes");
+                npm_install_build_system.arg("install");
+                npm_install_build_system.arg("--global");
+                npm_install_build_system.arg(npm_spec);
+                crate::utils::command_with_retries(
+                    &mut npm_install_build_system,
+                    format!(
+                        "{} build system {} for Hardhat project {project_name}",
+                        solx_utils::cargo_status_ok("Installing"),
+                        build_system.bright_yellow().bold()
+                    )
+                    .as_str(),
+                    16,
+                )?;
+            }
             let mut build_system_install_command = Command::new(build_system.as_str());
             build_system_install_command.current_dir(project_directory.as_path());
             match project.build_system {


### PR DESCRIPTION
Hardhat integration tests started failing because `npm install -g pnpm` resolves whatever the registry's `latest` tag points at. A later 10.x release turned `ERR_PNPM_IGNORED_BUILDS` into a hard exit, and the openzeppelin fixture doesn't pre-approve native build scripts (keccak, secp256k1) via `pnpm.onlyBuiltDependencies`, so every `pnpm install` exited 1 through all 16 retries.

Pin all three managers at both install sites:

- The workflow's `Install Yarn` step (`npm install -g …`) now installs `yarn@1.22.22 bun@1.3.13 pnpm@10.17.1`.
- The harness's per-project global install now routes through a new `BuildSystem::to_npm_spec()` returning the same three pinned specs. `npm` itself is left unpinned because it ships with Node and Node is managed via `actions/setup-node`.

A `build-system pin:` marker comment in both files cross-references the other, so the literal version pairs are grep-discoverable and won't silently drift apart.

Also pass `--ignore-scripts` to pnpm's per-project install and the dependency-override install. The test harness doesn't need keccak's or secp256k1's native binding builds — both fall back to pure-JS for the Hardhat test workloads — so skipping postinstall scripts entirely is safer and pnpm-version-independent.