### PR TITLE
fix(mlir): adapt to Sol→Yul pipeline split and align codegen with solc

### DIFF
--- a/solx-mlir/build.rs
+++ b/solx-mlir/build.rs
@@ -20,12 +20,13 @@ fn main() {
     // Sol dialect — custom Solidity MLIR dialect defined in solx-llvm.
     println!("cargo:rustc-link-lib=static=MLIRSolDialect");
     println!("cargo:rustc-link-lib=static=MLIRCAPISol");
-    println!("cargo:rustc-link-lib=static=MLIRSolToStandard");
+    println!("cargo:rustc-link-lib=static=MLIRSolToYul");
     println!("cargo:rustc-link-lib=static=MLIRSolTransforms");
 
-    // Yul dialect — dependency of the Sol-to-standard conversion pass.
+    // Yul dialect — dependency of the Sol-to-Yul conversion pass.
     println!("cargo:rustc-link-lib=static=MLIRYulDialect");
     println!("cargo:rustc-link-lib=static=MLIRCAPIYul");
+    println!("cargo:rustc-link-lib=static=MLIRYulToStandard");
 
     let include_path = std::path::PathBuf::from(&prefix).join("include");
 

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -255,15 +255,9 @@ impl<'context> Builder<'context> {
         if TypeFactory::integer_bit_width(result_type) == solx_utils::BIT_LENGTH_BOOLEAN as u32 {
             let boolean_attribute =
                 IntegerAttribute::new(result_type, i64::from(*value != BigInt::ZERO)).into();
-            return block
-                .append_operation(melior::dialect::arith::constant(
-                    self.context,
-                    boolean_attribute,
-                    self.unknown_location,
-                ))
-                .result(0)
-                .expect("arith.constant always produces one result")
-                .into();
+            return self
+                .emit_constant_operation(boolean_attribute, result_type, block)
+                .expect("well-typed boolean constant never fails emission");
         }
         // melior does not expose a `BigInt`-accepting attribute constructor,
         // so we round-trip through the MLIR attribute parser to avoid

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -8,8 +8,6 @@
 
 pub mod type_factory;
 
-use melior::dialect::ods::scf::IfOperation as ScfIfOperation;
-use melior::dialect::ods::scf::YieldOperation as ScfYieldOperation;
 use melior::ir::Attribute;
 use melior::ir::Block;
 use melior::ir::BlockLike;
@@ -447,82 +445,6 @@ impl<'context> Builder<'context> {
             .first_block()
             .expect("else region has a block");
         (then_ref, else_ref)
-    }
-
-    /// Emits a value-producing `scf.if` with then and else regions.
-    ///
-    /// Returns `(then_block, else_block)`. Each region must be terminated
-    /// with `emit_scf_yield` passing a value matching the result type.
-    /// The operation result is the yielded value from the taken branch.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the operation result cannot be extracted.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the MLIR operation cannot be constructed.
-    pub fn emit_scf_if<'block>(
-        &self,
-        condition: Value<'context, 'block>,
-        result_type: Type<'context>,
-        block: &BlockRef<'context, 'block>,
-    ) -> anyhow::Result<(
-        BlockRef<'context, 'block>,
-        BlockRef<'context, 'block>,
-        Value<'context, 'block>,
-    )>
-    where
-        'context: 'block,
-    {
-        let then_region = Region::new();
-        let then_block = Block::new(&[]);
-        then_region.append_block(then_block);
-
-        let else_region = Region::new();
-        let else_block = Block::new(&[]);
-        else_region.append_block(else_block);
-
-        let operation = block.append_operation(
-            ScfIfOperation::builder(self.context, self.unknown_location)
-                .results(&[result_type])
-                .condition(condition)
-                .then_region(then_region)
-                .else_region(else_region)
-                .build()
-                .into(),
-        );
-
-        let result = operation.result(0)?.into();
-        let then_ref = operation
-            .region(0)
-            .expect("scf.if has then region")
-            .first_block()
-            .expect("then region has a block");
-        let else_ref = operation
-            .region(1)
-            .expect("scf.if has else region")
-            .first_block()
-            .expect("else region has a block");
-        Ok((then_ref, else_ref, result))
-    }
-
-    /// Emits a `scf.yield` region terminator with a value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the MLIR operation cannot be constructed.
-    pub fn emit_scf_yield<'block, B>(&self, operands: &[Value<'context, 'block>], block: &B)
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        block.append_operation(
-            ScfYieldOperation::builder(self.context, self.unknown_location)
-                .results(operands)
-                .build()
-                .into(),
-        );
     }
 
     /// Emits a `sol.while` with condition and body regions.

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -277,29 +277,6 @@ impl<'context> Builder<'context> {
         self.emit_constant(&BigInt::from(u8::from(value)), self.types.i1, block)
     }
 
