### PR TITLE
chore(slang): Update slang_solidity_v2 to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "num-bigint",
  "num-rational",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -4341,12 +4341,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e5d910159ef0e9e3d1e1c599d1f934df62746d81#e5d910159ef0e9e3d1e1c599d1f934df62746d81"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -4554,6 +4554,7 @@ dependencies = [
  "semver 1.0.28",
  "serde_json",
  "slang_solidity_v2",
+ "slang_solidity_v2_common",
  "solx-codegen-evm",
  "solx-core",
  "solx-mlir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3837,7 +3837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4298,8 +4298,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slang_solidity_v2"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4311,8 +4311,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_ast"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
  "num-bigint",
  "num-rational",
@@ -4327,9 +4327,10 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_common"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "semver 1.0.28",
  "serde",
@@ -4339,13 +4340,13 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_cst"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 
 [[package]]
 name = "slang_solidity_v2_ir"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4353,8 +4354,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_parser"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4367,10 +4368,9 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_semantic"
-version = "1.3.5"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=dafc141184be5df5ed1a9fb7199e330a21aa1c10#dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+version = "1.3.6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7#24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
 dependencies = [
- "indexmap 2.14.0",
  "num-bigint",
  "num-integer",
  "num-rational",
@@ -4816,7 +4816,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4825,7 +4825,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5482,7 +5482,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,4 +99,9 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"
+rev = "e5d910159ef0e9e3d1e1c599d1f934df62746d81"
+
+[workspace.dependencies.slang_solidity_v2_common]
+git = "https://github.com/NomicFoundation/slang.git"
+# TODO: pin to a release tag instead of a revision.
+rev = "e5d910159ef0e9e3d1e1c599d1f934df62746d81"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,4 +99,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "dafc141184be5df5ed1a9fb7199e330a21aa1c10"
+rev = "24befe31d2cef93eeb68bb4d49a8e5ab76dc1df7"

--- a/solx-mlir/src/context/builder/mod.rs
+++ b/solx-mlir/src/context/builder/mod.rs
@@ -189,7 +189,12 @@ impl<'context> Builder<'context> {
             ));
         }
 
