### PR TITLE
perf(codegen): O(1) debug-info location lookup

### DIFF
--- a/solx-codegen-evm/src/codegen/context/solidity_data.rs
+++ b/solx-codegen-evm/src/codegen/context/solidity_data.rs
@@ -77,14 +77,12 @@ impl ISolidityData for SolidityData {
     fn get_solx_location(&self) -> Option<&solx_utils::DebugInfoMappedLocation> {
         let debug_info = self.debug_info.as_ref()?;
         let solc_location = self.get_debug_info_solc_location()?;
+        let start = usize::try_from(solc_location.start).ok()?;
 
-        debug_info.ast_nodes.values().find_map(|ast_node| {
-            if ast_node.solc_location.start == solc_location.start {
-                Some(&ast_node.mapped_location)
-            } else {
-                None
-            }
-        })
+        debug_info
+            .ast_nodes
+            .get(&start)
+            .map(|ast_node| &ast_node.mapped_location)
     }
 
     fn debug_info(&self) -> Option<&solx_utils::DebugInfo> {


### PR DESCRIPTION
Replaces a per-instruction linear AST scan in `get_solx_location` with a direct `HashMap` lookup on the key the map already uses, removing an O(instructions × AST) blowup that made DWARF debug info pathologically slow on the EVMLA pipeline (legacy+DWARF: 108s → 34s on an OpenZeppelin build). Compiled bytecode is byte-for-byte unchanged.