### PR TITLE
fix(benchmark): solx-tester skips E codegen; Hardhat ignores the configured solx

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -245,7 +245,7 @@ jobs:
         run: |
           ./target/release/solx-dev test solx-tester \
             --solidity-compiler ./target/release/solx \
-            --via-ir --optimizer 'M^B3' \
+            --optimizer 'M^B3' \
             --benchmark=../reference-benchmark.json
 
       - name: Run solx-tester benchmarks (PR)
@@ -257,7 +257,7 @@ jobs:
         run: |
           ./target/release/solx-dev test solx-tester \
             --solidity-compiler ./target/release/solx \
-            --via-ir --optimizer 'M^B3' \
+            --optimizer 'M^B3' \
             --benchmark=candidate-benchmark.json
 
       - name: Build benchmark converter

--- a/solx-dev/src/test/hardhat/mod.rs
+++ b/solx-dev/src/test/hardhat/mod.rs
@@ -237,7 +237,7 @@ pub fn test(
             for (key, value) in project.env.iter() {
                 npm_compile_command.env(key, value);
             }
-            if toolchain_name.starts_with("solx") {
+            if toolchain_name.contains("solx") {
                 npm_compile_command.env("USE_SOLX", "true");
                 npm_compile_command.env("SOLX", &*compiler_path_str);
             }
@@ -280,7 +280,7 @@ pub fn test(
             let npm_test_report_path = project_directory.join("junit-report.json");
             let npm_test_report_path_str = npm_test_report_path.to_string_lossy();
             npm_test_command.env("JUNIT_REPORT", &*npm_test_report_path_str);
-            if toolchain_name.starts_with("solx") {
+            if toolchain_name.contains("solx") {
                 npm_test_command.env("USE_SOLX", "true");
                 npm_test_command.env("SOLX", &*compiler_path_str);
             }


### PR DESCRIPTION
Two pre-existing bugs in the integration benchmarks.

**1. solx-tester benchmark skipped the EVMLA (E) codegen.**
The two `Run solx-tester benchmarks` steps pass `--via-ir`, and `Filters::check_mode` (`solx-tester/src/filters.rs`) drops every mode whose codegen `!= "Y"` when `via_ir` is set. So the solx-tester report only ever contained the Yul-IR (`Y`) codegen — `E` was silently skipped. Verified on a real report (run 28232358852): its only columns are `…-Y-M3B3-…` / `…-Y-MzB3-…`, zero `E`.
Fix: drop `--via-ir` from both benchmark steps (keep `-O 'M^B3'`); `check_mode` then keeps both codegens, so the report gets `E` and `Y` at `M3B3`/`MzB3`.

**2. Hardhat never used the configured solx.**
`solx-dev/src/test/hardhat/mod.rs` injects `USE_SOLX`/`SOLX` only when `toolchain_name.starts_with("solx")`, but `toolchain_name` is `"{compiler.name}-{codegen}"` and the shipped names are `"03.solx"`/`"02.solx-main"` — so the guard never fired and projects compiled with their own bundled solc (reporting 0 build failures). Fix: `contains("solx")`.

Foundry is unaffected (it drives `forge --use <path>` directly).