### PR TITLE
feat(solx-dev): add --install-distribution flag for lean CI install

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -202,7 +202,7 @@ runs:
           LINK_JOBS=1
         fi
 
-        ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} \
+        ./target/release/solx-dev llvm build --build-type ${{ inputs.build-type }} --install-distribution \
           --ccache-variant=ccache ${ENABLE_UTILS} ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${VALGRIND_OPTIONS} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${ENABLE_MLIR} ${SANITIZER} \
           --extra-args "-DCMAKE_EXPORT_COMPILE_COMMANDS='Off'" "-DLLVM_PARALLEL_LINK_JOBS='${LINK_JOBS}'" "-DLLVM_OPTIMIZED_TABLEGEN='On'"
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -96,7 +96,7 @@ jobs:
             pushd temp-solx-main
             ${SFW_PREFIX:-} cargo fetch --locked
             ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-            ./target/release/solx-dev llvm build --build-type Release
+            ./target/release/solx-dev llvm build --build-type Release --install-distribution
             popd
           fi
 

--- a/solx-dev/src/arguments/llvm/build.rs
+++ b/solx-dev/src/arguments/llvm/build.rs
@@ -49,9 +49,12 @@ pub struct Build {
     #[arg(long, help_heading = "Build Features")]
     pub enable_utils: bool,
 
-    /// Whether to build and install the LLVM IR debug tools (`opt`, `llc`).
+    /// Install only the lean `LLVM_DISTRIBUTION_COMPONENTS` whitelist
+    /// (`ninja install-distribution`) plus `llvm-config`. Intended for CI
+    /// artifacts; overridden by `--enable-tests`, which requires the full
+    /// toolset.
     #[arg(long, help_heading = "Build Features")]
-    pub enable_tools: bool,
+    pub install_distribution: bool,
 
     /// Whether to build the LLVM tests.
     #[arg(long, help_heading = "Build Features")]

--- a/solx-dev/src/llvm/mod.rs
+++ b/solx-dev/src/llvm/mod.rs
@@ -24,7 +24,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -50,6 +50,9 @@ pub fn build(
     // tests when not building utils will not work"), so promote `enable_tests`
     // to imply `enable_utils` rather than push that contract onto every caller.
     let enable_utils = enable_utils || enable_tests;
+    // `--enable-tests` requires the full toolset (the regression suite
+    // depends on every LLVM binary), so it overrides `--install-distribution`.
+    let install_distribution = install_distribution && !enable_tests;
 
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
@@ -57,7 +60,7 @@ pub fn build(
                 build_type,
                 enable_mlir,
                 enable_utils,
-                enable_tools,
+                install_distribution,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -72,7 +75,7 @@ pub fn build(
                 build_type,
                 enable_mlir,
                 enable_utils,
-                enable_tools,
+                install_distribution,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -85,7 +88,7 @@ pub fn build(
                 build_type,
                 enable_mlir,
                 enable_utils,
-                enable_tools,
+                install_distribution,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -102,7 +105,7 @@ pub fn build(
                 build_type,
                 enable_mlir,
                 enable_utils,
-                enable_tools,
+                install_distribution,
                 enable_tests,
                 enable_coverage,
                 extra_args,
@@ -117,7 +120,7 @@ pub fn build(
                 build_type,
                 enable_mlir,
                 enable_utils,
-                enable_tools,
+                install_distribution,
                 enable_tests,
                 enable_coverage,
                 extra_args,

--- a/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_linux_gnu.rs
@@ -16,7 +16,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -39,6 +39,12 @@ pub fn build(
     let llvm_module_llvm_str = llvm_module_llvm.to_string_lossy();
     let llvm_build_final_str = llvm_build_final.to_string_lossy();
     let llvm_target_final_str = llvm_target_final.to_string_lossy();
+
+    let distribution_opts = if install_distribution {
+        crate::llvm::platforms::shared::build_opts_distribution(enable_mlir, enable_utils)
+    } else {
+        Vec::new()
+    };
 
     crate::utils::command(
         Command::new("cmake")
@@ -71,10 +77,7 @@ pub fn build(
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_split_dwarf(build_type))
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::build_opts_distribution(
-                enable_mlir,
-                enable_utils,
-            ))
+            .args(&distribution_opts)
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -85,11 +88,11 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
     crate::llvm::platforms::shared::build_and_install_llvm_binaries(
         llvm_build_final.as_ref(),
         llvm_target_final.as_ref(),
-        enable_tools,
+        install_distribution,
     )?;
+
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/aarch64_macos.rs
+++ b/solx-dev/src/llvm/platforms/aarch64_macos.rs
@@ -16,7 +16,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -34,6 +34,12 @@ pub fn build(
     let llvm_module_llvm_str = llvm_module_llvm.to_string_lossy();
     let llvm_build_final_str = llvm_build_final.to_string_lossy();
     let llvm_target_final_str = llvm_target_final.to_string_lossy();
+
+    let distribution_opts = if install_distribution {
+        crate::llvm::platforms::shared::build_opts_distribution(enable_mlir, enable_utils)
+    } else {
+        Vec::new()
+    };
 
     crate::utils::command(
         Command::new("cmake")
@@ -63,10 +69,7 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::build_opts_distribution(
-                enable_mlir,
-                enable_utils,
-            ))
+            .args(&distribution_opts)
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -75,11 +78,10 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
     crate::llvm::platforms::shared::build_and_install_llvm_binaries(
         llvm_build_final.as_ref(),
         llvm_target_final.as_ref(),
-        enable_tools,
+        install_distribution,
     )?;
 
     Ok(())

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -42,11 +42,6 @@ pub const SHARED_BUILD_OPTS: [&str; 23] = [
 /// time.
 const REQUIRED_LLVM_BINARIES: &[&str] = &["llvm-config"];
 
-/// LLVM IR debug tools installed alongside `REQUIRED_LLVM_BINARIES` when
-/// `--enable-tools` is passed, for local inspection and optimization of
-/// emitted IR.
-const OPTIONAL_LLVM_BINARIES: &[&str] = &["opt", "llc"];
-
 ///
 /// The CMake argument for LLVM_ENABLE_PROJECTS.
 /// LLD is always included; MLIR is added when `enable_mlir` is true.
@@ -218,8 +213,7 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
 /// time. `llvm-sys` still needs `llvm-config` at Rust build time —
 /// `build_and_install_llvm_binaries` builds it directly via
 /// `ninja llvm-config` and copies the binary into the install prefix
-/// afterwards. The same helper also installs `opt` and `llc` when
-/// `--enable-tools` is passed. `lld-*` is always included because
+/// afterwards. `lld-*` is always included because
 /// `shared_build_opts_projects` always enables `lld`. `mlir-*` is included
 /// only when `enable_mlir` is true.
 ///
@@ -260,11 +254,10 @@ pub fn build_opts_distribution(enable_mlir: bool, enable_utils: bool) -> Vec<Str
 }
 
 ///
-/// Build the LLVM binaries whose install rules are suppressed by
-/// `LLVM_BUILD_TOOLS=Off` and copy them into the install prefix's `bin/`.
-/// `llvm-config` is always installed (`llvm-sys` needs it at Rust build
-/// time); `opt` and `llc` are added when `enable_tools` is set, for local
-/// LLVM-IR inspection and optimization.
+/// Install LLVM. `install_distribution = false` runs the unfiltered
+/// `ninja install` (full toolset); `true` runs `ninja install-distribution`
+/// and then builds and copies `REQUIRED_LLVM_BINARIES`, whose install rules
+/// are suppressed by `LLVM_BUILD_TOOLS=Off`.
 ///
 /// Both ninja args and the destination path use forward-slash form on
 /// Windows; callers are expected to pass already-normalized paths (existing
@@ -277,13 +270,13 @@ pub fn build_opts_distribution(enable_mlir: bool, enable_utils: bool) -> Vec<Str
 pub fn build_and_install_llvm_binaries(
     build_dir: &Path,
     target_dir: &Path,
-    enable_tools: bool,
+    install_distribution: bool,
 ) -> anyhow::Result<()> {
-    let optional_binaries: &[&str] = if enable_tools {
-        OPTIONAL_LLVM_BINARIES
-    } else {
-        &[]
-    };
+    if !install_distribution {
+        crate::utils::ninja(build_dir, "install")?;
+        return Ok(());
+    }
+    crate::utils::ninja(build_dir, "install-distribution")?;
 
     let exe_suffix = if cfg!(target_os = "windows") {
         ".exe"
@@ -298,11 +291,11 @@ pub fn build_and_install_llvm_binaries(
         Command::new("ninja")
             .arg("-C")
             .arg(&*build_dir_str)
-            .args(REQUIRED_LLVM_BINARIES.iter().chain(optional_binaries)),
+            .args(REQUIRED_LLVM_BINARIES.iter()),
         "Building LLVM binaries",
     )?;
 
-    for bin in REQUIRED_LLVM_BINARIES.iter().chain(optional_binaries) {
+    for bin in REQUIRED_LLVM_BINARIES.iter() {
         let bin_name = format!("{bin}{exe_suffix}");
         fs_extra::file::copy(
             build_dir.join("bin").join(&bin_name),

--- a/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_linux_gnu.rs
@@ -16,7 +16,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -39,6 +39,12 @@ pub fn build(
     let llvm_module_llvm_str = llvm_module_llvm.to_string_lossy();
     let llvm_build_final_str = llvm_build_final.to_string_lossy();
     let llvm_target_final_str = llvm_target_final.to_string_lossy();
+
+    let distribution_opts = if install_distribution {
+        crate::llvm::platforms::shared::build_opts_distribution(enable_mlir, enable_utils)
+    } else {
+        Vec::new()
+    };
 
     crate::utils::command(
         Command::new("cmake")
@@ -72,10 +78,7 @@ pub fn build(
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_split_dwarf(build_type))
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::build_opts_distribution(
-                enable_mlir,
-                enable_utils,
-            ))
+            .args(&distribution_opts)
             .args(extra_args)
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
             .args(crate::llvm::platforms::shared::shared_build_opts_sanitizers(sanitizer))
@@ -85,11 +88,11 @@ pub fn build(
             )),
         "LLVM building cmake",
     )?;
-    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
     crate::llvm::platforms::shared::build_and_install_llvm_binaries(
         llvm_build_final.as_ref(),
         llvm_target_final.as_ref(),
-        enable_tools,
+        install_distribution,
     )?;
+
     Ok(())
 }

--- a/solx-dev/src/llvm/platforms/x86_64_macos.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_macos.rs
@@ -16,7 +16,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -34,6 +34,12 @@ pub fn build(
     let llvm_module_llvm_str = llvm_module_llvm.to_string_lossy();
     let llvm_build_final_str = llvm_build_final.to_string_lossy();
     let llvm_target_final_str = llvm_target_final.to_string_lossy();
+
+    let distribution_opts = if install_distribution {
+        crate::llvm::platforms::shared::build_opts_distribution(enable_mlir, enable_utils)
+    } else {
+        Vec::new()
+    };
 
     crate::utils::command(
         Command::new("cmake")
@@ -63,10 +69,7 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::build_opts_distribution(
-                enable_mlir,
-                enable_utils,
-            ))
+            .args(&distribution_opts)
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -75,11 +78,10 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
     crate::llvm::platforms::shared::build_and_install_llvm_binaries(
         llvm_build_final.as_ref(),
         llvm_target_final.as_ref(),
-        enable_tools,
+        install_distribution,
     )?;
 
     Ok(())

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -17,7 +17,7 @@ pub fn build(
     build_type: BuildType,
     enable_mlir: bool,
     enable_utils: bool,
-    enable_tools: bool,
+    install_distribution: bool,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -39,6 +39,12 @@ pub fn build(
     let llvm_module_llvm_str = llvm_module_llvm.to_string_lossy();
     let llvm_build_final_str = llvm_build_final.to_string_lossy();
     let llvm_target_final_str = llvm_target_final.to_string_lossy();
+
+    let distribution_opts = if install_distribution {
+        crate::llvm::platforms::shared::build_opts_distribution(enable_mlir, enable_utils)
+    } else {
+        Vec::new()
+    };
 
     crate::utils::command(
         Command::new("cmake")
@@ -70,10 +76,7 @@ pub fn build(
             ))
             .args(crate::llvm::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::llvm::platforms::shared::shared_build_opts_werror())
-            .args(crate::llvm::platforms::shared::build_opts_distribution(
-                enable_mlir,
-                enable_utils,
-            ))
+            .args(&distribution_opts)
             .args(extra_args)
             .args(CcacheVariant::cmake_args(ccache_variant))
             .args(crate::llvm::platforms::shared::shared_build_opts_assertions(enable_assertions))
@@ -81,11 +84,10 @@ pub fn build(
         "LLVM building cmake",
     )?;
 
-    crate::utils::ninja(llvm_build_final.as_ref(), "install-distribution")?;
     crate::llvm::platforms::shared::build_and_install_llvm_binaries(
         llvm_build_final.as_ref(),
         llvm_target_final.as_ref(),
-        enable_tools,
+        install_distribution,
     )?;
 
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {

--- a/solx-dev/src/solx_dev/main.rs
+++ b/solx-dev/src/solx_dev/main.rs
@@ -56,7 +56,7 @@ fn main_inner() -> anyhow::Result<()> {
                 arguments.build_type,
                 arguments.enable_mlir,
                 arguments.enable_utils,
-                arguments.enable_tools,
+                arguments.install_distribution,
                 arguments.enable_tests,
                 arguments.enable_coverage,
                 extra_args_unescaped,


### PR DESCRIPTION
Default LLVM install is now the full toolset (`ninja install`); `--install-distribution` opts into `ninja install-distribution` plus `llvm-config` for CI artifacts. `--enable-tests` overrides `--install-distribution` because the LLVM regression suite depends on the full toolset.

Drops `--enable-tools` entirely — local builds get the full toolset by default without needing a flag, and CI selects the lean variant via the new opt-in.