### PR TITLE
fix(tester): pass debug output dir via SOLX_OUTPUT_DIR env var

### DIFF
--- a/solx-tester/src/compilers/llvm_ir/mod.rs
+++ b/solx-tester/src/compilers/llvm_ir/mod.rs
@@ -77,8 +77,7 @@ impl LLVMIRCompiler {
             let mut output_directory = debug_output_directory.to_owned();
             output_directory.push(mode.to_string());
 
-            command.arg("--debug-output-dir");
-            command.arg(output_directory);
+            command.env("SOLX_OUTPUT_DIR", output_directory);
         }
 
         let mut process = command

--- a/solx-tester/src/compilers/solidity/mod.rs
+++ b/solx-tester/src/compilers/solidity/mod.rs
@@ -141,8 +141,7 @@ impl SolidityCompiler {
             let mut output_directory = debug_output_directory.to_owned();
             output_directory.push(mode.to_string());
 
-            command.arg("--debug-output-dir");
-            command.arg(output_directory);
+            command.env("SOLX_OUTPUT_DIR", output_directory);
         }
 
         let mut process = command


### PR DESCRIPTION
Commit 367fc1c removed the `--debug-output-dir` solx CLI flag in favor of the `SOLX_OUTPUT_DIR` env var, but missed updating the two `run_solx` subprocess-invocation sites in solx-tester. As a result, passing `-D` / `--debug` to solx-tester now fails immediately with `error: unexpected argument '--debug-output-dir' found`.

This forwards the per-mode debug directory via the env var instead, restoring the IR-dump behavior that `-D` is supposed to trigger.