### PR TITLE
fix(ci): pin Node 24 for renovate-config-check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,6 +114,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
       - name: Renovate schema check
         run: npx --yes --package renovate -- renovate-config-validator renovate.json
 


### PR DESCRIPTION
The `renovate-config-check` job runs `npx --yes --package renovate -- renovate-config-validator` on `ubuntu-24.04` without an `actions/setup-node` step, so it uses the runner's default Node 20.x. Renovate 43.x requires `^24.11.0` and 40.x-42.x all require Node 22.13+, so npm walks down to the highest 20-compatible renovate (currently 39.264.1). Renovate 39.x predates the `managerFilePatterns` field rename, so as soon as Renovate's hosted bot opens a config-migration PR (e.g. #437), the validator rejects it with `Custom Manager contains disallowed fields: managerFilePatterns` and CI fails.

Pin Node 24 via `actions/setup-node` before the two `npx` steps, mirroring the pin already used in `integration-tests.yaml`. With Node 24 on the runner, `npx --yes --package renovate` resolves to the latest renovate, which accepts both the old `fileMatch` and the migrated `managerFilePatterns` forms.