### PR TITLE
feat(slang): emit every contract in a source unit

### DIFF
--- a/solx-mlir/tests/lit/module.sol
+++ b/solx-mlir/tests/lit/module.sol
@@ -11,8 +11,40 @@
 // CHECK-NEXT:       sol.return %{{.*}} : ui256
 // CHECK:        } {kind = #Contract}
 
+// CHECK:      module attributes {llvm.data_layout
+// CHECK:        sol.contract @{{.*Impl.*}} {
+// CHECK:          sol.func @{{.*h.*}}() -> ui256
+// CHECK:        } {kind = #Contract}
+
+// CHECK:      module attributes {llvm.data_layout
+// CHECK:        sol.contract @{{.*Second.*}} {
+// CHECK:          sol.func @{{.*g.*}}() -> ui256
+// CHECK:        } {kind = #Contract}
+
+// CHECK-NOT:  sol.contract
+
 contract C {
     function f() public pure returns (uint256) {
         return 42;
     }
+}
+
+interface Iface {
+    function h() external pure returns (uint256);
+}
+
+contract Impl is Iface {
+    function h() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract Second {
+    function g() public pure returns (uint256) {
+        return 7;
+    }
+}
+
+abstract contract Undeployable {
+    function h() public pure virtual returns (uint256);
 }

--- a/solx-mlir/tests/lit/module.sol
+++ b/solx-mlir/tests/lit/module.sol
@@ -11,12 +11,12 @@
 // CHECK-NEXT:       sol.return %{{.*}} : ui256
 // CHECK:        } {kind = #Contract}
 
-// CHECK:      module attributes {llvm.data_layout
+// CHECK:      module attributes {llvm.data_layout = "E-p:256:256-i256:256:256-S256-a:256:256", llvm.target_triple = "evm-unknown-unknown"
 // CHECK:        sol.contract @{{.*Impl.*}} {
 // CHECK:          sol.func @{{.*h.*}}() -> ui256
 // CHECK:        } {kind = #Contract}
 
-// CHECK:      module attributes {llvm.data_layout
+// CHECK:      module attributes {llvm.data_layout = "E-p:256:256-i256:256:256-S256-a:256:256", llvm.target_triple = "evm-unknown-unknown"
 // CHECK:        sol.contract @{{.*Second.*}} {
 // CHECK:          sol.func @{{.*g.*}}() -> ui256
 // CHECK:        } {kind = #Contract}

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -27,8 +27,7 @@ impl<'context> SourceUnitScope<'context> {
     /// `method_identifiers` map (externally-dispatchable signature to 4-byte selector, lower-case
     /// hex); `convert-sol-to-yul` builds the entry-point dispatcher from the function selectors.
     /// Function signatures are pre-registered for call resolution before any body is emitted.
-    /// `operator_functions` land in the contract body because MLIR has no file scope. Inherited
-    /// state variables are not yet declared: derived contracts do not compile through this path.
+    /// `operator_functions` land in the contract body because MLIR has no file scope.
     pub fn contract_definition(
         &mut self,
         node: &ContractDefinition,

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 
 use itertools::Itertools;
+use slang_solidity_v2::ast::ContractBase;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::SourceUnit;
@@ -18,37 +19,44 @@ use solx_utils::EVMVersion;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'context> SourceUnitScope<'context> {
-    /// Lowers the unit's contracts, owning the per-file melior scope, into standard-JSON contract
-    /// outputs keyed by contract name. Only the first contract per file compiles through this path
-    /// today; the rest are skipped until inheritance-aware emission lands.
+    /// Lowers every contract the unit deploys into standard-JSON contract outputs keyed by contract
+    /// name, each in its own MLIR module off the file's melior context, as solc emits one module per
+    /// contract. An abstract contract and an interface deploy nothing and produce no module, and a
+    /// contract with a contract base is skipped: an interface base carries no state or bodies to
+    /// inherit, a contract base does.
     ///
     /// # Errors
     ///
     /// Returns an error if module finalization fails.
+    // TODO: emit a contract inheriting from a contract, which needs its inherited state variables
+    // and functions, and a library, whose own address reaches LLVM through the untranslated
+    // `llvm.setimmutable`.
     pub fn source_unit(
         unit: &SourceUnit,
         evm_version: EVMVersion,
         capture_sol_dialect: impl Fn(&str) -> bool,
     ) -> anyhow::Result<BTreeMap<String, Contract>> {
-        let contracts = unit.contracts();
-        let Some(contract) = contracts.first() else {
-            return Ok(BTreeMap::new());
-        };
+        let operator_functions = Self::operator_bound_functions(unit);
         let melior = Context::create_melior_context();
-        let mut scope = SourceUnitScope::new(Context::new(&melior, evm_version));
-        let method_identifiers =
-            scope.contract_definition(contract, &Self::operator_bound_functions(unit));
+        let mut contracts = BTreeMap::new();
+        for contract in unit.contracts().iter().filter(|contract| {
+            !contract.is_abstract()
+                && !contract
+                    .direct_bases()
+                    .iter()
+                    .any(|base| matches!(base, ContractBase::Contract(_)))
+        }) {
+            let mut scope = SourceUnitScope::new(Context::new(&melior, evm_version));
+            let method_identifiers = scope.contract_definition(contract, &operator_functions);
 
-        let name = contract.name().name().to_owned();
-        let mlir = Context::from(scope).finalize_module(
-            &format!("{name}{}", solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX),
-            capture_sol_dialect(&name),
-        )?;
-
-        Ok(BTreeMap::from([(
-            name,
-            Contract::new_mlir(mlir, method_identifiers),
-        )]))
+            let name = contract.name().name().to_owned();
+            let mlir = Context::from(scope).finalize_module(
+                &format!("{name}{}", solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX),
+                capture_sol_dialect(&name),
+            )?;
+            contracts.insert(name, Contract::new_mlir(mlir, method_identifiers));
+        }
+        Ok(contracts)
     }
 
     /// The functions `unit`'s `using {f as op} for T global;` directives bind operators to, in

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -21,9 +21,10 @@ use crate::scope::source_unit::SourceUnitScope;
 impl<'context> SourceUnitScope<'context> {
     /// Lowers every contract the unit deploys into standard-JSON contract outputs keyed by contract
     /// name, each in its own MLIR module off the file's melior context, as solc emits one module per
-    /// contract. An abstract contract and an interface deploy nothing and produce no module, and a
-    /// contract with a contract base is skipped: an interface base carries no state or bodies to
-    /// inherit, a contract base does.
+    /// contract. An abstract contract and an interface deploy nothing and produce no module. A
+    /// contract with a contract base is skipped because emission collects only the contract's own
+    /// state and functions: an interface base carries nothing to inherit, a contract base carries
+    /// state and bodies that would be silently dropped.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Completes source-unit emission, lowering every contract a file deploys rather than only the first:

- `contract C { … }` at file scope lowers to its own `sol.contract` module, one module per contract as solc emits them, off a single melior context shared by the file; the standard-JSON output keys each by contract name, so the tester's source-order resolution finds the real deploy target instead of whichever contract happened to come first.
- `abstract contract A { … }` and `interface I { … }` lower to nothing, the modules `solc --mlir-action=print-init` also omits; `contract D is C { … }` is skipped alongside them, since a contract base carries state and function bodies to inherit while an interface base carries neither.
