### PR TITLE
[experiment] Excel benchmark reports from the Slang-built solx

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -89,6 +89,7 @@ jobs:
         with:
           build-type: Release
           enable-assertions: 'false'
+          enable-mlir: 'true'
 
       # Submodule SHA alone is not sufficient: `solx-dev llvm build` is
       # driven by `solx-dev/src/llvm/*`, so a PR that edits those scripts
@@ -126,7 +127,7 @@ jobs:
           pushd temp-solx-main
           ${SFW_PREFIX:-} cargo fetch --locked
           ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-          ./target/release/solx-dev llvm build --build-type Release --install-distribution
+          ./target/release/solx-dev llvm build --build-type Release --enable-mlir --install-distribution
           popd
 
       - name: Build solc (PR)
@@ -180,13 +181,17 @@ jobs:
         env:
           BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
           SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
-        run: ${SFW_PREFIX:-} cargo build --frozen --release --bin solx
+        run: |
+          ${SFW_PREFIX:-} cargo build --frozen --release -p solx-slang -p solx-mlir -p solx \
+            --no-default-features --features slang --target-dir target-slang
+          mkdir -p target/release
+          cp target-slang/release/solx target/release/solx
 
       - name: Build solx-dev and solx-tester (PR)
         env:
           BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
           SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
-        run: ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev --bin solx-tester
+        run: ${SFW_PREFIX:-} cargo build --frozen --release -p solx-dev -p solx-tester --features solx-tester/slang-ast
 
       - name: Fetch dependencies (main)
         working-directory: temp-solx-main
@@ -199,7 +204,11 @@ jobs:
         env:
           BOOST_PREFIX: ${{ github.workspace }}/temp-solx-main/solx-solidity/boost/lib
           SOLC_PREFIX: ${{ github.workspace }}/temp-solx-main/solx-solidity/build
-        run: ${SFW_PREFIX:-} cargo build --frozen --release --bin solx
+        run: |
+          ${SFW_PREFIX:-} cargo build --frozen --release -p solx-slang -p solx-mlir -p solx \
+            --no-default-features --features slang --target-dir target-slang
+          mkdir -p target/release
+          cp target-slang/release/solx target/release/solx
 
       - name: Build solx-dev and solx-tester (main)
         working-directory: temp-solx-main
@@ -207,7 +216,7 @@ jobs:
         env:
           BOOST_PREFIX: ${{ github.workspace }}/temp-solx-main/solx-solidity/boost/lib
           SOLC_PREFIX: ${{ github.workspace }}/temp-solx-main/solx-solidity/build
-        run: ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev --bin solx-tester
+        run: ${SFW_PREFIX:-} cargo build --frozen --release -p solx-dev -p solx-tester --features solx-tester/slang-ast
 
       - name: Run solx-tester tests (PR)
         id: solx_tester_tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "bytes",
 ]
 
@@ -339,7 +339,7 @@ dependencies = [
  "ark-ff-macros 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
@@ -490,7 +490,7 @@ checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
  "ark-std 0.5.0",
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -550,9 +550,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.8"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ascii-canvas"
@@ -1325,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1531,18 +1531,18 @@ checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1621,7 +1621,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "auto_impl",
  "bytes",
 ]
@@ -1632,7 +1632,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "auto_impl",
  "bytes",
 ]
@@ -1986,7 +1986,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
 ]
 
 [[package]]
@@ -1995,7 +1995,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
 ]
 
 [[package]]
@@ -2048,9 +2048,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2927,7 +2927,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "bitvec",
  "byte-slice-cast",
  "const_format",
@@ -3408,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.5.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
 ]
@@ -3843,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -3900,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4975,9 +4975,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4995,9 +4995,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5477,7 +5477,7 @@ name = "web3"
 version = "0.20.0"
 source = "git+https://github.com/tomusdrw/rust-web3?rev=8d889ae3270508f1e68b6a29bbe51b2bedf7fb1e#8d889ae3270508f1e68b6a29bbe51b2bedf7fb1e"
 dependencies = [
- "arrayvec 0.7.8",
+ "arrayvec 0.7.7",
  "base64",
  "bytes",
  "derive_more 0.99.20",
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
Experimental, throwaway PR: run the existing Foundry / Hardhat / solx-tester benchmark pipeline with the **Slang front-end** build of `solx` standing in for the default `solc`-front-end build, to see the Excel reports it produces.

Only `.github/workflows/integration-tests.yaml` changes:
- enable MLIR in the LLVM builds (the Slang pipeline needs it);
- build `solx` via `--features slang` into `target-slang` and copy it to the default compiler path, for both the PR and `temp-solx-main` checkouts;
- build `solx-tester` with its `slang-ast` feature;
- drop the now-unneeded solc build.

Base is `recut-final-pending` rebased onto `main` (mature Slang front-end + the `ci:integration-benchmark-full` machinery).

Deliverable: the `foundry-report`, `hardhat-report`, and `solx-tester-report` xlsx artifacts uploaded by the run.