### PR TITLE
fix(standard-json): always emit sourceLocation start/end

### DIFF
--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -14,6 +14,7 @@ use slang_solidity::utils::LanguageFacts;
 
 use solx_core::Frontend;
 use solx_standard_json::CollectableError;
+use solx_standard_json::output::error::source_location::SourceLocation;
 
 use crate::ast::AstEmitter;
 
@@ -102,13 +103,11 @@ impl Frontend for Slang {
                         Some(path.as_str()),
                         None,
                         "Source content is unavailable.",
-                        Some(
-                            solx_standard_json::output::error::source_location::SourceLocation::new(
-                                path.to_owned(),
-                                None,
-                                None,
-                            ),
-                        ),
+                        Some(SourceLocation::new(
+                            path.to_owned(),
+                            SourceLocation::UNKNOWN_OFFSET,
+                            SourceLocation::UNKNOWN_OFFSET,
+                        )),
                         Some(&input_json.sources),
                     ));
                 continue;
@@ -125,8 +124,8 @@ impl Frontend for Slang {
                 let source_location =
                     solx_standard_json::output::error::source_location::SourceLocation::new(
                         file_identifier.to_owned(),
-                        Some(text_range.start.utf8 as isize),
-                        Some(text_range.end.utf8 as isize),
+                        text_range.start.utf8 as isize,
+                        text_range.end.utf8 as isize,
                     );
 
                 solx_standard_json::OutputError::new_error_with_data(

--- a/solx-standard-json/src/output/error/mod.rs
+++ b/solx-standard-json/src/output/error/mod.rs
@@ -120,7 +120,13 @@ impl Error {
     where
         S: std::fmt::Display,
     {
-        let source_location = path.map(|path| SourceLocation::new(path.to_owned(), None, None));
+        let source_location = path.map(|path| {
+            SourceLocation::new(
+                path.to_owned(),
+                SourceLocation::UNKNOWN_OFFSET,
+                SourceLocation::UNKNOWN_OFFSET,
+            )
+        });
         Self::new_error_with_data(path, None, message, source_location, None)
     }
 

--- a/solx-standard-json/src/output/error/secondary_source_location.rs
+++ b/solx-standard-json/src/output/error/secondary_source_location.rs
@@ -10,12 +10,10 @@
 pub struct SecondarySourceLocation {
     /// File path.
     pub file: String,
-    /// Start location.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start: Option<isize>,
-    /// End location.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end: Option<isize>,
+    /// Start offset. [`super::source_location::SourceLocation::UNKNOWN_OFFSET`] when unknown.
+    pub start: isize,
+    /// End offset. [`super::source_location::SourceLocation::UNKNOWN_OFFSET`] when unknown.
+    pub end: isize,
     /// Additional diagnostic message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,

--- a/solx-standard-json/src/output/error/source_location.rs
+++ b/solx-standard-json/src/output/error/source_location.rs
@@ -10,19 +10,21 @@
 pub struct SourceLocation {
     /// File path.
     pub file: String,
-    /// Start location.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start: Option<isize>,
-    /// End location.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end: Option<isize>,
+    /// Start offset. [`SourceLocation::UNKNOWN_OFFSET`] when unknown.
+    pub start: isize,
+    /// End offset. [`SourceLocation::UNKNOWN_OFFSET`] when unknown.
+    pub end: isize,
 }
 
 impl SourceLocation {
+    /// Sentinel emitted in `start`/`end` when offsets are unknown,
+    /// matching `solc`'s convention.
+    pub const UNKNOWN_OFFSET: isize = -1;
+
     ///
     /// A shortcut constructor.
     ///
-    pub fn new<S>(file: S, start: Option<isize>, end: Option<isize>) -> Self
+    pub fn new<S>(file: S, start: isize, end: isize) -> Self
     where
         S: Into<String>,
     {

--- a/solx-standard-json/src/output/source.rs
+++ b/solx-standard-json/src/output/source.rs
@@ -91,8 +91,8 @@ impl Source {
             .and_then(|source| source.content.as_deref());
         let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
             path.to_owned(),
-            Some(solc_location.start),
-            Some(solc_location.end),
+            solc_location.start,
+            solc_location.end,
             source_code,
         );
 
@@ -132,8 +132,8 @@ impl Source {
             .and_then(|source| source.content.as_deref());
         let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
             path.to_owned(),
-            Some(solc_location.start),
-            Some(solc_location.end),
+            solc_location.start,
+            solc_location.end,
             source_code,
         );
 
@@ -166,8 +166,8 @@ impl Source {
             .and_then(|source| source.content.as_deref());
         let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
             path.to_owned(),
-            Some(solc_location.start),
-            Some(solc_location.end),
+            solc_location.start,
+            solc_location.end,
             source_code,
         );
 

--- a/solx-utils/src/debug_info/mapped_location.rs
+++ b/solx-utils/src/debug_info/mapped_location.rs
@@ -59,17 +59,15 @@ impl MappedLocation {
     ///
     pub fn from_solc_location(
         path: String,
-        start: Option<isize>,
-        end: Option<isize>,
+        start: isize,
+        end: isize,
         source_code: Option<&str>,
     ) -> Self {
         let source_code = match source_code {
             Some(source_code) => source_code,
             None => return Self::new(path),
         };
-        let start = start.unwrap_or_default();
-        let end = end.unwrap_or_default();
-        if start <= 0 || end <= 0 {
+        if start < 0 || end < 0 || end < start {
             return Self::new(path);
         }
         let start = start as usize;
@@ -81,7 +79,7 @@ impl MappedLocation {
 
             if cursor <= start && start <= cursor_next {
                 let column = start - cursor;
-                let (line, column) = if column - 1 == source_line.len() {
+                let (line, column) = if column == source_line.len() + 1 {
                     (line + 2, 1)
                 } else {
                     (line + 1, start - cursor + 1)


### PR DESCRIPTION
Reported as a `forge build solady` failure (`Error: missing field 'start' at line 1 column 12157`) when pointing Foundry at solx via `solc_version`. solx's `SourceLocation` declared `start`/`end` as `Option<isize>` with `skip_serializing_if`, so contract-scoped diagnostics that knew only the file (`Error::new_error_contract`, slang's unavailable-source path) emitted `{"file": "..."}` with both offsets missing; `foundry-compilers` models them as required fields and aborts deserialization.

solc's protocol is all-or-nothing: omit the whole `sourceLocation` object, or emit `file`, `start`, and `end` together with `-1` as the unknown sentinel (see `formatSourceLocation` in `solx-solidity/libsolidity/interface/StandardCompiler.cpp` and the `int start = -1; int end = -1;` defaults in `solx-solidity/liblangutil/SourceLocation.h`). [`docs/src/user-guide/03-standard-json.md`](docs/src/user-guide/03-standard-json.md#L391-L400) already documents this contract — the code just didn't match.
