### PR TITLE
chore(slang): bump slang_solidity_v2 and fix hex literal lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3837,7 +3837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4293,7 +4293,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "num-bigint",
  "num-rational",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "itertools 0.14.0",
  "semver 1.0.28",
@@ -4334,12 +4334,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=af822aba9d748e1053c79cccec079f27bc54860c#af822aba9d748e1053c79cccec079f27bc54860c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
 dependencies = [
  "indexmap 2.14.0",
  "num-bigint",
@@ -4810,7 +4810,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4819,7 +4819,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5476,7 +5476,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,5 +99,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-# Temporary: points at NomicFoundation/slang#1801 until it lands on main.
-rev = "af822aba9d748e1053c79cccec079f27bc54860c"
+rev = "dafc141184be5df5ed1a9fb7199e330a21aa1c10"

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -56,7 +56,7 @@ impl<'context> TypeConversion<'context> {
             )),
             SlangType::Address(_) => builder.types.sol_address,
             SlangType::Literal(literal_type) => match literal_type.kind() {
-                LiteralKind::Address => builder.types.sol_address,
+                LiteralKind::Address { .. } => builder.types.sol_address,
                 LiteralKind::Integer { value } => {
                     let bits = Self::integer_bits_required(&value) as usize;
                     let bits = bits


### PR DESCRIPTION
Bumps `slang_solidity_v2` to a rev that includes the fix in NomicFoundation/slang#1801, which restores `HexNumberExpression::integer_value()` to parsing the literal text instead of routing through binder typing. Without it, hex literals in address-returning positions panic during lowering with `hex literals always evaluate to integers` — `solx-mlir/tests/lit/literal_types.sol` regressed when the v2 migration landed but the failure was masked because the migration PR did not have the `ci:slang` label.

Adapts to the v2 API changes that landed on slang main since the previous pin:

- `ContractDefinition::compute_abi_with_file_id(file_id)` is gone; the replacement `compute_abi()` derives the file from the contract node.
- `CompilationUnit::get_file_ast_root(file_id)` is gone; the replacement flow is `CompilationUnit::file(file_id)` then `File::ast()`.

The slang rev pin is temporary until NomicFoundation/slang#1801 lands on slang main; a follow-up will move it to the merged commit.