### PR TITLE
refactor(solx-dev): move JS pkg manager pins into harness configs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -226,10 +226,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
-      - name: Install JS package managers
-        # build-system pin: keep in sync with solx-dev/src/test/hardhat/config/project/build_system.rs::to_npm_spec
-        run: ${SFW_PREFIX:-} npm install -g yarn@1.22.22 bun@1.3.13 pnpm@10.17.1
-
       # Some projects might use hardcoded ssh URLs: force git to use https instead.
       - name: Git https settings
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,20 @@
   "schedule": ["before 9am on Monday"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track build-system and dependency pins inside solx-dev harness configs. The `pkg = \"x.y.z\"` shape appears in both `hardhat-tests.toml` and `foundry-tests.toml` under `[build_systems]`; the `\"pkg@x.y.z\"` shape appears in `hardhat-tests.toml` `dependencies` arrays (foundry-tests.toml has no such arrays).",
+      "fileMatch": [
+        "^solx-dev/(hardhat|foundry)-tests\\.toml$"
+      ],
+      "matchStrings": [
+        "\"(?<depName>[a-z][\\w-]*)@(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "(?<depName>yarn|pnpm|bun)\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
     {
       "description": "Extra cooldown for majors",
@@ -58,6 +72,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/nomicfoundation/solx-ci-runner"],
       "enabled": false
+    },
+    {
+      "description": "Pin yarn to 1.x (Classic). Yarn 2+ (Berry) is a different product and the Hardhat/Foundry fixtures we run use Yarn 1 semantics; never auto-bump across that line.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["yarn"],
+      "allowedVersions": "<2"
     }
   ],
   "labels": ["dependencies"],

--- a/solx-dev/foundry-tests.toml
+++ b/solx-dev/foundry-tests.toml
@@ -1,5 +1,9 @@
 # Foundry project test configuration.
 #
+# Build systems:
+#   [build_systems]
+#   yarn = "<x.y.z>"                # Pinned version installed globally before each project run.
+#
 # Compilers:
 #   [compilers.<id>]
 #   name = "00.solc"              # Display name in reports (hyphens become newlines)
@@ -24,6 +28,9 @@
 #   left = "03.solx-legacy"         # Left toolchain: {compiler.name}-{codegen}
 #   right = "02.solx-main-legacy"   # Right toolchain: {compiler.name}-{codegen}
 #   disabled = true/false           # Whether to skip this comparison
+
+[build_systems]
+yarn = "1.22.22"
 
 [compilers.solc]
 name = "00.solc-0.8.34"

--- a/solx-dev/hardhat-tests.toml
+++ b/solx-dev/hardhat-tests.toml
@@ -1,5 +1,11 @@
 # Hardhat project test configuration.
 #
+# Build systems:
+#   [build_systems]
+#   yarn = "<x.y.z>"                # Pinned version installed globally before each project run.
+#   pnpm = "<x.y.z>"
+#   bun  = "<x.y.z>"
+#
 # Compilers:
 #   [compilers.<id>]
 #   name = "00.solc"              # Display name in reports (hyphens become newlines)
@@ -26,6 +32,11 @@
 #   left = "03.solx-legacy"         # Left toolchain: {compiler.name}-{codegen}
 #   right = "02.solx-main-legacy"   # Right toolchain: {compiler.name}-{codegen}
 #   disabled = true/false           # Whether to skip this comparison
+
+[build_systems]
+yarn = "1.22.22"
+pnpm = "10.17.1"
+bun = "1.3.13"
 
 [compilers.solc]
 name = "00.solc-0.8.34"

--- a/solx-dev/src/test/foundry/config/mod.rs
+++ b/solx-dev/src/test/foundry/config/mod.rs
@@ -25,6 +25,9 @@ pub struct Config {
     /// List of comparisons for Excel diff columns.
     #[serde(default)]
     pub comparisons: Vec<Comparison>,
+    /// Pinned versions of build systems installed globally before per-project tests.
+    #[serde(default)]
+    pub build_systems: BTreeMap<String, String>,
 }
 
 impl TryFrom<PathBuf> for Config {

--- a/solx-dev/src/test/foundry/mod.rs
+++ b/solx-dev/src/test/foundry/mod.rs
@@ -123,6 +123,12 @@ pub fn test(
                 crate::utils::exists("npm")?;
 
                 let build_system = "yarn";
+                let yarn_version = config.build_systems.get(build_system).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Foundry test configuration missing `build_systems.{build_system}`"
+                    )
+                })?;
+                let npm_spec = format!("{build_system}@{yarn_version}");
                 let mut npm_install_yarn = Command::new("npm");
                 npm_install_yarn.current_dir(project_directory.as_path());
                 npm_install_yarn.arg("install");
