### PR TITLE
ci: full benchmark on `ci:integration-benchmark-full` label

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -216,6 +216,23 @@ jobs:
           SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
         run: ./target/release/solx-dev test solx-tester --solidity-compiler ./target/release/solx
 
+      # When `ci:benchmark-full` is present, enable every otherwise-disabled
+      # compiler (solc, solx-latest) and its comparison columns in the Foundry
+      # and Hardhat benchmark configs, so the reports cover the full matrix
+      # instead of just solx (PR) vs solx-main. Scoped to `[compilers.*]` and
+      # `[[comparisons]]`; disabled `[projects.*]` (hangs / unsupported Solidity)
+      # are deliberately left off. Edits only this throwaway CI checkout.
+      - name: Enable full benchmark (all compilers + comparisons)
+        if: contains(github.event.pull_request.labels.*.name, 'ci:benchmark-full')
+        run: |
+          for cfg in solx-dev/foundry-tests.toml solx-dev/hardhat-tests.toml; do
+            awk '
+              /^\[/ { in_section = ($0 ~ /^\[compilers\./ || $0 ~ /^\[\[comparisons\]\]/) }
+              in_section && $0 == "disabled = true" { $0 = "disabled = false" }
+              { print }
+            ' "$cfg" > "$cfg.tmp" && mv "$cfg.tmp" "$cfg"
+          done
+
       - name: Run solx-tester benchmarks (main)
         id: solx_tester_bench_main
         continue-on-error: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,11 +20,9 @@ jobs:
 
   label-check:
     if: >-
-      ((github.event.action == 'labeled'
-          && contains(fromJSON('["ci:integration", "ci:integration-benchmark-full"]'), github.event.label.name)
-          && contains(github.event.pull_request.labels.*.name, 'ci:integration'))
-        || (github.event.action != 'labeled'
-          && contains(github.event.pull_request.labels.*.name, 'ci:integration')))
+      contains(github.event.pull_request.labels.*.name, 'ci:integration')
+      && (github.event.action != 'labeled'
+        || contains(fromJSON('["ci:integration", "ci:integration-benchmark-full"]'), github.event.label.name))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,8 +20,11 @@ jobs:
 
   label-check:
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ci:integration'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:integration'))
+      ((github.event.action == 'labeled'
+          && contains(fromJSON('["ci:integration", "ci:integration-benchmark-full"]'), github.event.label.name)
+          && contains(github.event.pull_request.labels.*.name, 'ci:integration'))
+        || (github.event.action != 'labeled'
+          && contains(github.event.pull_request.labels.*.name, 'ci:integration')))
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
     steps:
@@ -216,14 +219,15 @@ jobs:
           SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
         run: ./target/release/solx-dev test solx-tester --solidity-compiler ./target/release/solx
 
-      # When `ci:benchmark-full` is present, enable every otherwise-disabled
-      # compiler (solc, solx-latest) and its comparison columns in the Foundry
-      # and Hardhat benchmark configs, so the reports cover the full matrix
-      # instead of just solx (PR) vs solx-main. Scoped to `[compilers.*]` and
-      # `[[comparisons]]`; disabled `[projects.*]` (hangs / unsupported Solidity)
-      # are deliberately left off. Edits only this throwaway CI checkout.
+      # When `ci:integration-benchmark-full` is present, enable every
+      # otherwise-disabled compiler (solc, solx-latest) and its comparison
+      # columns in the Foundry and Hardhat benchmark configs, so the reports
+      # cover the full matrix instead of just solx (PR) vs solx-main. Scoped to
+      # `[compilers.*]` and `[[comparisons]]`; disabled `[projects.*]` (hangs /
+      # unsupported Solidity) are deliberately left off. Edits only this
+      # throwaway CI checkout.
       - name: Enable full benchmark (all compilers + comparisons)
-        if: contains(github.event.pull_request.labels.*.name, 'ci:benchmark-full')
+        if: contains(github.event.pull_request.labels.*.name, 'ci:integration-benchmark-full')
         run: |
           for cfg in solx-dev/foundry-tests.toml solx-dev/hardhat-tests.toml; do
             awk '


### PR DESCRIPTION
Adds a single label-gated step to the integration-tests workflow so that a PR carrying `ci:integration-benchmark-full` runs the complete benchmark matrix instead of the default solx-PR vs solx-main comparison. When the label is present, an `awk` pass flips `disabled = true` to `false` only within the `[compilers.*]` and `[[comparisons]]` sections of the Foundry and Hardhat configs, enabling the solc and solx-latest columns plus their diff columns; disabled `[projects.*]` (which are off for hang/unsupported-Solidity reasons) are deliberately left untouched, the edit only affects CI's throwaway checkout, and absent the label the step is skipped so default runs are byte-for-byte unchanged. Note that `ci:integration-benchmark-full` is a modifier on an already-triggered `ci:integration` run, so both labels are applied here.