-        if selector.is_some() || matches!(kind, Some(crate::FunctionKind::Constructor)) {
+        if selector.is_some()
+            || matches!(
+                kind,
+                Some(crate::FunctionKind::Constructor | crate::FunctionKind::Fallback)
+            )
+        {
             builder = builder.orig_fn_type(TypeAttribute::new(function_type.into()));
         }
 

--- a/solx-mlir/tests/lit/evm_context.sol
+++ b/solx-mlir/tests/lit/evm_context.sol
@@ -34,9 +34,6 @@
 // CHECK: sol.func @{{.*get_blobbasefee.*}}
 // CHECK:   sol.blobbasefee : ui256
 
-// CHECK: sol.func @{{.*get_difficulty.*}}
-// CHECK:   sol.difficulty : ui256
-
 // CHECK: sol.func @{{.*get_prevrandao.*}}
 // CHECK:   sol.prevrandao : ui256
 
@@ -86,10 +83,6 @@ contract C {
 
     function get_blobbasefee() public view returns (uint256) {
         return block.blobbasefee;
-    }
-
-    function get_difficulty() public view returns (uint256) {
-        return block.difficulty;
     }
 
     function get_prevrandao() public view returns (uint256) {

--- a/solx-mlir/tests/lit/special_functions.sol
+++ b/solx-mlir/tests/lit/special_functions.sol
@@ -3,7 +3,7 @@
 
 // CHECK: sol.func @{{.*}} attributes {{.*}}kind = #{{.*}}Constructor
 // CHECK: sol.func @{{.*}} attributes {{.*}}kind = #{{.*}}Receive, state_mutability = #{{.*}}Payable
-// CHECK: sol.func @{{.*}} attributes {{.*}}kind = #{{.*}}Fallback, state_mutability = #{{.*}}Payable
+// CHECK: sol.func @{{.*}} attributes {{.*}}kind = #{{.*}}Fallback{{.*}}state_mutability = #{{.*}}Payable
 
 contract C {
     uint256 x;

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -17,6 +17,7 @@ ruint.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 slang_solidity_v2.workspace = true
+slang_solidity_v2_common.workspace = true
 melior = { git = "https://github.com/NomicFoundation/melior", rev = "62a909e2ff67fcc19f7f42dc4fb70c3e03376bd2", features = ["ods-dialects", "helpers"] }
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }

--- a/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
+++ b/solx-slang/src/ast/contract/function/expression/call/type_conversion.rs
@@ -44,7 +44,7 @@ impl<'context> TypeConversion<'context> {
         match slang_type {
             SlangType::Integer(integer_type) => {
                 let bits = integer_type.bits();
-                if integer_type.signed() {
+                if integer_type.is_signed() {
                     Type::from(IntegerType::signed(builder.context, bits))
                 } else {
                     Type::from(IntegerType::unsigned(builder.context, bits))

--- a/solx-slang/src/ast/contract/function/expression/operator.rs
+++ b/solx-slang/src/ast/contract/function/expression/operator.rs
@@ -201,11 +201,13 @@ impl Operator {
                 .build()
                 .into(),
             Self::ShiftLeft => ShlOperation::builder(context, location)
+                .result(lhs.r#type())
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()
                 .into(),
             Self::ShiftRight => ShrOperation::builder(context, location)
+                .result(lhs.r#type())
                 .lhs(lhs)
                 .rhs(rhs)
                 .build()

--- a/solx-slang/src/ast/contract/function/statement/event.rs
+++ b/solx-slang/src/ast/contract/function/statement/event.rs
@@ -74,7 +74,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
         for (parameter, argument) in parameters.iter().zip(ordered_arguments) {
             let (value, next_block) = emitter.emit_value(&argument, current_block)?;
             current_block = next_block;
-            let indexed = parameter.indexed();
+            let indexed = parameter.is_indexed();
             let parameter_type = TypeConversion::resolve_slang_type(
                 &parameter
                     .get_type()
@@ -87,7 +87,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
                 &self.state.builder,
                 &current_block,
             );
-            if indexed.is_some() {
+            if indexed {
                 // TODO: indexed reference-type parameters (string, bytes,
                 // arrays, structs) must store the keccak256 hash of their
                 // encoded value as the topic, not the value itself. That
@@ -98,7 +98,7 @@ impl<'state, 'context, 'block> StatementEmitter<'state, 'context, 'block> {
             }
         }
 
-        let signature = if event_definition.anonymous_keyword().is_some() {
+        let signature = if event_definition.is_anonymous() {
             None
         } else {
             Some(

--- a/solx-slang/src/slang/compilation_config.rs
+++ b/solx-slang/src/slang/compilation_config.rs
@@ -7,6 +7,8 @@ use std::path::Component;
 use std::path::Path;
 
 use slang_solidity_v2::compilation::CompilationBuilderConfig;
+use slang_solidity_v2::diagnostics::kinds::compilation::MissingFile;
+use slang_solidity_v2::diagnostics::kinds::compilation::UnresolvedImport;
 
 /// Provides file reading and import resolution for the Slang compilation builder.
 pub struct CompilationConfig {
@@ -21,18 +23,20 @@ impl CompilationConfig {
 }
 
 impl CompilationBuilderConfig for CompilationConfig {
-    fn read_file(&mut self, file_identifier: &str) -> Result<String, String> {
+    fn read_file(&mut self, file_identifier: &str) -> Result<String, MissingFile> {
         self.sources
             .get(file_identifier)
             .cloned()
-            .ok_or(format!("file not found {file_identifier}"))
+            .ok_or_else(|| MissingFile {
+                reason: format!("file not found {file_identifier}"),
+            })
     }
 
     fn resolve_import(
         &mut self,
         source_file_identifier: &str,
         import_path: &str,
-    ) -> Result<String, String> {
+    ) -> Result<String, UnresolvedImport> {
         let path = import_path
             .strip_prefix('"')
             .and_then(|stripped| stripped.strip_suffix('"'))
@@ -70,8 +74,8 @@ impl CompilationBuilderConfig for CompilationConfig {
             }
         }
 
-        Err(format!(
-            "failed to resolve import {import_path} in {source_file_identifier}"
-        ))
+        Err(UnresolvedImport {
+            reason: format!("failed to resolve import {import_path} in {source_file_identifier}"),
+        })
     }
 }

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -12,6 +12,7 @@ use slang_solidity_v2::compilation::CompilationBuilder;
 use slang_solidity_v2::compilation::CompilationUnit;
 use slang_solidity_v2::diagnostics::DiagnosticExtensions;
 use slang_solidity_v2::utils::LanguageVersion;
+use slang_solidity_v2_common::evm_targets::EvmTarget;
 
 use solx_core::Frontend;
 use solx_standard_json::CollectableError;
@@ -60,7 +61,9 @@ impl Slang {
                     self.version.default
                 )
             })?;
-        let mut builder = CompilationBuilder::create(version, configuration);
+        // The Slang frontend gates EVM built-in availability on the target; solx
+        // handles EVM-version targeting downstream, so admit every built-in here.
+        let mut builder = CompilationBuilder::create(version, EvmTarget::LATEST, configuration);
 
         for path in paths.iter() {
             builder.add_file(path.clone());


### PR DESCRIPTION
Makes code changes to handle AST API changes.

This should be used instead of #464, as there were some minor API changes. Please let me know if I should do differently and push those changes in the other PR.