@@ -130,7 +136,7 @@ pub fn test(
                 npm_install_yarn.arg("--force");
                 npm_install_yarn.arg("--yes");
                 npm_install_yarn.arg("--global");
-                npm_install_yarn.arg(build_system);
+                npm_install_yarn.arg(&npm_spec);
                 crate::utils::command_with_retries(
                     &mut npm_install_yarn,
                     format!(

--- a/solx-dev/src/test/hardhat/config/mod.rs
+++ b/solx-dev/src/test/hardhat/config/mod.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use self::comparison::Comparison;
 use self::compiler::Compiler;
 use self::project::Project;
+use self::project::build_system::BuildSystem;
 
 ///
 /// `solx` Hardhat config.
@@ -25,6 +26,9 @@ pub struct Config {
     /// List of comparisons for Excel diff columns.
     #[serde(default)]
     pub comparisons: Vec<Comparison>,
+    /// Pinned versions of build systems installed globally before per-project tests.
+    #[serde(default)]
+    pub build_systems: BTreeMap<BuildSystem, String>,
 }
 
 impl TryFrom<PathBuf> for Config {

--- a/solx-dev/src/test/hardhat/config/project/build_system.rs
+++ b/solx-dev/src/test/hardhat/config/project/build_system.rs
@@ -5,7 +5,7 @@
 ///
 /// `solx` Hardhat project build system.
 ///
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BuildSystem {
     /// Eponymous build system.
@@ -26,24 +26,6 @@ impl std::fmt::Display for BuildSystem {
             Self::Yarn => write!(f, "yarn"),
             Self::Pnpm => write!(f, "pnpm"),
             Self::Bun => write!(f, "bun"),
-        }
-    }
-}
-
-impl BuildSystem {
-    /// Argument passed to `npm install --global` to install this build system,
-    /// or `None` to skip the global install entirely. Pinned to exact versions
-    /// so behaviour doesn't drift when the registry's `latest` tag advances
-    /// under us. `Npm` returns `None` because `npm install -g npm` would
-    /// reinstall the very tool we're bootstrapping from — the Node-bundled
-    /// npm (managed via `actions/setup-node`) is used directly instead.
-    // build-system pin: keep in sync with .github/workflows/integration-tests.yaml ("Install JS package managers" step)
-    pub fn to_npm_spec(&self) -> Option<&'static str> {
-        match self {
-            Self::Npm => None,
-            Self::Yarn => Some("yarn@1.22.22"),
-            Self::Pnpm => Some("pnpm@10.17.1"),
-            Self::Bun => Some("bun@1.3.13"),
         }
     }
 }

--- a/solx-dev/src/test/hardhat/mod.rs
+++ b/solx-dev/src/test/hardhat/mod.rs
@@ -120,7 +120,8 @@ pub fn test(
             }
 
             let build_system = project.build_system.to_string();
-            if let Some(npm_spec) = project.build_system.to_npm_spec() {
+            if let Some(version) = config.build_systems.get(&project.build_system) {
+                let npm_spec = format!("{build_system}@{version}");
                 let mut npm_install_build_system = Command::new("npm");
                 npm_install_build_system.current_dir(project_directory.as_path());
                 npm_install_build_system.args(["--loglevel", "error"]);
@@ -128,7 +129,7 @@ pub fn test(
                 npm_install_build_system.arg("--yes");
                 npm_install_build_system.arg("install");
                 npm_install_build_system.arg("--global");
-                npm_install_build_system.arg(npm_spec);
+                npm_install_build_system.arg(&npm_spec);
                 crate::utils::command_with_retries(
                     &mut npm_install_build_system,
                     format!(
@@ -139,6 +140,8 @@ pub fn test(
                     .as_str(),
                     16,
                 )?;
+            } else if project.build_system != BuildSystem::Npm {
+                anyhow::bail!("Hardhat test configuration missing `build_systems.{build_system}`");
             }
             let mut build_system_install_command = Command::new(build_system.as_str());
             build_system_install_command.current_dir(project_directory.as_path());


### PR DESCRIPTION
The Hardhat and Foundry harnesses already pin third-party JS deps inside their toml configs (`dependencies = ["hardhat@2.20.1"]` etc.). Pkg-manager versions now live alongside them under a new `[build_systems]` table, parsed into `Config.build_systems` and looked up at the install call site. The hardcoded `BuildSystem::to_npm_spec` match arms go away.

Drops the workflow's "Install JS package managers" step — the harness's per-project `npm install -g <spec>` is the only install path needed and runs identically in CI and locally, so the workflow step was duplicating what the harness already does. The cross-file marker comments pairing yaml and Rust go away with it. The Foundry harness's previously-hardcoded `let build_system = "yarn"` install also reads from the new config, so the third install site is now pinned the same way.

Renovate picks up the new pins via a `customManagers` regex scoped to `solx-dev/(hardhat|foundry)-tests.toml`; the same regex also covers existing `dependencies` array literals that previously weren't tracked. A `<2` `allowedVersions` rule on `yarn` prevents auto-bumping across Classic→Berry since the fixtures rely on Yarn 1 semantics.

Validated locally with `cargo check`/`fmt`/`clippy`/`test` on `solx-dev`, `renovate-config-validator`, and `renovate --platform=local --dry-run=full` — each `[build_systems]` entry and each `dependencies = ["pkg@x.y.z"]` literal extracts as an npm-datasource dep with the expected update list.

Addresses #433.