-    /// Emits an all-ones `sol.constant` for the given integer type.
-    pub fn emit_sol_constant_all_ones<'block, B>(
-        &self,
-        integer_type: Type<'context>,
-        block: &B,
-    ) -> Value<'context, 'block>
-    where
-        B: BlockLike<'context, 'block>,
-        'context: 'block,
-    {
-        let all_ones = if IntegerType::try_from(integer_type)
-            .ok()
-            .is_some_and(|integer| integer.is_signed())
-        {
-            // Two's-complement all-ones for any signed width is `-1`.
-            BigInt::from(-1)
-        } else {
-            let bit_width = TypeFactory::integer_bit_width(integer_type);
-            (BigInt::from(1u32) << bit_width) - BigInt::from(1u32)
-        };
-        self.emit_constant(&all_ones, integer_type, block)
-    }
-
     // ==== String literals ====
 
     /// Emits a `sol.string_lit` constant with a `!sol.string<Memory>` result.

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -105,13 +105,13 @@ impl<'context> Context<'context> {
     /// Creates a new MLIR state with an empty module.
     ///
     /// Sets the `sol.evm_version` module attribute required by the
-    /// `convert-sol-to-std` pass.
+    /// `convert-sol-to-yul` pass.
     pub fn new(context: &'context melior::Context, evm_version: solx_utils::EVMVersion) -> Self {
         let location = Location::unknown(context);
         let module = Module::new(location);
 
         // Set the EVM version attribute on the module — required by the
-        // Sol-to-standard conversion pass.
+        // Sol-to-Yul conversion pass.
         // SAFETY: `solxCreateEvmVersionAttr` returns a valid MlirAttribute
         // from the C++ Sol dialect. The context pointer is valid.
         let evm_version_attribute = unsafe {
@@ -207,12 +207,13 @@ impl<'context> Context<'context> {
     /// Run the Sol-to-LLVM conversion pass pipeline on a module in-place.
     ///
     /// The pass pipeline is:
-    /// 1. `convert-sol-to-std` — Sol + Yul → func/arith/scf/cf/LLVM
-    /// 2. `convert-func-to-llvm`
+    /// 1. `convert-sol-to-yul` — Sol → Yul
+    /// 2. `convert-yul-to-std` — Yul → func/arith/scf/cf/LLVM
     /// 3. `convert-scf-to-cf`
-    /// 4. `convert-cf-to-llvm`
+    /// 4. `convert-func-to-llvm`
     /// 5. `convert-arith-to-llvm`
-    /// 6. `reconcile-unrealized-casts`
+    /// 6. `convert-cf-to-llvm`
+    /// 7. `reconcile-unrealized-casts`
     ///
     /// Modifier lowering and LICM are skipped — they operate on `sol.modifier`
     /// and `sol.while`/`sol.for` ops which are not yet emitted.
@@ -238,7 +239,10 @@ impl<'context> Context<'context> {
                 crate::ffi::mlirCreateSolModifierOpLoweringPass(),
             ));
             pass_manager.add_pass(melior::pass::Pass::from_raw(
-                crate::ffi::mlirCreateConversionConvertSolToStandardPass(),
+                crate::ffi::mlirCreateConversionConvertSolToYulPass(),
+            ));
+            pass_manager.add_pass(melior::pass::Pass::from_raw(
+                crate::ffi::mlirCreateConversionConvertYulToStandardPass(),
             ));
             pass_manager.add_pass(melior::pass::Pass::from_raw(
                 crate::ffi::mlirCreateTransformsCanonicalizer(),

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -2,8 +2,8 @@
 //! FFI bindings for Sol and Yul dialect C API functions.
 //!
 //! These functions are provided by the `libMLIRCAPISol`, `libMLIRSolTransforms`,
-//! `libMLIRSolToStandard`, and `libMLIRCAPIYul` static libraries built from
-//! solx-llvm.
+//! `libMLIRSolToYul`, `libMLIRYulToStandard`, and `libMLIRCAPIYul` static
+//! libraries built from solx-llvm.
 //!
 
 use mlir_sys::MlirBlock;
@@ -37,10 +37,13 @@ unsafe extern "C" {
     /// Creates the `sol-modifier-op-lowering` pass.
     pub fn mlirCreateSolModifierOpLoweringPass() -> MlirPass;
 
-    // ---- Sol-to-Standard conversion ----
+    // ---- Sol-to-Yul conversion ----
 
-    /// Creates the `convert-sol-to-std` pass.
-    pub fn mlirCreateConversionConvertSolToStandardPass() -> MlirPass;
+    /// Creates the `convert-sol-to-yul` pass.
+    pub fn mlirCreateConversionConvertSolToYulPass() -> MlirPass;
+
+    /// Creates the `convert-yul-to-std` pass.
+    pub fn mlirCreateConversionConvertYulToStandardPass() -> MlirPass;
 
     // ---- Standard-to-LLVM conversion passes ----
 

--- a/solx-mlir/tests/lit/bitwise.sol
+++ b/solx-mlir/tests/lit/bitwise.sol
@@ -11,7 +11,7 @@
 // CHECK:   sol.xor %{{.*}}, %{{.*}} : ui256
 
 // CHECK: sol.func @{{.*bit_not.*}}
-// CHECK:   sol.xor %{{.*}}, %{{.*}} : ui256
+// CHECK:   sol.not %{{.*}} : ui256
 
 // CHECK: sol.func @{{.*shift_left.*}}
 // CHECK:   sol.shl %{{.*}}, %{{.*}} : ui256

--- a/solx-mlir/tests/lit/conditional.sol
+++ b/solx-mlir/tests/lit/conditional.sol
@@ -1,0 +1,16 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*ternary.*}}(%{{.*}}: i1, %{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.store %{{.*}}, %[[SLOT:.*]] : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   } else {
+// CHECK:     sol.store %{{.*}}, %[[SLOT]] : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   }
+// CHECK:   sol.load %[[SLOT]] : !sol.ptr<ui256, Stack>, ui256
+
+contract C {
+    function ternary(bool c, uint256 a, uint256 b) public pure returns (uint256) {
+        return c ? a : b;
+    }
+}

--- a/solx-mlir/tests/lit/control_flow.sol
+++ b/solx-mlir/tests/lit/control_flow.sol
@@ -31,7 +31,7 @@
 
 // CHECK: sol.func @{{.*infinite_for.*}}
 // CHECK:   sol.for cond {
-// CHECK:     %[[TRUE:.*]] = arith.constant true
+// CHECK:     %[[TRUE:.*]] = sol.constant true
 // CHECK:     sol.condition %[[TRUE]]
 // CHECK:   } body {
 

--- a/solx-mlir/tests/lit/int_types.sol
+++ b/solx-mlir/tests/lit/int_types.sol
@@ -11,10 +11,10 @@
 // CHECK:   sol.cadd %{{.*}}, %{{.*}} : si256
 
 // CHECK: sol.func @{{.*bool_return.*}}
-// CHECK:   %true = arith.constant true
+// CHECK:   %true = sol.constant true
 
 // CHECK: sol.func @{{.*bool_false.*}}
-// CHECK:   %false = arith.constant false
+// CHECK:   %false = sol.constant false
 
 contract C {
     function uint8_arith(uint8 a, uint8 b) public pure returns (uint8) {

--- a/solx-mlir/tests/lit/logical.sol
+++ b/solx-mlir/tests/lit/logical.sol
@@ -3,7 +3,7 @@
 
 // Short-circuit &&: alloca a result slot, seed it, conditionally store b in
 // the then-branch, then load and return. Both compilers seed with
-// `arith.constant false`.
+// `sol.constant false`.
 // CHECK: sol.func @{{.*logical_and.*}}
 // CHECK:   sol.alloca : !sol.ptr<i1, Stack>
 // CHECK:   sol.alloca : !sol.ptr<i1, Stack>
@@ -19,13 +19,13 @@
 
 // Short-circuit ||: same shape, with the conditional store in the else-branch.
 // Seed differs: solc stores the loaded `a` (a SSA register); solx stores
-// `arith.constant true` (constant-folded "if a is true the result is true").
+// `sol.constant true` (constant-folded "if a is true the result is true").
 // CHECK: sol.func @{{.*logical_or.*}}
 // CHECK:   sol.alloca : !sol.ptr<i1, Stack>
 // CHECK:   sol.alloca : !sol.ptr<i1, Stack>
 // CHECK:   %[[RES:.*]] = sol.alloca : !sol.ptr<i1, Stack>
 // CHECK-SOLC:   sol.store %{{.*}}, %[[RES]]
-// CHECK-SOLX:   %[[T:.*]] = arith.constant true
+// CHECK-SOLX:   %[[T:.*]] = sol.constant true
 // CHECK-SOLX:   sol.store %[[T]], %[[RES]]
 // CHECK:   sol.if %{{.*}} {
 // CHECK:   } else {

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -34,8 +34,8 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
         target_type: Option<Type<'context>>,
         block: BlockRef<'context, 'block>,
     ) -> anyhow::Result<(Value<'context, 'block>, BlockRef<'context, 'block>)> {
-        let (lhs, block) = self.emit_value(left, block)?;
         let (rhs, block) = self.emit_value(right, block)?;
+        let (lhs, block) = self.emit_value(left, block)?;
         let result_type = target_type.unwrap_or_else(|| {
             let lhs_width = solx_mlir::TypeFactory::integer_bit_width(lhs.r#type());
             let rhs_width = solx_mlir::TypeFactory::integer_bit_width(rhs.r#type());

--- a/solx-slang/src/ast/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/ast/contract/function/expression/arithmetic.rs
@@ -13,8 +13,8 @@ use slang_solidity::backend::ir::ast::Definition;
 use slang_solidity::backend::ir::ast::Expression;
 
 use solx_mlir::CmpPredicate;
+use solx_mlir::ods::sol::NotOperation;
 use solx_mlir::ods::sol::SubOperation;
-use solx_mlir::ods::sol::XorOperation;
 
 use crate::ast::contract::function::expression::ExpressionEmitter;
 use crate::ast::contract::function::expression::call::type_conversion::TypeConversion;
@@ -102,23 +102,18 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let operand_type = target_type.unwrap_or_else(|| value.r#type());
                 let value = TypeConversion::from_target_type(operand_type, &self.state.builder)
                     .emit(value, &self.state.builder, &block);
-                let all_ones = self
-                    .state
-                    .builder
-                    .emit_sol_constant_all_ones(operand_type, &block);
                 let result = block
                     .append_operation(
-                        XorOperation::builder(
+                        NotOperation::builder(
                             self.state.builder.context,
                             self.state.builder.unknown_location,
                         )
-                        .lhs(value)
-                        .rhs(all_ones)
+                        .value(value)
                         .build()
                         .into(),
                     )
                     .result(0)
-                    .expect("sol.xor always produces one result")
+                    .expect("sol.not always produces one result")
                     .into();
                 Ok((result, block))
             }

--- a/solx-slang/src/ast/contract/function/expression/mod.rs
+++ b/solx-slang/src/ast/contract/function/expression/mod.rs
@@ -298,22 +298,32 @@ impl<'state, 'context, 'block> ExpressionEmitter<'state, 'context, 'block> {
                 let (condition_value, block) = self.emit_value(&condition, block)?;
                 let condition_boolean = self.emit_is_nonzero(condition_value, &block);
 
-                let (then_block, else_block, result) =
-                    self.state
-                        .builder
-                        .emit_scf_if(condition_boolean, result_type, &block)?;
+                let result_slot = self.state.builder.emit_sol_alloca(result_type, &block);
+                let (then_block, else_block) =
+                    self.state.builder.emit_sol_if(condition_boolean, &block);
 
                 let true_expression = conditional.true_expression();
                 let (then_value, then_end) = self.emit_value(&true_expression, then_block)?;
                 let then_cast = TypeConversion::from_target_type(result_type, &self.state.builder)
                     .emit(then_value, &self.state.builder, &then_end);
-                self.state.builder.emit_scf_yield(&[then_cast], &then_end);
+                self.state
+                    .builder
+                    .emit_sol_store(then_cast, result_slot, &then_end);
+                self.state.builder.emit_sol_yield(&then_end);
 
                 let false_expression = conditional.false_expression();
                 let (else_value, else_end) = self.emit_value(&false_expression, else_block)?;
                 let else_cast = TypeConversion::from_target_type(result_type, &self.state.builder)
                     .emit(else_value, &self.state.builder, &else_end);
-                self.state.builder.emit_scf_yield(&[else_cast], &else_end);
+                self.state
+                    .builder
+                    .emit_sol_store(else_cast, result_slot, &else_end);
+                self.state.builder.emit_sol_yield(&else_end);
+
+                let result = self
+                    .state
+                    .builder
+                    .emit_sol_load(result_slot, result_type, &block)?;
 
                 Ok((Some(result), block))
             }

--- a/solx-slang/src/ast/contract/function/expression/operator.rs
+++ b/solx-slang/src/ast/contract/function/expression/operator.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use melior::ir::Location;
 use melior::ir::Value;
+use melior::ir::ValueLike;
 use melior::ir::operation::Operation;
 
 use solx_mlir::CmpPredicate;
@@ -188,11 +189,13 @@ impl Operator {
                 .build()
                 .into(),
             Self::Exponentiation if checked => CExpOperation::builder(context, location)
+                .result(lhs.r#type())
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()
                 .into(),
             Self::Exponentiation => ExpOperation::builder(context, location)
+                .result(lhs.r#type())
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -20,7 +20,7 @@ use self::function::expression::call::type_conversion::TypeConversion;
 /// Lowers a Solidity contract to Sol dialect MLIR.
 ///
 /// Emits `sol.contract` wrapping `sol.func` definitions. The
-/// `convert-sol-to-std` pass generates the entry-point dispatcher
+/// `convert-sol-to-yul` pass generates the entry-point dispatcher
 /// from the function selectors.
 pub struct ContractEmitter<'state, 'context> {
     /// The shared MLIR context.


### PR DESCRIPTION
The bump splits the Sol-to-Standard conversion into convert-sol-to-yul plus convert-yul-to-std and tightens the Sol→Yul stage to promote all integer types to i256. The first commit renames the pass wiring and the C API symbols, and adapts the sol.exp / sol.cexp ODS builders to the new result-type setter introduced by Sol_IntExpOp.

The next three commits fix codegen shapes where solx and solc diverged in ways the new pipeline now refuses. emit_constant routes booleans through sol.constant instead of arith.constant so they stay inside the conversion target. The bitwise `~` operator emits sol.not directly instead of xoring against a materialised all-ones constant. The ternary lowers via a statement-only sol.if wrapped around an alloca/store/yield/load slot, matching solc's shape.

The fifth commit drops emit_scf_if and emit_scf_yield from the builder — no caller emits scf.if or scf.yield after the ternary refactor. The sixth swaps binary-operand evaluation order to right-then-left so non-commutative ops produce the same SSA shapes as solc.

Lit fixtures realigned: int_types.sol, control_flow.sol, and logical.sol expect sol.constant for bool literals; bitwise.sol unifies bit_not; conditional.sol covers the ternary lowering.