### PR TITLE
perf: optimize the EVM legacy assembly compilation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,7 @@ dependencies = [
  "inkwell",
  "num",
  "rayon",
+ "rustc-hash",
  "semver 1.0.28",
  "serde",
  "serde_json",

--- a/solx-codegen-evm/src/codegen/context/evmla_data.rs
+++ b/solx-codegen-evm/src/codegen/context/evmla_data.rs
@@ -38,12 +38,4 @@ impl<'ctx> IEVMLAData<'ctx> for EVMLAData<'ctx> {
     fn get_element(&self, position: usize) -> &Value<'ctx> {
         &self.stack[position]
     }
-
-    fn set_element(&mut self, position: usize, value: Value<'ctx>) {
-        self.stack[position] = value;
-    }
-
-    fn set_original(&mut self, position: usize, original: String) {
-        self.stack[position].original = Some(original);
-    }
 }

--- a/solx-codegen-evm/src/codegen/context/function/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/function/mod.rs
@@ -332,36 +332,10 @@ impl<'ctx> Function<'ctx> {
 
 impl<'ctx> IEVMLAFunction<'ctx> for Function<'ctx> {
     fn find_block(&self, key: &BlockKey, stack_hash: &u64) -> anyhow::Result<Block<'ctx>> {
-        let evmla_data = self.evmla();
-
-        if evmla_data
+        self.evmla()
             .blocks
             .get(key)
-            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
-            .len()
-            == 1
-        {
-            return evmla_data
-                .blocks
-                .get(key)
-                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
-                .first()
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"));
-        }
-
-        evmla_data
-            .blocks
-            .get(key)
-            .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
-            .iter()
-            .find(|block| {
-                block
-                    .evm()
-                    .stack_hashes
-                    .iter()
-                    .any(|hash| hash == stack_hash)
-            })
+            .and_then(|blocks| blocks.get(stack_hash))
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))
     }

--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -85,6 +85,10 @@ pub struct Context<'ctx> {
     captured_evmla: Option<String>,
     /// Captured Ethereal IR for output.
     captured_ethir: Option<String>,
+    /// Whether to capture EVM legacy assembly IR for output.
+    capture_evmla: bool,
+    /// Whether to capture Ethereal IR for output.
+    capture_ethir: bool,
     /// Whether to capture LLVM IR for output.
     capture_llvm_ir: bool,
 }
@@ -146,6 +150,8 @@ impl<'ctx> Context<'ctx> {
 
             captured_evmla: None,
             captured_ethir: None,
+            capture_evmla: false,
+            capture_ethir: false,
             capture_llvm_ir: false,
         }
     }
@@ -417,6 +423,34 @@ impl<'ctx> Context<'ctx> {
     ///
     pub fn set_captured_ethir(&mut self, ethir: String) {
         self.captured_ethir = Some(ethir);
+    }
+
+    ///
+    /// Returns whether EVM legacy assembly IR capture is enabled.
+    ///
+    pub fn capture_evmla(&self) -> bool {
+        self.capture_evmla
+    }
+
+    ///
+    /// Enables EVM legacy assembly IR capture for output.
+    ///
+    pub fn set_capture_evmla(&mut self, capture: bool) {
+        self.capture_evmla = capture;
+    }
+
+    ///
+    /// Returns whether Ethereal IR capture is enabled.
+    ///
+    pub fn capture_ethir(&self) -> bool {
+        self.capture_ethir
+    }
+
+    ///
+    /// Enables Ethereal IR capture for output.
+    ///
+    pub fn set_capture_ethir(&mut self, capture: bool) {
+        self.capture_ethir = capture;
     }
 
     ///

--- a/solx-codegen-evm/src/context/function/block/evmla_data.rs
+++ b/solx-codegen-evm/src/context/function/block/evmla_data.rs
@@ -9,15 +9,15 @@
 ///
 #[derive(Debug, Clone)]
 pub struct EVMLAData {
-    /// The initial hashes of the allowed stack states.
-    pub stack_hashes: Vec<u64>,
+    /// The hash of the block's initial stack state.
+    pub stack_hash: u64,
 }
 
 impl EVMLAData {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(stack_hashes: Vec<u64>) -> Self {
-        Self { stack_hashes }
+    pub fn new(stack_hash: u64) -> Self {
+        Self { stack_hash }
     }
 }

--- a/solx-codegen-evm/src/context/function/evmla_data.rs
+++ b/solx-codegen-evm/src/context/function/evmla_data.rs
@@ -4,6 +4,8 @@
 
 use std::collections::BTreeMap;
 
+use indexmap::IndexMap;
+
 use crate::context::function::block::Block;
 use crate::context::function::block::key::Key as BlockKey;
 
@@ -16,7 +18,7 @@ use crate::context::function::block::key::Key as BlockKey;
 pub struct EVMLAData<'ctx> {
     /// The ordinary blocks with numeric tags.
     /// Is only used by the Solidity EVM compiler.
-    pub blocks: BTreeMap<BlockKey, Vec<Block<'ctx>>>,
+    pub blocks: BTreeMap<BlockKey, IndexMap<u64, Block<'ctx>>>,
     /// The function stack size.
     pub stack_size: usize,
 }
@@ -36,10 +38,9 @@ impl<'ctx> EVMLAData<'ctx> {
     /// Inserts a function block.
     ///
     pub fn insert_block(&mut self, key: BlockKey, block: Block<'ctx>) {
-        if let Some(blocks) = self.blocks.get_mut(&key) {
-            blocks.push(block);
-        } else {
-            self.blocks.insert(key, vec![block]);
-        }
+        self.blocks
+            .entry(key)
+            .or_default()
+            .insert(block.evm().stack_hash, block);
     }
 }

--- a/solx-codegen-evm/src/context/traits/evmla_data.rs
+++ b/solx-codegen-evm/src/context/traits/evmla_data.rs
@@ -15,20 +15,4 @@ pub trait IEVMLAData<'ctx> {
     /// If `position` is out of bounds.
     ///
     fn get_element(&self, position: usize) -> &Value<'ctx>;
-
-    ///
-    /// Sets the element at the specified stack position.
-    ///
-    /// # Panics
-    /// If `position` is out of bounds.
-    ///
-    fn set_element(&mut self, position: usize, value: Value<'ctx>);
-
-    ///
-    /// Sets the compile-time string representation to the element at the specified stack position.
-    ///
-    /// # Panics
-    /// If `position` is out of bounds.
-    ///
-    fn set_original(&mut self, position: usize, original: String);
 }

--- a/solx-core/src/project/contract/ir/evmla.rs
+++ b/solx-core/src/project/contract/ir/evmla.rs
@@ -49,6 +49,7 @@ impl EVMLegacyAssembly {
 
         let mut deploy_code_dependencies = solx_codegen_evm::Dependencies::new(full_path);
         assembly.accumulate_evm_dependencies(&mut deploy_code_dependencies);
+        assembly.strip_runtime_code(runtime_code_identifier);
 
         Ok(Self {
             assembly,

--- a/solx-core/src/project/contract/mod.rs
+++ b/solx-core/src/project/contract/mod.rs
@@ -280,18 +280,24 @@ impl Contract {
             }
             (IR::EVMLegacyAssembly(mut code), code_segment) => {
                 let (
+                    selector_evmla,
+                    selector_ethir,
                     selector_debug_info,
                     selector_llvm_ir_unoptimized,
                     selector_llvm_ir,
                     selector_llvm_assembly,
                 ) = match code_segment {
                     solx_utils::CodeSegment::Deploy => (
+                        solx_standard_json::InputSelector::BytecodeEVMLA,
+                        solx_standard_json::InputSelector::BytecodeEthIR,
                         solx_standard_json::InputSelector::BytecodeDebugInfo,
                         solx_standard_json::InputSelector::BytecodeLLVMIRUnoptimized,
                         solx_standard_json::InputSelector::BytecodeLLVMIR,
                         solx_standard_json::InputSelector::BytecodeLLVMAssembly,
                     ),
                     solx_utils::CodeSegment::Runtime => (
+                        solx_standard_json::InputSelector::RuntimeBytecodeEVMLA,
+                        solx_standard_json::InputSelector::RuntimeBytecodeEthIR,
                         solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
                         solx_standard_json::InputSelector::RuntimeBytecodeLLVMIRUnoptimized,
                         solx_standard_json::InputSelector::RuntimeBytecodeLLVMIR,
@@ -353,6 +359,16 @@ impl Contract {
                     crate::process::evm_stack_error_handler,
                 );
                 context.set_evmla_data(evmla_data);
+                context.set_capture_evmla(output_selection.check_selection(
+                    contract_name.path.as_str(),
+                    contract_name.name.as_deref(),
+                    selector_evmla,
+                ));
+                context.set_capture_ethir(output_selection.check_selection(
+                    contract_name.path.as_str(),
+                    contract_name.name.as_deref(),
+                    selector_ethir,
+                ));
                 let run_evm_assembly_lowering = profiler.start_evm_translation_unit(
                     contract_name.full_path.as_str(),
                     code_segment,

--- a/solx-evm-assembly/Cargo.toml
+++ b/solx-evm-assembly/Cargo.toml
@@ -19,6 +19,7 @@ num.workspace = true
 rayon.workspace = true
 inkwell.workspace = true
 twox-hash = "2.1"
+rustc-hash = "2.1"
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-utils = { path = "../solx-utils" }

--- a/solx-evm-assembly/src/assembly/instruction/name.rs
+++ b/solx-evm-assembly/src/assembly/instruction/name.rs
@@ -393,10 +393,211 @@ pub enum Name {
     },
 }
 
+impl Name {
+    ///
+    /// Returns the static mnemonic of the instruction.
+    ///
+    pub const fn mnemonic(&self) -> &'static str {
+        match self {
+            Self::PUSH => "PUSH",
+            Self::PUSH_Tag => "PUSH_Tag",
+            Self::PUSH_Data => "PUSH_Data",
+            Self::PUSH_DataSize => "PUSH_DataSize",
+            Self::PUSH_DataOffset => "PUSH_DataOffset",
+
+            Self::PUSH1 => "PUSH1",
+            Self::PUSH2 => "PUSH2",
+            Self::PUSH3 => "PUSH3",
+            Self::PUSH4 => "PUSH4",
+            Self::PUSH5 => "PUSH5",
+            Self::PUSH6 => "PUSH6",
+            Self::PUSH7 => "PUSH7",
+            Self::PUSH8 => "PUSH8",
+            Self::PUSH9 => "PUSH9",
+            Self::PUSH10 => "PUSH10",
+            Self::PUSH11 => "PUSH11",
+            Self::PUSH12 => "PUSH12",
+            Self::PUSH13 => "PUSH13",
+            Self::PUSH14 => "PUSH14",
+            Self::PUSH15 => "PUSH15",
+            Self::PUSH16 => "PUSH16",
+            Self::PUSH17 => "PUSH17",
+            Self::PUSH18 => "PUSH18",
+            Self::PUSH19 => "PUSH19",
+            Self::PUSH20 => "PUSH20",
+            Self::PUSH21 => "PUSH21",
+            Self::PUSH22 => "PUSH22",
+            Self::PUSH23 => "PUSH23",
+            Self::PUSH24 => "PUSH24",
+            Self::PUSH25 => "PUSH25",
+            Self::PUSH26 => "PUSH26",
+            Self::PUSH27 => "PUSH27",
+            Self::PUSH28 => "PUSH28",
+            Self::PUSH29 => "PUSH29",
+            Self::PUSH30 => "PUSH30",
+            Self::PUSH31 => "PUSH31",
+            Self::PUSH32 => "PUSH32",
+            Self::PUSH0 => "PUSH0",
+
+            Self::DUP1 => "DUP1",
+            Self::DUP2 => "DUP2",
+            Self::DUP3 => "DUP3",
+            Self::DUP4 => "DUP4",
+            Self::DUP5 => "DUP5",
+            Self::DUP6 => "DUP6",
+            Self::DUP7 => "DUP7",
+            Self::DUP8 => "DUP8",
+            Self::DUP9 => "DUP9",
+            Self::DUP10 => "DUP10",
+            Self::DUP11 => "DUP11",
+            Self::DUP12 => "DUP12",
+            Self::DUP13 => "DUP13",
+            Self::DUP14 => "DUP14",
+            Self::DUP15 => "DUP15",
+            Self::DUP16 => "DUP16",
+            Self::DUPX => "DUPX",
+
+            Self::SWAP1 => "SWAP1",
+            Self::SWAP2 => "SWAP2",
+            Self::SWAP3 => "SWAP3",
+            Self::SWAP4 => "SWAP4",
+            Self::SWAP5 => "SWAP5",
+            Self::SWAP6 => "SWAP6",
+            Self::SWAP7 => "SWAP7",
+            Self::SWAP8 => "SWAP8",
+            Self::SWAP9 => "SWAP9",
+            Self::SWAP10 => "SWAP10",
+            Self::SWAP11 => "SWAP11",
+            Self::SWAP12 => "SWAP12",
+            Self::SWAP13 => "SWAP13",
+            Self::SWAP14 => "SWAP14",
+            Self::SWAP15 => "SWAP15",
+            Self::SWAP16 => "SWAP16",
+            Self::SWAPX => "SWAPX",
+
+            Self::POP => "POP",
+
+            Self::Tag => "Tag",
+            Self::JUMP => "JUMP",
+            Self::JUMPI => "JUMPI",
+            Self::JUMPDEST => "JUMPDEST",
+
+            Self::ADD => "ADD",
+            Self::SUB => "SUB",
+            Self::MUL => "MUL",
+            Self::DIV => "DIV",
+            Self::MOD => "MOD",
+            Self::SDIV => "SDIV",
+            Self::SMOD => "SMOD",
+
+            Self::LT => "LT",
+            Self::GT => "GT",
+            Self::EQ => "EQ",
+            Self::ISZERO => "ISZERO",
+            Self::SLT => "SLT",
+            Self::SGT => "SGT",
+
+            Self::OR => "OR",
+            Self::XOR => "XOR",
+            Self::NOT => "NOT",
+            Self::AND => "AND",
+            Self::SHL => "SHL",
+            Self::SHR => "SHR",
+            Self::SAR => "SAR",
+            Self::CLZ => "CLZ",
+            Self::BYTE => "BYTE",
+
+            Self::ADDMOD => "ADDMOD",
+            Self::MULMOD => "MULMOD",
+            Self::EXP => "EXP",
+            Self::SIGNEXTEND => "SIGNEXTEND",
+            Self::SHA3 => "SHA3",
+            Self::KECCAK256 => "KECCAK256",
+
+            Self::MLOAD => "MLOAD",
+            Self::MSTORE => "MSTORE",
+            Self::MSTORE8 => "MSTORE8",
+            Self::MCOPY => "MCOPY",
+
+            Self::SLOAD => "SLOAD",
+            Self::SSTORE => "SSTORE",
+            Self::TLOAD => "TLOAD",
+            Self::TSTORE => "TSTORE",
+            Self::PUSHIMMUTABLE => "PUSHIMMUTABLE",
+            Self::ASSIGNIMMUTABLE => "ASSIGNIMMUTABLE",
+
+            Self::CALLDATALOAD => "CALLDATALOAD",
+            Self::CALLDATASIZE => "CALLDATASIZE",
+            Self::CALLDATACOPY => "CALLDATACOPY",
+            Self::CODESIZE => "CODESIZE",
+            Self::CODECOPY => "CODECOPY",
+            Self::PUSHSIZE => "PUSHSIZE",
+            Self::EXTCODESIZE => "EXTCODESIZE",
+            Self::EXTCODEHASH => "EXTCODEHASH",
+            Self::RETURNDATASIZE => "RETURNDATASIZE",
+            Self::RETURNDATACOPY => "RETURNDATACOPY",
+
+            Self::RETURN => "RETURN",
+            Self::REVERT => "REVERT",
+            Self::STOP => "STOP",
+            Self::INVALID => "INVALID",
+
+            Self::LOG0 => "LOG0",
+            Self::LOG1 => "LOG1",
+            Self::LOG2 => "LOG2",
+            Self::LOG3 => "LOG3",
+            Self::LOG4 => "LOG4",
+
+            Self::CALL => "CALL",
+            Self::STATICCALL => "STATICCALL",
+            Self::DELEGATECALL => "DELEGATECALL",
+
+            Self::CREATE => "CREATE",
+            Self::CREATE2 => "CREATE2",
+
+            Self::ADDRESS => "ADDRESS",
+            Self::CALLER => "CALLER",
+
+            Self::CALLVALUE => "CALLVALUE",
+            Self::GAS => "GAS",
+            Self::BALANCE => "BALANCE",
+            Self::SELFBALANCE => "SELFBALANCE",
+
+            Self::PUSHLIB => "PUSHLIB",
+            Self::PUSHDEPLOYADDRESS => "PUSHDEPLOYADDRESS",
+            Self::MEMORYGUARD => "MEMORYGUARD",
+
+            Self::GASLIMIT => "GASLIMIT",
+            Self::GASPRICE => "GASPRICE",
+            Self::ORIGIN => "ORIGIN",
+            Self::CHAINID => "CHAINID",
+            Self::TIMESTAMP => "TIMESTAMP",
+            Self::NUMBER => "NUMBER",
+            Self::BLOCKHASH => "BLOCKHASH",
+            Self::BLOBHASH => "BLOBHASH",
+            Self::DIFFICULTY => "DIFFICULTY",
+            Self::PREVRANDAO => "PREVRANDAO",
+            Self::COINBASE => "COINBASE",
+            Self::BASEFEE => "BASEFEE",
+            Self::BLOBBASEFEE => "BLOBBASEFEE",
+            Self::MSIZE => "MSIZE",
+
+            Self::CALLCODE => "CALLCODE",
+            Self::PC => "PC",
+            Self::EXTCODECOPY => "EXTCODECOPY",
+            Self::SELFDESTRUCT => "SELFDESTRUCT",
+
+            Self::UNSAFEASM => "UNSAFEASM",
+
+            Self::RecursiveCall { .. } => "RECURSIVE_CALL",
+            Self::RecursiveReturn { .. } => "RECURSIVE_RETURN",
+        }
+    }
+}
+
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Tag => write!(f, "Tag"),
             Self::RecursiveCall {
                 name,
                 entry_key,
@@ -409,7 +610,7 @@ impl std::fmt::Display for Name {
                 "RECURSIVE_CALL({name}_{entry_key}, {input_size}, {output_size}, {return_address})",
             ),
             Self::RecursiveReturn { input_size } => write!(f, "RECURSIVE_RETURN({input_size})"),
-            _ => write!(f, "{self:?}",),
+            _ => f.write_str(self.mnemonic()),
         }
     }
 }

--- a/solx-evm-assembly/src/assembly/instruction/stack.rs
+++ b/solx-evm-assembly/src/assembly/instruction/stack.rs
@@ -18,10 +18,7 @@ where
 {
     let result = context
         .field_type()
-        .const_int_from_string(
-            value.to_ascii_uppercase().as_str(),
-            inkwell::types::StringRadix::Hexadecimal,
-        )
+        .const_int_from_string(value.as_str(), inkwell::types::StringRadix::Hexadecimal)
         .ok_or_else(|| anyhow::anyhow!("Invalid hexadecimal PUSH value: {value}"))?
         .as_basic_value_enum();
     Ok(result)
@@ -51,7 +48,6 @@ pub fn dup<'ctx, C>(
     context: &mut C,
     offset: usize,
     height: usize,
-    original: &mut Option<String>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
     C: solx_codegen_evm::IContext<'ctx>,
@@ -64,8 +60,6 @@ where
         solx_codegen_evm::Pointer::new_stack_field(context, element.to_llvm().into_pointer_value()),
         format!("dup{offset}").as_str(),
     )?;
-
-    element.original.clone_into(original);
 
     Ok(value)
 }
@@ -99,19 +93,6 @@ where
     );
     let swap_value =
         context.build_load(swap_pointer, format!("swap{offset}_swap_value").as_str())?;
-
-    if let Some(original) = swap_element.original {
-        context
-            .evmla_mut()
-            .expect("Always exists")
-            .set_original(height - 1, original.to_owned());
-    }
-    if let Some(original) = top_element.original {
-        context
-            .evmla_mut()
-            .expect("Always exists")
-            .set_original(height - offset - 1, original.to_owned());
-    }
 
     context.build_store(top_pointer, swap_value)?;
     context.build_store(swap_pointer, top_value)?;

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -312,7 +312,6 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
     }
 
     fn into_llvm(self, context: &mut solx_codegen_evm::Context) -> anyhow::Result<()> {
-        // Use module name which already includes the code segment (e.g., "contract.runtime")
         let contract_path = context
             .module()
             .get_name()
@@ -320,7 +319,6 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             .expect("Always valid")
             .to_owned();
 
-        // Get optimizer settings for file naming (same as LLVM IR dumps)
         let is_size_fallback = context.optimizer().settings().is_fallback_to_size_enabled();
         let spill_area = context
             .optimizer()
@@ -328,22 +326,32 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             .spill_area_size()
             .map(|size| (solx_codegen_evm::SOLC_USER_MEMORY_OFFSET, size));
 
-        let (code_segment, blocks) = if let Ok(runtime_code) = self.runtime_code() {
+        let output_evmla = context
+            .output_config()
+            .map_or(context.capture_evmla(), |output_config| {
+                output_config.output_evmla
+            });
+        let output_ethir = context
+            .output_config()
+            .map_or(context.capture_ethir(), |output_config| {
+                output_config.output_ethir
+            });
+
+        if output_evmla {
             let evmla_string = self.to_string();
-            if let Some(output_config) = context.output_config() {
-                output_config.dump_evmla(
+            match context.output_config() {
+                Some(output_config) => output_config.dump_evmla(
                     contract_path.as_str(),
                     evmla_string.as_str(),
                     is_size_fallback,
                     spill_area,
-                )?;
-            } else {
-                // Capture for standard JSON output when not writing to files
-                context.set_captured_evmla(evmla_string);
+                )?,
+                None => context.set_captured_evmla(evmla_string),
             }
+        }
 
+        let (code_segment, blocks) = if let Ok(runtime_code) = self.runtime_code() {
             let deploy_code_blocks = EtherealIR::get_blocks(
-                context.evmla().expect("Always exists").version.to_owned(),
                 solx_utils::CodeSegment::Deploy,
                 self.code
                     .as_deref()
@@ -355,7 +363,6 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Runtime code instructions not found"))?;
             let runtime_code_blocks = EtherealIR::get_blocks(
-                context.evmla().expect("Always exists").version.to_owned(),
                 solx_utils::CodeSegment::Runtime,
                 runtime_code_instructions.as_slice(),
             )?;
@@ -364,21 +371,7 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             blocks.extend(runtime_code_blocks);
             (solx_utils::CodeSegment::Deploy, blocks)
         } else {
-            let evmla_string = self.to_string();
-            if let Some(output_config) = context.output_config() {
-                output_config.dump_evmla(
-                    contract_path.as_str(),
-                    evmla_string.as_str(),
-                    is_size_fallback,
-                    spill_area,
-                )?;
-            } else {
-                // Capture for standard JSON output when not writing to files
-                context.set_captured_evmla(evmla_string);
-            }
-
             let blocks = EtherealIR::get_blocks(
-                context.evmla().expect("Always exists").version.to_owned(),
                 solx_utils::CodeSegment::Runtime,
                 self.code
                     .as_deref()
@@ -392,18 +385,19 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             self.extra_metadata.unwrap_or_default(),
             Some(code_segment),
             blocks,
+            output_ethir,
         )?;
-        let ethir_string = ethereal_ir.to_string();
-        if let Some(output_config) = context.output_config() {
-            output_config.dump_ethir(
-                contract_path.as_str(),
-                ethir_string.as_str(),
-                is_size_fallback,
-                spill_area,
-            )?;
-        } else {
-            // Capture for standard JSON output when not writing to files
-            context.set_captured_ethir(ethir_string);
+        if output_ethir {
+            let ethir_string = ethereal_ir.to_string();
+            match context.output_config() {
+                Some(output_config) => output_config.dump_ethir(
+                    contract_path.as_str(),
+                    ethir_string.as_str(),
+                    is_size_fallback,
+                    spill_area,
+                )?,
+                None => context.set_captured_ethir(ethir_string),
+            }
         }
 
         let mut entry = solx_codegen_evm::EntryFunction::new(ethereal_ir);

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -94,6 +94,18 @@ impl Assembly {
     }
 
     ///
+    /// Replaces the nested runtime code with a path reference, dropping its instructions.
+    ///
+    /// The deploy translation unit never enters the runtime blocks, so shipping the runtime
+    /// instructions inside the deploy input is dead weight.
+    ///
+    pub fn strip_runtime_code(&mut self, path: String) {
+        if let Some(data) = self.data.as_mut() {
+            data.insert("0".to_owned(), Data::Path(path));
+        }
+    }
+
+    ///
     /// Get the list of EVM dependencies.
     ///
     pub fn accumulate_evm_dependencies(&self, dependencies: &mut solx_codegen_evm::Dependencies) {
@@ -350,40 +362,18 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             }
         }
 
-        let (code_segment, blocks) = if let Ok(runtime_code) = self.runtime_code() {
-            let deploy_code_blocks = EtherealIR::get_blocks(
-                solx_utils::CodeSegment::Deploy,
-                self.code
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("Deploy code instructions not found"))?,
-            )?;
-
-            let runtime_code_instructions = runtime_code
-                .code
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("Runtime code instructions not found"))?;
-            let runtime_code_blocks = EtherealIR::get_blocks(
-                solx_utils::CodeSegment::Runtime,
-                runtime_code_instructions.as_slice(),
-            )?;
-
-            let mut blocks = deploy_code_blocks;
-            blocks.extend(runtime_code_blocks);
-            (solx_utils::CodeSegment::Deploy, blocks)
-        } else {
-            let blocks = EtherealIR::get_blocks(
-                solx_utils::CodeSegment::Runtime,
-                self.code
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("Deploy code instructions not found"))?,
-            )?;
-            (solx_utils::CodeSegment::Runtime, blocks)
-        };
+        let code_segment = context.code_segment().expect("Code segment must be set");
+        let blocks = EtherealIR::get_blocks(
+            code_segment,
+            self.code
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("Code instructions not found"))?,
+        )?;
 
         let ethereal_ir = EtherealIR::new(
             context.evmla().expect("Always exists").version.to_owned(),
             self.extra_metadata.unwrap_or_default(),
-            Some(code_segment),
+            code_segment,
             blocks,
             output_ethir,
         )?;

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -95,8 +95,6 @@ impl solx_codegen_evm::WriteLLVM for Element {
             solidity_data.set_debug_info_solc_location(solc_location);
         }
 
-        let mut original = self.instruction.value.clone();
-
         let result = match self.instruction.name.clone() {
             InstructionName::PUSH0 => Ok(Some(context.field_const(0).as_basic_value_enum())),
             InstructionName::PUSH
@@ -200,103 +198,60 @@ impl solx_codegen_evm::WriteLLVM for Element {
             }
 
             InstructionName::DUP1 => {
-                crate::assembly::instruction::stack::dup(context, 1, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 1, self.stack_size).map(Some)
             }
             InstructionName::DUP2 => {
-                crate::assembly::instruction::stack::dup(context, 2, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 2, self.stack_size).map(Some)
             }
             InstructionName::DUP3 => {
-                crate::assembly::instruction::stack::dup(context, 3, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 3, self.stack_size).map(Some)
             }
             InstructionName::DUP4 => {
-                crate::assembly::instruction::stack::dup(context, 4, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 4, self.stack_size).map(Some)
             }
             InstructionName::DUP5 => {
-                crate::assembly::instruction::stack::dup(context, 5, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 5, self.stack_size).map(Some)
             }
             InstructionName::DUP6 => {
-                crate::assembly::instruction::stack::dup(context, 6, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 6, self.stack_size).map(Some)
             }
             InstructionName::DUP7 => {
-                crate::assembly::instruction::stack::dup(context, 7, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 7, self.stack_size).map(Some)
             }
             InstructionName::DUP8 => {
-                crate::assembly::instruction::stack::dup(context, 8, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 8, self.stack_size).map(Some)
             }
             InstructionName::DUP9 => {
-                crate::assembly::instruction::stack::dup(context, 9, self.stack_size, &mut original)
-                    .map(Some)
+                crate::assembly::instruction::stack::dup(context, 9, self.stack_size).map(Some)
             }
-            InstructionName::DUP10 => crate::assembly::instruction::stack::dup(
-                context,
-                10,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP11 => crate::assembly::instruction::stack::dup(
-                context,
-                11,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP12 => crate::assembly::instruction::stack::dup(
-                context,
-                12,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP13 => crate::assembly::instruction::stack::dup(
-                context,
-                13,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP14 => crate::assembly::instruction::stack::dup(
-                context,
-                14,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP15 => crate::assembly::instruction::stack::dup(
-                context,
-                15,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP16 => crate::assembly::instruction::stack::dup(
-                context,
-                16,
-                self.stack_size,
-                &mut original,
-            )
-            .map(Some),
+            InstructionName::DUP10 => {
+                crate::assembly::instruction::stack::dup(context, 10, self.stack_size).map(Some)
+            }
+            InstructionName::DUP11 => {
+                crate::assembly::instruction::stack::dup(context, 11, self.stack_size).map(Some)
+            }
+            InstructionName::DUP12 => {
+                crate::assembly::instruction::stack::dup(context, 12, self.stack_size).map(Some)
+            }
+            InstructionName::DUP13 => {
+                crate::assembly::instruction::stack::dup(context, 13, self.stack_size).map(Some)
+            }
+            InstructionName::DUP14 => {
+                crate::assembly::instruction::stack::dup(context, 14, self.stack_size).map(Some)
+            }
+            InstructionName::DUP15 => {
+                crate::assembly::instruction::stack::dup(context, 15, self.stack_size).map(Some)
+            }
+            InstructionName::DUP16 => {
+                crate::assembly::instruction::stack::dup(context, 16, self.stack_size).map(Some)
+            }
             InstructionName::DUPX => {
                 let offset = self
                     .stack_input
                     .pop_constant()?
                     .to_usize()
                     .ok_or_else(|| anyhow::anyhow!("DUPX offset too large"))?;
-                crate::assembly::instruction::stack::dup(
-                    context,
-                    offset,
-                    self.stack_size,
-                    &mut original,
-                )
-                .map(Some)
+                crate::assembly::instruction::stack::dup(context, offset, self.stack_size).map(Some)
             }
 
             InstructionName::SWAP1 => {
@@ -1202,8 +1157,6 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 solx_codegen_evm::Pointer::new_stack_field(context, pointer),
                 result,
             )?;
-            context.evmla_mut().expect("Always exists").stack[self.stack_size - 1].original =
-                original;
         }
 
         Ok(())

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -24,8 +24,12 @@ use self::stack::element::Element as StackElement;
 pub struct Element {
     /// The instruction.
     pub instruction: Instruction,
-    /// The stack data.
+    /// The stack snapshot after the instruction, captured only for Ethereal IR text output.
     pub stack: Stack,
+    /// The stack depth after the instruction.
+    pub stack_size: usize,
+    /// The stack state hash after the instruction, set for control transfer instructions.
+    pub stack_hash: Option<u64>,
     /// The stack input.
     pub stack_input: Stack,
     /// The stack output.
@@ -36,15 +40,14 @@ impl Element {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(solc_version: semver::Version, instruction: Instruction) -> Self {
-        let input_size = instruction.input_size(&solc_version);
-        let output_size = instruction.output_size();
-
+    pub fn new(instruction: Instruction) -> Self {
         Self {
             instruction,
-            stack: Stack::new(),
-            stack_input: Stack::with_capacity(input_size),
-            stack_output: Stack::with_capacity(output_size),
+            stack: Stack::default(),
+            stack_size: 0,
+            stack_hash: None,
+            stack_input: Stack::default(),
+            stack_output: Stack::default(),
         }
     }
 
@@ -62,7 +65,7 @@ impl Element {
         let mut arguments = Vec::with_capacity(input_size);
         for index in 0..input_size {
             let pointer = context.evmla().expect("Always exists").stack
-                [self.stack.elements.len() + input_size - output_size - 1 - index]
+                [self.stack_size + input_size - output_size - 1 - index]
                 .to_llvm()
                 .into_pointer_value();
             let value = context.build_load(
@@ -196,115 +199,88 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 .map(Some)
             }
 
-            InstructionName::DUP1 => crate::assembly::instruction::stack::dup(
-                context,
-                1,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP2 => crate::assembly::instruction::stack::dup(
-                context,
-                2,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP3 => crate::assembly::instruction::stack::dup(
-                context,
-                3,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP4 => crate::assembly::instruction::stack::dup(
-                context,
-                4,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP5 => crate::assembly::instruction::stack::dup(
-                context,
-                5,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP6 => crate::assembly::instruction::stack::dup(
-                context,
-                6,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP7 => crate::assembly::instruction::stack::dup(
-                context,
-                7,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP8 => crate::assembly::instruction::stack::dup(
-                context,
-                8,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
-            InstructionName::DUP9 => crate::assembly::instruction::stack::dup(
-                context,
-                9,
-                self.stack.elements.len(),
-                &mut original,
-            )
-            .map(Some),
+            InstructionName::DUP1 => {
+                crate::assembly::instruction::stack::dup(context, 1, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP2 => {
+                crate::assembly::instruction::stack::dup(context, 2, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP3 => {
+                crate::assembly::instruction::stack::dup(context, 3, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP4 => {
+                crate::assembly::instruction::stack::dup(context, 4, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP5 => {
+                crate::assembly::instruction::stack::dup(context, 5, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP6 => {
+                crate::assembly::instruction::stack::dup(context, 6, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP7 => {
+                crate::assembly::instruction::stack::dup(context, 7, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP8 => {
+                crate::assembly::instruction::stack::dup(context, 8, self.stack_size, &mut original)
+                    .map(Some)
+            }
+            InstructionName::DUP9 => {
+                crate::assembly::instruction::stack::dup(context, 9, self.stack_size, &mut original)
+                    .map(Some)
+            }
             InstructionName::DUP10 => crate::assembly::instruction::stack::dup(
                 context,
                 10,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP11 => crate::assembly::instruction::stack::dup(
                 context,
                 11,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP12 => crate::assembly::instruction::stack::dup(
                 context,
                 12,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP13 => crate::assembly::instruction::stack::dup(
                 context,
                 13,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP14 => crate::assembly::instruction::stack::dup(
                 context,
                 14,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP15 => crate::assembly::instruction::stack::dup(
                 context,
                 15,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
             InstructionName::DUP16 => crate::assembly::instruction::stack::dup(
                 context,
                 16,
-                self.stack.elements.len(),
+                self.stack_size,
                 &mut original,
             )
             .map(Some),
@@ -317,74 +293,65 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 crate::assembly::instruction::stack::dup(
                     context,
                     offset,
-                    self.stack.elements.len(),
+                    self.stack_size,
                     &mut original,
                 )
                 .map(Some)
             }
 
             InstructionName::SWAP1 => {
-                crate::assembly::instruction::stack::swap(context, 1, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 1, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP2 => {
-                crate::assembly::instruction::stack::swap(context, 2, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 2, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP3 => {
-                crate::assembly::instruction::stack::swap(context, 3, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 3, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP4 => {
-                crate::assembly::instruction::stack::swap(context, 4, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 4, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP5 => {
-                crate::assembly::instruction::stack::swap(context, 5, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 5, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP6 => {
-                crate::assembly::instruction::stack::swap(context, 6, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 6, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP7 => {
-                crate::assembly::instruction::stack::swap(context, 7, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 7, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP8 => {
-                crate::assembly::instruction::stack::swap(context, 8, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 8, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP9 => {
-                crate::assembly::instruction::stack::swap(context, 9, self.stack.elements.len())
-                    .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, 9, self.stack_size).map(|_| None)
             }
             InstructionName::SWAP10 => {
-                crate::assembly::instruction::stack::swap(context, 10, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 10, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP11 => {
-                crate::assembly::instruction::stack::swap(context, 11, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 11, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP12 => {
-                crate::assembly::instruction::stack::swap(context, 12, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 12, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP13 => {
-                crate::assembly::instruction::stack::swap(context, 13, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 13, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP14 => {
-                crate::assembly::instruction::stack::swap(context, 14, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 14, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP15 => {
-                crate::assembly::instruction::stack::swap(context, 15, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 15, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAP16 => {
-                crate::assembly::instruction::stack::swap(context, 16, self.stack.elements.len())
+                crate::assembly::instruction::stack::swap(context, 16, self.stack_size)
                     .map(|_| None)
             }
             InstructionName::SWAPX => {
@@ -393,12 +360,8 @@ impl solx_codegen_evm::WriteLLVM for Element {
                     .pop_constant()?
                     .to_usize()
                     .ok_or_else(|| anyhow::anyhow!("SWAPX offset too large"))?;
-                crate::assembly::instruction::stack::swap(
-                    context,
-                    offset,
-                    self.stack.elements.len(),
-                )
-                .map(|_| None)
+                crate::assembly::instruction::stack::swap(context, offset, self.stack_size)
+                    .map(|_| None)
             }
 
             InstructionName::POP => crate::assembly::instruction::stack::pop(context).map(|_| None),
@@ -414,7 +377,7 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 crate::assembly::instruction::jump::unconditional(
                     context,
                     destination,
-                    self.stack.hash(),
+                    self.stack_hash.expect("Always exists"),
                 )
                 .map(|_| None)
             }
@@ -424,7 +387,7 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 crate::assembly::instruction::jump::unconditional(
                     context,
                     destination,
-                    self.stack.hash(),
+                    self.stack_hash.expect("Always exists"),
                 )
                 .map(|_| None)
             }
@@ -435,8 +398,8 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 crate::assembly::instruction::jump::conditional(
                     context,
                     destination,
-                    self.stack.hash(),
-                    self.stack.elements.len(),
+                    self.stack_hash.expect("Always exists"),
+                    self.stack_size,
                 )
                 .map(|_| None)
             }
@@ -1158,7 +1121,7 @@ impl solx_codegen_evm::WriteLLVM for Element {
                 match result {
                     Some(value) if value.is_int_value() => {
                         let pointer = context.evmla().expect("Always exists").stack
-                            [self.stack.elements.len() - output_size]
+                            [self.stack_size - output_size]
                             .to_llvm()
                             .into_pointer_value();
                         context.build_store(
@@ -1178,7 +1141,7 @@ impl solx_codegen_evm::WriteLLVM for Element {
                                 context.field_type(),
                                 solx_codegen_evm::AddressSpace::Stack,
                                 context.evmla().expect("Always exists").stack
-                                    [self.stack.elements.len() - output_size + index]
+                                    [self.stack_size - output_size + index]
                                     .to_llvm()
                                     .into_pointer_value(),
                             );
@@ -1232,16 +1195,15 @@ impl solx_codegen_evm::WriteLLVM for Element {
         }?;
 
         if let Some(result) = result {
-            let pointer = context.evmla().expect("Always exists").stack
-                [self.stack.elements.len() - 1]
+            let pointer = context.evmla().expect("Always exists").stack[self.stack_size - 1]
                 .to_llvm()
                 .into_pointer_value();
             context.build_store(
                 solx_codegen_evm::Pointer::new_stack_field(context, pointer),
                 result,
             )?;
-            context.evmla_mut().expect("Always exists").stack[self.stack.elements.len() - 1]
-                .original = original;
+            context.evmla_mut().expect("Always exists").stack[self.stack_size - 1].original =
+                original;
         }
 
         Ok(())

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -32,6 +32,8 @@ pub struct Element {
     pub stack_hash: Option<u64>,
     /// The stack input.
     pub stack_input: Stack,
+    /// The stack output depth.
+    pub stack_output_size: usize,
     /// The stack output.
     pub stack_output: Stack,
 }
@@ -47,6 +49,7 @@ impl Element {
             stack_size: 0,
             stack_hash: None,
             stack_input: Stack::default(),
+            stack_output_size: 0,
             stack_output: Stack::default(),
         }
     }

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/element.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/element.rs
@@ -8,7 +8,7 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Element {
     /// The runtime value.
-    Value(String),
+    Value(&'static str),
     /// The compile-time value.
     Constant(num::BigUint),
     /// The compile-time destination tag.
@@ -25,7 +25,7 @@ impl Element {
     ///
     /// A shortcut constructor.
     ///
-    pub fn value(identifier: String) -> Self {
+    pub fn value(identifier: &'static str) -> Self {
         Self::Value(identifier)
     }
 }

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/mod.rs
@@ -20,18 +20,6 @@ pub struct Stack {
 }
 
 impl Stack {
-    /// The default stack size.
-    pub const DEFAULT_STACK_SIZE: usize = 16;
-
-    ///
-    /// A shortcut constructor.
-    ///
-    pub fn new() -> Self {
-        Self {
-            elements: Vec::with_capacity(Self::DEFAULT_STACK_SIZE),
-        }
-    }
-
     ///
     /// A shortcut constructor.
     ///
@@ -69,13 +57,6 @@ impl Stack {
     ///
     pub fn push(&mut self, element: Element) {
         self.elements.push(element);
-    }
-
-    ///
-    /// Appends another stack on top of this one, consuming its elements.
-    ///
-    pub fn append(&mut self, other: &mut Self) {
-        self.elements.append(&mut other.elements);
     }
 
     ///

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/stack/mod.rs
@@ -60,13 +60,6 @@ impl Stack {
     }
 
     ///
-    /// Extends this stack by cloning elements from another stack.
-    ///
-    pub fn extend_from(&mut self, other: &Self) {
-        self.elements.extend(other.elements.iter().cloned());
-    }
-
-    ///
     /// Pops a stack element.
     ///
     pub fn pop(&mut self) -> anyhow::Result<Element> {

--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -41,7 +41,6 @@ impl Block {
     /// Assembles a block from the sequence of instructions.
     ///
     pub fn try_from_instructions(
-        solc_version: semver::Version,
         code_segment: solx_utils::CodeSegment,
         slice: &[Instruction],
     ) -> anyhow::Result<(Self, usize)> {
@@ -67,15 +66,15 @@ impl Block {
             instance: None,
             elements: Vec::with_capacity(Self::ELEMENTS_VECTOR_DEFAULT_CAPACITY),
             predecessors: BTreeSet::new(),
-            initial_stack: ElementStack::new(),
-            stack: ElementStack::new(),
+            initial_stack: ElementStack::default(),
+            stack: ElementStack::default(),
             extra_hashes: vec![],
         };
 
         let mut dead_code = false;
         while cursor < slice.len() {
             if !dead_code {
-                let element: Element = Element::new(solc_version.clone(), slice[cursor].to_owned());
+                let element: Element = Element::new(slice[cursor].to_owned());
                 block.elements.push(element);
             }
 

--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -34,9 +34,6 @@ pub struct Block {
 }
 
 impl Block {
-    /// The elements vector initial capacity.
-    pub const ELEMENTS_VECTOR_DEFAULT_CAPACITY: usize = 64;
-
     ///
     /// Assembles a block from the sequence of instructions.
     ///
@@ -64,7 +61,7 @@ impl Block {
         let mut block = Self {
             key: solx_codegen_evm::BlockKey::new(code_segment, tag),
             instance: None,
-            elements: Vec::with_capacity(Self::ELEMENTS_VECTOR_DEFAULT_CAPACITY),
+            elements: Vec::new(),
             predecessors: BTreeSet::new(),
             initial_stack: ElementStack::default(),
             stack: ElementStack::default(),

--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -29,8 +29,6 @@ pub struct Block {
     pub initial_stack: ElementStack,
     /// The stack.
     pub stack: ElementStack,
-    /// The extra block hashes for alternative routes.
-    pub extra_hashes: Vec<u64>,
 }
 
 impl Block {
@@ -65,7 +63,6 @@ impl Block {
             predecessors: BTreeSet::new(),
             initial_stack: ElementStack::default(),
             stack: ElementStack::default(),
-            extra_hashes: vec![],
         };
 
         let mut dead_code = false;

--- a/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/mod.rs
@@ -25,8 +25,8 @@ pub struct Block {
     pub elements: Vec<Element>,
     /// The block predecessors.
     pub predecessors: BTreeSet<(solx_codegen_evm::BlockKey, usize)>,
-    /// The initial stack state.
-    pub initial_stack: ElementStack,
+    /// The initial stack state hash, which acts as the block instance identifier.
+    pub initial_stack_hash: u64,
     /// The stack.
     pub stack: ElementStack,
 }
@@ -61,7 +61,7 @@ impl Block {
             instance: None,
             elements: Vec::new(),
             predecessors: BTreeSet::new(),
-            initial_stack: ElementStack::default(),
+            initial_stack_hash: 0,
             stack: ElementStack::default(),
         };
 

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -49,7 +49,7 @@ pub struct Function {
     /// The function name.
     pub name: String,
     /// The optional code segment. Only used for the EVM target.
-    pub code_segment: Option<solx_utils::CodeSegment>,
+    pub code_segment: solx_utils::CodeSegment,
     /// The separately labelled blocks.
     pub blocks: BTreeMap<solx_codegen_evm::BlockKey, Vec<Block>>,
     /// The function type.
@@ -66,7 +66,7 @@ impl Function {
     ///
     pub fn new(
         solc_version: semver::Version,
-        code_segment: Option<solx_utils::CodeSegment>,
+        code_segment: solx_utils::CodeSegment,
         r#type: Type,
         capture_stacks: bool,
     ) -> Self {
@@ -102,30 +102,20 @@ impl Function {
     ) -> anyhow::Result<()> {
         let mut visited_blocks = FxHashSet::default();
 
-        let code_segments = match self.code_segment {
-            Some(code_segment) => vec![code_segment],
-            None => vec![
-                solx_utils::CodeSegment::Deploy,
-                solx_utils::CodeSegment::Runtime,
-            ],
-        };
-
         match self.r#type {
             Type::Entry => {
-                for code_segment in code_segments {
-                    self.consume_block(
-                        blocks,
-                        functions,
-                        extra_metadata,
-                        visited_functions,
-                        &mut visited_blocks,
-                        QueueElement::new(
-                            solx_codegen_evm::BlockKey::new(code_segment, 0u64),
-                            None,
-                            Stack::default(),
-                        ),
-                    )?;
-                }
+                self.consume_block(
+                    blocks,
+                    functions,
+                    extra_metadata,
+                    visited_functions,
+                    &mut visited_blocks,
+                    QueueElement::new(
+                        solx_codegen_evm::BlockKey::new(self.code_segment, 0u64),
+                        None,
+                        Stack::default(),
+                    ),
+                )?;
             }
             Type::Defined {
                 ref block_key,
@@ -1357,7 +1347,7 @@ impl Function {
         if !visited_functions.contains(&visited_element) {
             let mut function = Self::new(
                 version.to_owned(),
-                Some(block_key.code_segment),
+                block_key.code_segment,
                 Type::new_defined(
                     function.name.to_owned(),
                     function.ast_id,

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -162,8 +162,9 @@ impl Function {
 
         let mut queue = vec![];
 
+        let initial_stack_hash = queue_element.stack.hash();
         let visited_element =
-            VisitedElement::new(queue_element.block_key.clone(), queue_element.stack.hash());
+            VisitedElement::new(queue_element.block_key.clone(), initial_stack_hash);
         if let Some(&instance) = visited_blocks.get(&visited_element) {
             if let Some(predecessor) = queue_element.predecessor.take() {
                 self.blocks
@@ -181,8 +182,8 @@ impl Function {
             .ok_or_else(|| {
                 anyhow::anyhow!("Undeclared destination block {}", queue_element.block_key)
             })?;
-        block.initial_stack = std::mem::take(&mut queue_element.stack);
-        block.stack = block.initial_stack.clone();
+        block.initial_stack_hash = initial_stack_hash;
+        block.stack = std::mem::take(&mut queue_element.stack);
         let block = self.insert_block(block);
         visited_blocks.insert(visited_element, block.instance.expect("Always exists"));
         if let Some(predecessor) = queue_element.predecessor.take() {
@@ -1466,7 +1467,7 @@ impl solx_codegen_evm::WriteLLVM for Function {
             for (index, block) in blocks.iter().enumerate() {
                 let inner = context.append_basic_block(format!("block_{key}/{index}").as_str());
                 let evmla_data =
-                    solx_codegen_evm::FunctionBlockEVMLAData::new(block.initial_stack.hash());
+                    solx_codegen_evm::FunctionBlockEVMLAData::new(block.initial_stack_hash);
                 let mut block = solx_codegen_evm::FunctionBlock::new(inner);
                 block.set_evmla_data(evmla_data);
                 context

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -98,7 +98,7 @@ impl Function {
         blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut FxHashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<solx_codegen_evm::BlockKey>,
     ) -> anyhow::Result<()> {
         let mut visited_blocks = FxHashMap::default();
 
@@ -153,7 +153,7 @@ impl Function {
         blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut FxHashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<solx_codegen_evm::BlockKey>,
         visited_blocks: &mut FxHashMap<VisitedElement, usize>,
         mut queue_element: QueueElement,
     ) -> anyhow::Result<()> {
@@ -243,7 +243,7 @@ impl Function {
         blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut FxHashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<solx_codegen_evm::BlockKey>,
         code_segment: solx_utils::CodeSegment,
         instance: usize,
         block_stack: &mut Stack,
@@ -1319,7 +1319,7 @@ impl Function {
         blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut FxHashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<solx_codegen_evm::BlockKey>,
         block_key: solx_codegen_evm::BlockKey,
         block_stack: &mut Stack,
         block_element: &mut BlockElement,
@@ -1327,8 +1327,6 @@ impl Function {
         capture_stacks: bool,
     ) -> anyhow::Result<(solx_codegen_evm::BlockKey, Vec<Element>)> {
         let return_address_offset = block_stack.elements.len() - 2 - function.input_size;
-        let input_arguments_offset = return_address_offset + 1;
-        let callee_tag_offset = input_arguments_offset + function.input_size;
 
         let return_address = match block_stack.elements[return_address_offset] {
             Element::Tag(ref return_address) => {
@@ -1336,15 +1334,8 @@ impl Function {
             }
             ref element => anyhow::bail!("Expected the function return address, found {element}"),
         };
-        let mut stack = Stack::with_capacity(1 + function.input_size);
-        stack.push(StackElement::ReturnAddress(1 + function.output_size));
-        stack
-            .elements
-            .extend_from_slice(&block_stack.elements[input_arguments_offset..callee_tag_offset]);
-        let stack_hash = stack.hash();
 
-        let visited_element = VisitedElement::new(block_key.clone(), stack_hash);
-        if !visited_functions.contains(&visited_element) {
+        if !visited_functions.contains(&block_key) {
             let mut function = Self::new(
                 version.to_owned(),
                 block_key.code_segment,
@@ -1357,7 +1348,7 @@ impl Function {
                 ),
                 capture_stacks,
             );
-            visited_functions.insert(visited_element);
+            visited_functions.insert(block_key.clone());
             function.traverse(blocks, functions, extra_metadata, visited_functions)?;
             functions.insert(block_key.clone(), function);
         }

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -1302,10 +1302,14 @@ impl Function {
                 .drain(block_stack.len() - input_size..)
                 .collect(),
         );
-        block_element.stack_output = Stack::new_with_elements(output_data);
-        block_stack.extend_from(&block_element.stack_output);
+        block_element.stack_output_size = output_data.len();
+        block_stack.elements.extend(output_data);
         block_element.stack_size = block_stack.len();
         if capture_stacks {
+            block_element.stack_output = Stack::new_with_elements(
+                block_stack.elements[block_stack.len() - block_element.stack_output_size..]
+                    .to_vec(),
+            );
             block_element.stack = block_stack.clone();
         }
         Ok(())
@@ -1408,7 +1412,7 @@ impl Function {
                 for block_element in block.elements.iter() {
                     let total_length = block_element.stack_size
                         + block_element.stack_input.len()
-                        + block_element.stack_output.len();
+                        + block_element.stack_output_size;
                     if total_length > self.stack_size {
                         self.stack_size = total_length;
                     }

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -1269,6 +1269,8 @@ impl Function {
             capture_stacks,
         )?;
 
+        // Keep this set in sync with the `stack_hash.expect()` readers in `block::element`:
+        // those arms panic if their instruction is not captured here.
         if matches!(
             block_element.instruction.name,
             InstructionName::Tag | InstructionName::JUMP | InstructionName::JUMPI

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -8,8 +8,6 @@ pub mod r#type;
 pub mod visited_element;
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
 
 use inkwell::types::BasicType;
 use inkwell::values::BasicValue;
@@ -21,6 +19,8 @@ use num::Num;
 use num::One;
 use num::ToPrimitive;
 use num::Zero;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use solx_codegen_evm::IContext;
 use solx_codegen_evm::IEVMLAFunction;
@@ -95,12 +95,12 @@ impl Function {
     ///
     pub fn traverse(
         &mut self,
-        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut HashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<VisitedElement>,
     ) -> anyhow::Result<()> {
-        let mut visited_blocks = HashSet::new();
+        let mut visited_blocks = FxHashSet::default();
 
         let code_segments = match self.code_segment {
             Some(code_segment) => vec![code_segment],
@@ -160,11 +160,11 @@ impl Function {
     ///
     fn consume_block(
         &mut self,
-        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut HashSet<VisitedElement>,
-        visited_blocks: &mut HashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<VisitedElement>,
+        visited_blocks: &mut FxHashSet<VisitedElement>,
         mut queue_element: QueueElement,
     ) -> anyhow::Result<()> {
         let version = self.solc_version.to_owned();
@@ -250,10 +250,10 @@ impl Function {
     /// the invalid part is truncated after terminating with an `INVALID` instruction.
     ///
     fn handle_instruction(
-        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut HashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<VisitedElement>,
         code_segment: solx_utils::CodeSegment,
         instance: usize,
         block_stack: &mut Stack,
@@ -1326,10 +1326,10 @@ impl Function {
     ///
     fn handle_function_call(
         function: &ExtraMetadataDefinedFunction,
-        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
-        visited_functions: &mut HashSet<VisitedElement>,
+        visited_functions: &mut FxHashSet<VisitedElement>,
         block_key: solx_codegen_evm::BlockKey,
         block_stack: &mut Stack,
         block_element: &mut BlockElement,
@@ -1408,7 +1408,7 @@ impl Function {
     /// Checks whether the tag value references an existing block in the given code segment.
     ///
     fn is_tag_value_valid(
-        blocks: &HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: &FxHashMap<solx_codegen_evm::BlockKey, Block>,
         code_segment: solx_utils::CodeSegment,
         tag: &u64,
     ) -> bool {

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -52,12 +52,12 @@ pub struct Function {
     pub code_segment: Option<solx_utils::CodeSegment>,
     /// The separately labelled blocks.
     pub blocks: BTreeMap<solx_codegen_evm::BlockKey, Vec<Block>>,
-    /// Index of initial stack hashes per block key for O(1) duplicate detection.
-    block_hash_index: HashMap<solx_codegen_evm::BlockKey, HashSet<u64>>,
     /// The function type.
     pub r#type: Type,
     /// The function stack size.
     pub stack_size: usize,
+    /// Whether per-element stack snapshots are captured for Ethereal IR text output.
+    pub capture_stacks: bool,
 }
 
 impl Function {
@@ -68,6 +68,7 @@ impl Function {
         solc_version: semver::Version,
         code_segment: Option<solx_utils::CodeSegment>,
         r#type: Type,
+        capture_stacks: bool,
     ) -> Self {
         let name = match r#type {
             Type::Entry => solx_codegen_evm::ENTRY_FUNCTION_NAME.to_string(),
@@ -83,9 +84,9 @@ impl Function {
             name,
             code_segment,
             blocks: BTreeMap::new(),
-            block_hash_index: HashMap::new(),
             r#type,
             stack_size: 0,
+            capture_stacks,
         }
     }
 
@@ -121,7 +122,7 @@ impl Function {
                         QueueElement::new(
                             solx_codegen_evm::BlockKey::new(code_segment, 0u64),
                             None,
-                            Stack::new(),
+                            Stack::default(),
                         ),
                     )?;
                 }
@@ -134,12 +135,9 @@ impl Function {
             } => {
                 let mut stack = Stack::with_capacity(1 + input_size);
                 stack.push(Element::ReturnAddress(output_size));
-                stack.append(&mut Stack::new_with_elements(vec![
-                    Element::value(
-                        "ARGUMENT".to_owned()
-                    );
-                    input_size
-                ]));
+                stack
+                    .elements
+                    .extend(std::iter::repeat_n(Element::value("ARGUMENT"), input_size));
 
                 self.consume_block(
                     blocks,
@@ -170,8 +168,23 @@ impl Function {
         mut queue_element: QueueElement,
     ) -> anyhow::Result<()> {
         let version = self.solc_version.to_owned();
+        let capture_stacks = self.capture_stacks;
 
         let mut queue = vec![];
+
+        let visited_element =
+            VisitedElement::new(queue_element.block_key.clone(), queue_element.stack.hash());
+        if visited_blocks.contains(&visited_element) {
+            if let Some(predecessor) = queue_element.predecessor.take() {
+                self.blocks
+                    .get_mut(&queue_element.block_key)
+                    .and_then(|instances| instances.last_mut())
+                    .expect("Always exists")
+                    .insert_predecessor(predecessor.0, predecessor.1);
+            }
+            return Ok(());
+        }
+        visited_blocks.insert(visited_element);
 
         let mut block = blocks
             .get(&queue_element.block_key)
@@ -179,19 +192,12 @@ impl Function {
             .ok_or_else(|| {
                 anyhow::anyhow!("Undeclared destination block {}", queue_element.block_key)
             })?;
-        block.initial_stack = queue_element.stack.clone();
-        let block = self.insert_block(block);
+        block.initial_stack = std::mem::take(&mut queue_element.stack);
         block.stack = block.initial_stack.clone();
+        let block = self.insert_block(block);
         if let Some(predecessor) = queue_element.predecessor.take() {
             block.insert_predecessor(predecessor.0, predecessor.1);
         }
-
-        let visited_element =
-            VisitedElement::new(queue_element.block_key.clone(), queue_element.stack.hash());
-        if visited_blocks.contains(&visited_element) {
-            return Ok(());
-        }
-        visited_blocks.insert(visited_element);
 
         let mut block_size = 0;
         for block_element in block.elements.iter_mut() {
@@ -207,13 +213,17 @@ impl Function {
                 &mut block.stack,
                 block_element,
                 &version,
+                capture_stacks,
                 &mut queue,
                 &mut queue_element,
             )
             .is_err()
             {
                 block_element.instruction = Instruction::invalid(&block_element.instruction);
-                block_element.stack = block.stack.clone();
+                block_element.stack_size = block.stack.len();
+                if capture_stacks {
+                    block_element.stack = block.stack.clone();
+                }
                 break;
             }
         }
@@ -249,6 +259,7 @@ impl Function {
         block_stack: &mut Stack,
         block_element: &mut BlockElement,
         version: &semver::Version,
+        capture_stacks: bool,
         queue: &mut Vec<QueueElement>,
         queue_element: &mut QueueElement,
     ) -> anyhow::Result<()> {
@@ -287,7 +298,13 @@ impl Function {
                     Element::ReturnAddress(output_size) => {
                         block_element.instruction =
                             Instruction::r#return(1 + output_size, instruction);
-                        Self::update_io_data(block_stack, block_element, 1 + output_size, vec![])?;
+                        Self::update_io_data(
+                            block_stack,
+                            block_element,
+                            1 + output_size,
+                            vec![],
+                            capture_stacks,
+                        )?;
                         return Ok(());
                     }
                     element => {
@@ -312,6 +329,7 @@ impl Function {
                         block_stack,
                         block_element,
                         version,
+                        capture_stacks,
                     )?
                 } else {
                     (block_key, vec![])
@@ -322,7 +340,7 @@ impl Function {
                     Some(QueueElement::new(
                         next_block_key,
                         queue_element.predecessor.clone(),
-                        Stack::new(),
+                        Stack::default(),
                     )),
                 )
             }
@@ -360,7 +378,7 @@ impl Function {
                     Some(QueueElement::new(
                         block_key,
                         queue_element.predecessor.clone(),
-                        Stack::new(),
+                        Stack::default(),
                     )),
                 )
             }
@@ -382,7 +400,7 @@ impl Function {
                     Some(QueueElement::new(
                         block_key,
                         queue_element.predecessor.clone(),
-                        Stack::new(),
+                        Stack::default(),
                     )),
                 )
             }
@@ -671,10 +689,7 @@ impl Function {
             instruction @ Instruction {
                 name: InstructionName::PUSHDEPLOYADDRESS,
                 ..
-            } => (
-                vec![StackElement::value(instruction.name.to_string())],
-                None,
-            ),
+            } => (vec![StackElement::value(instruction.name.mnemonic())], None),
 
             instruction @ Instruction {
                 name: InstructionName::ADD,
@@ -690,8 +705,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -704,8 +719,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -718,17 +733,17 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         match operand_1.checked_add(operand_2) {
                             Some(result) => Element::Constant(result),
-                            None => Element::value(instruction.name.to_string()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -747,8 +762,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -761,8 +776,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -775,17 +790,17 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         match operand_1.checked_sub(operand_2) {
                             Some(result) => Element::Constant(result),
-                            None => Element::value(instruction.name.to_string()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -804,8 +819,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -818,8 +833,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -832,17 +847,17 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         match operand_1.checked_mul(operand_2) {
                             Some(result) => Element::Constant(result),
-                            None => Element::value(instruction.name.to_string()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -864,8 +879,8 @@ impl Function {
                                 {
                                     Element::Tag(result)
                                 }
-                                Some(_) => Element::value(instruction.name.to_string()),
-                                None => Element::value(instruction.name.to_string()),
+                                Some(_) => Element::value(instruction.name.mnemonic()),
+                                None => Element::value(instruction.name.mnemonic()),
                             }
                         }
                     }
@@ -883,8 +898,8 @@ impl Function {
                                 {
                                     Element::Tag(result)
                                 }
-                                Some(_) => Element::value(instruction.name.to_string()),
-                                None => Element::value(instruction.name.to_string()),
+                                Some(_) => Element::value(instruction.name.mnemonic()),
+                                None => Element::value(instruction.name.mnemonic()),
                             }
                         }
                     }
@@ -901,8 +916,8 @@ impl Function {
                                 {
                                     Element::Tag(result)
                                 }
-                                Some(_) => Element::value(instruction.name.to_string()),
-                                None => Element::value(instruction.name.to_string()),
+                                Some(_) => Element::value(instruction.name.mnemonic()),
+                                None => Element::value(instruction.name.mnemonic()),
                             }
                         }
                     }
@@ -912,11 +927,11 @@ impl Function {
                         } else {
                             match operand_1.checked_div(operand_2) {
                                 Some(result) => Element::Constant(result),
-                                None => Element::value(instruction.name.to_string()),
+                                None => Element::value(instruction.name.mnemonic()),
                             }
                         }
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -936,7 +951,7 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         }
                     }
@@ -951,7 +966,7 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         }
                     }
@@ -965,10 +980,10 @@ impl Function {
                                     if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                         Element::Tag(result)
                                     } else {
-                                        Element::value(instruction.name.to_string())
+                                        Element::value(instruction.name.mnemonic())
                                     }
                                 }
-                                None => Element::value(instruction.name.to_string()),
+                                None => Element::value(instruction.name.mnemonic()),
                             }
                         }
                     }
@@ -979,7 +994,7 @@ impl Function {
                             Element::Constant(operand_1 % operand_2)
                         }
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1000,8 +1015,8 @@ impl Function {
                             {
                                 Element::Tag(result)
                             }
-                            Some(_) => Element::value(instruction.name.to_string()),
-                            None => Element::value(instruction.name.to_string()),
+                            Some(_) => Element::value(instruction.name.mnemonic()),
+                            None => Element::value(instruction.name.mnemonic()),
                         }
                     }
                     (Element::Constant(constant), Element::Constant(offset)) => {
@@ -1009,7 +1024,7 @@ impl Function {
                         let offset = offset.to_u64().expect("Always valid");
                         Element::Constant(constant << offset)
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1028,7 +1043,7 @@ impl Function {
                         if Self::is_tag_value_valid(blocks, code_segment, &result) {
                             Element::Tag(result)
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(constant), Element::Constant(offset)) => {
@@ -1036,7 +1051,7 @@ impl Function {
                         let offset = offset.to_u64().expect("Always valid");
                         Element::Constant(constant >> offset)
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1053,7 +1068,7 @@ impl Function {
                         if Self::is_tag_value_valid(blocks, code_segment, &result) {
                             Element::Tag(result)
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -1062,10 +1077,10 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -1074,16 +1089,16 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         Element::Constant(operand_1 | operand_2)
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1100,7 +1115,7 @@ impl Function {
                         if Self::is_tag_value_valid(blocks, code_segment, &result) {
                             Element::Tag(result)
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -1109,10 +1124,10 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -1121,16 +1136,16 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         Element::Constant(operand_1 ^ operand_2)
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1147,7 +1162,7 @@ impl Function {
                         if Self::is_tag_value_valid(blocks, code_segment, &result) {
                             Element::Tag(result)
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Tag(tag), Element::Constant(constant)) => {
@@ -1156,10 +1171,10 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(constant), Element::Tag(tag)) => {
@@ -1168,16 +1183,16 @@ impl Function {
                             if Self::is_tag_value_valid(blocks, code_segment, &result) {
                                 Element::Tag(result)
                             } else {
-                                Element::value(instruction.name.to_string())
+                                Element::value(instruction.name.mnemonic())
                             }
                         } else {
-                            Element::value(instruction.name.to_string())
+                            Element::value(instruction.name.mnemonic())
                         }
                     }
                     (Element::Constant(operand_1), Element::Constant(operand_2)) => {
                         Element::Constant(operand_1 & operand_2)
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1193,7 +1208,7 @@ impl Function {
                     (Element::Tag(operand_1), Element::Tag(operand_2)) => {
                         Element::Constant(num::BigUint::from(u64::from(operand_1 < operand_2)))
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1208,7 +1223,7 @@ impl Function {
                     (Element::Tag(operand_1), Element::Tag(operand_2)) => {
                         Element::Constant(num::BigUint::from(u64::from(operand_1 > operand_2)))
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1223,7 +1238,7 @@ impl Function {
                     (Element::Tag(operand_1), Element::Tag(operand_2)) => {
                         Element::Constant(num::BigUint::from(u64::from(operand_1 == operand_2)))
                     }
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
@@ -1243,14 +1258,14 @@ impl Function {
                     } else {
                         num::BigUint::zero()
                     }),
-                    _ => Element::value(instruction.name.to_string()),
+                    _ => Element::value(instruction.name.mnemonic()),
                 };
 
                 (vec![result], None)
             }
 
             instruction => (
-                vec![Element::value(instruction.name.to_string()); instruction.output_size()],
+                vec![Element::value(instruction.name.mnemonic()); instruction.output_size()],
                 None,
             ),
         };
@@ -1260,10 +1275,18 @@ impl Function {
             block_element,
             block_element.instruction.input_size(version),
             stack_output,
+            capture_stacks,
         )?;
 
+        if matches!(
+            block_element.instruction.name,
+            InstructionName::Tag | InstructionName::JUMP | InstructionName::JUMPI
+        ) {
+            block_element.stack_hash = Some(block_stack.hash());
+        }
+
         if let Some(mut queue_element) = queue_element {
-            block_element.stack.clone_into(&mut queue_element.stack);
+            queue_element.stack = block_stack.clone();
             queue.push(queue_element);
         }
 
@@ -1278,6 +1301,7 @@ impl Function {
         block_element: &mut BlockElement,
         input_size: usize,
         output_data: Vec<Element>,
+        capture_stacks: bool,
     ) -> anyhow::Result<()> {
         if block_stack.len() < input_size {
             anyhow::bail!("Stack underflow");
@@ -1290,7 +1314,10 @@ impl Function {
         );
         block_element.stack_output = Stack::new_with_elements(output_data);
         block_stack.extend_from(&block_element.stack_output);
-        block_element.stack = block_stack.clone();
+        block_element.stack_size = block_stack.len();
+        if capture_stacks {
+            block_element.stack = block_stack.clone();
+        }
         Ok(())
     }
 
@@ -1307,6 +1334,7 @@ impl Function {
         block_stack: &mut Stack,
         block_element: &mut BlockElement,
         version: &semver::Version,
+        capture_stacks: bool,
     ) -> anyhow::Result<(solx_codegen_evm::BlockKey, Vec<Element>)> {
         let return_address_offset = block_stack.elements.len() - 2 - function.input_size;
         let input_arguments_offset = return_address_offset + 1;
@@ -1320,9 +1348,9 @@ impl Function {
         };
         let mut stack = Stack::with_capacity(1 + function.input_size);
         stack.push(StackElement::ReturnAddress(1 + function.output_size));
-        stack.append(&mut Stack::new_with_elements(
-            block_stack.elements[input_arguments_offset..callee_tag_offset].to_owned(),
-        ));
+        stack
+            .elements
+            .extend_from_slice(&block_stack.elements[input_arguments_offset..callee_tag_offset]);
         let stack_hash = stack.hash();
 
         let visited_element = VisitedElement::new(block_key.clone(), stack_hash);
@@ -1337,17 +1365,20 @@ impl Function {
                     function.input_size,
                     function.output_size,
                 ),
+                capture_stacks,
             );
             visited_functions.insert(visited_element);
             function.traverse(blocks, functions, extra_metadata, visited_functions)?;
             functions.insert(block_key.clone(), function);
         }
 
-        let stack_output = vec![Element::value("RETURN_VALUE".to_owned()); function.output_size];
-        let mut return_stack = Stack::new_with_elements(
-            block_stack.elements[..block_stack.len() - function.input_size - 2].to_owned(),
-        );
-        return_stack.append(&mut Stack::new_with_elements(stack_output.clone()));
+        let stack_output = vec![Element::value("RETURN_VALUE"); function.output_size];
+        let return_size = block_stack.len() - function.input_size - 2;
+        let mut return_stack = Stack::with_capacity(return_size + function.output_size);
+        return_stack
+            .elements
+            .extend_from_slice(&block_stack.elements[..return_size]);
+        return_stack.elements.extend(stack_output.iter().cloned());
         let return_stack_hash = return_stack.hash();
 
         block_element.instruction = Instruction::call(
@@ -1367,25 +1398,10 @@ impl Function {
     /// Pushes a block into the function.
     ///
     fn insert_block(&mut self, mut block: Block) -> &mut Block {
-        let key = block.key.clone();
-        let stack_hash = block.initial_stack.hash();
-
-        let hash_set = self.block_hash_index.entry(key.clone()).or_default();
-        if hash_set.insert(stack_hash) {
-            if let Some(entry) = self.blocks.get_mut(&key) {
-                block.instance = Some(entry.len());
-                entry.push(block);
-            } else {
-                block.instance = Some(0);
-                self.blocks.insert(key.clone(), vec![block]);
-            }
-        }
-
-        self.blocks
-            .get_mut(&key)
-            .expect("Always exists")
-            .last_mut()
-            .expect("Always exists")
+        let instances = self.blocks.entry(block.key.clone()).or_default();
+        block.instance = Some(instances.len());
+        instances.push(block);
+        instances.last_mut().expect("Always exists")
     }
 
     ///
@@ -1409,7 +1425,7 @@ impl Function {
         for (_tag, blocks) in self.blocks.iter() {
             for block in blocks.iter() {
                 for block_element in block.elements.iter() {
-                    let total_length = block_element.stack.elements.len()
+                    let total_length = block_element.stack_size
                         + block_element.stack_input.len()
                         + block_element.stack_output.len();
                     if total_length > self.stack_size {

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -100,7 +100,7 @@ impl Function {
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut FxHashSet<VisitedElement>,
     ) -> anyhow::Result<()> {
-        let mut visited_blocks = FxHashSet::default();
+        let mut visited_blocks = FxHashMap::default();
 
         match self.r#type {
             Type::Entry => {
@@ -154,7 +154,7 @@ impl Function {
         functions: &mut BTreeMap<solx_codegen_evm::BlockKey, Self>,
         extra_metadata: &ExtraMetadata,
         visited_functions: &mut FxHashSet<VisitedElement>,
-        visited_blocks: &mut FxHashSet<VisitedElement>,
+        visited_blocks: &mut FxHashMap<VisitedElement, usize>,
         mut queue_element: QueueElement,
     ) -> anyhow::Result<()> {
         let version = self.solc_version.to_owned();
@@ -164,17 +164,16 @@ impl Function {
 
         let visited_element =
             VisitedElement::new(queue_element.block_key.clone(), queue_element.stack.hash());
-        if visited_blocks.contains(&visited_element) {
+        if let Some(&instance) = visited_blocks.get(&visited_element) {
             if let Some(predecessor) = queue_element.predecessor.take() {
                 self.blocks
                     .get_mut(&queue_element.block_key)
-                    .and_then(|instances| instances.last_mut())
+                    .and_then(|instances| instances.get_mut(instance))
                     .expect("Always exists")
                     .insert_predecessor(predecessor.0, predecessor.1);
             }
             return Ok(());
         }
-        visited_blocks.insert(visited_element);
 
         let mut block = blocks
             .get(&queue_element.block_key)
@@ -185,6 +184,7 @@ impl Function {
         block.initial_stack = std::mem::take(&mut queue_element.stack);
         block.stack = block.initial_stack.clone();
         let block = self.insert_block(block);
+        visited_blocks.insert(visited_element, block.instance.expect("Always exists"));
         if let Some(predecessor) = queue_element.predecessor.take() {
             block.insert_predecessor(predecessor.0, predecessor.1);
         }
@@ -1470,9 +1470,8 @@ impl solx_codegen_evm::WriteLLVM for Function {
         for (key, blocks) in self.blocks.iter() {
             for (index, block) in blocks.iter().enumerate() {
                 let inner = context.append_basic_block(format!("block_{key}/{index}").as_str());
-                let mut stack_hashes = vec![block.initial_stack.hash()];
-                stack_hashes.extend_from_slice(block.extra_hashes.as_slice());
-                let evmla_data = solx_codegen_evm::FunctionBlockEVMLAData::new(stack_hashes);
+                let evmla_data =
+                    solx_codegen_evm::FunctionBlockEVMLAData::new(block.initial_stack.hash());
                 let mut block = solx_codegen_evm::FunctionBlock::new(inner);
                 block.set_evmla_data(evmla_data);
                 context
@@ -1530,7 +1529,8 @@ impl solx_codegen_evm::WriteLLVM for Function {
                     .blocks
                     .get(block_key)
                     .expect("Always exists")
-                    .first()
+                    .values()
+                    .next()
                     .expect("Always exists")
                     .inner();
                 context.build_unconditional_branch(initial_block)?;
@@ -1546,7 +1546,7 @@ impl solx_codegen_evm::WriteLLVM for Function {
                 .get(&key)
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("Undeclared function block {key}"))?
-                .into_iter()
+                .into_values()
                 .map(|block| block.inner())
                 .zip(blocks)
             {

--- a/solx-evm-assembly/src/ethereal_ir/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/mod.rs
@@ -49,9 +49,14 @@ impl EtherealIR {
         extra_metadata: ExtraMetadata,
         code_segment: Option<solx_utils::CodeSegment>,
         blocks: HashMap<solx_codegen_evm::BlockKey, Block>,
+        capture_stacks: bool,
     ) -> anyhow::Result<Self> {
-        let mut entry_function =
-            Function::new(solc_version, code_segment, FunctionType::new_entry());
+        let mut entry_function = Function::new(
+            solc_version,
+            code_segment,
+            FunctionType::new_entry(),
+            capture_stacks,
+        );
         let mut defined_functions = BTreeMap::new();
         let mut visited_functions = HashSet::new();
         entry_function.traverse(
@@ -71,7 +76,6 @@ impl EtherealIR {
     /// Gets blocks for the specified type of the contract code.
     ///
     pub fn get_blocks(
-        solc_version: semver::Version,
         code_segment: solx_utils::CodeSegment,
         instructions: &[Instruction],
     ) -> anyhow::Result<HashMap<solx_codegen_evm::BlockKey, Block>> {
@@ -79,11 +83,8 @@ impl EtherealIR {
         let mut offset = 0;
 
         while offset < instructions.len() {
-            let (block, size) = Block::try_from_instructions(
-                solc_version.clone(),
-                code_segment,
-                &instructions[offset..],
-            )?;
+            let (block, size) =
+                Block::try_from_instructions(code_segment, &instructions[offset..])?;
             blocks.insert(
                 solx_codegen_evm::BlockKey::new(code_segment, block.key.tag),
                 block,

--- a/solx-evm-assembly/src/ethereal_ir/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/mod.rs
@@ -45,7 +45,7 @@ impl EtherealIR {
     pub fn new(
         solc_version: semver::Version,
         extra_metadata: ExtraMetadata,
-        code_segment: Option<solx_utils::CodeSegment>,
+        code_segment: solx_utils::CodeSegment,
         blocks: FxHashMap<solx_codegen_evm::BlockKey, Block>,
         capture_stacks: bool,
     ) -> anyhow::Result<Self> {

--- a/solx-evm-assembly/src/ethereal_ir/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/mod.rs
@@ -38,9 +38,6 @@ pub struct EtherealIR {
 }
 
 impl EtherealIR {
-    /// The blocks hashmap initial capacity.
-    pub const BLOCKS_HASHMAP_DEFAULT_CAPACITY: usize = 64;
-
     ///
     /// Assembles a sequence of functions from the sequence of instructions.
     ///
@@ -79,7 +76,7 @@ impl EtherealIR {
         code_segment: solx_utils::CodeSegment,
         instructions: &[Instruction],
     ) -> anyhow::Result<HashMap<solx_codegen_evm::BlockKey, Block>> {
-        let mut blocks = HashMap::with_capacity(Self::BLOCKS_HASHMAP_DEFAULT_CAPACITY);
+        let mut blocks = HashMap::new();
         let mut offset = 0;
 
         while offset < instructions.len() {

--- a/solx-evm-assembly/src/ethereal_ir/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/mod.rs
@@ -5,8 +5,9 @@
 pub mod function;
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
+
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use solx_codegen_evm::IContext;
 
@@ -45,7 +46,7 @@ impl EtherealIR {
         solc_version: semver::Version,
         extra_metadata: ExtraMetadata,
         code_segment: Option<solx_utils::CodeSegment>,
-        blocks: HashMap<solx_codegen_evm::BlockKey, Block>,
+        blocks: FxHashMap<solx_codegen_evm::BlockKey, Block>,
         capture_stacks: bool,
     ) -> anyhow::Result<Self> {
         let mut entry_function = Function::new(
@@ -55,7 +56,7 @@ impl EtherealIR {
             capture_stacks,
         );
         let mut defined_functions = BTreeMap::new();
-        let mut visited_functions = HashSet::new();
+        let mut visited_functions = FxHashSet::default();
         entry_function.traverse(
             &blocks,
             &mut defined_functions,
@@ -75,8 +76,8 @@ impl EtherealIR {
     pub fn get_blocks(
         code_segment: solx_utils::CodeSegment,
         instructions: &[Instruction],
-    ) -> anyhow::Result<HashMap<solx_codegen_evm::BlockKey, Block>> {
-        let mut blocks = HashMap::new();
+    ) -> anyhow::Result<FxHashMap<solx_codegen_evm::BlockKey, Block>> {
+        let mut blocks = FxHashMap::default();
         let mut offset = 0;
 
         while offset < instructions.len() {

--- a/solx-evm-assembly/src/extra_metadata/mod.rs
+++ b/solx-evm-assembly/src/extra_metadata/mod.rs
@@ -4,16 +4,27 @@
 
 pub mod defined_function;
 
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::IgnoredAny;
+use serde::de::MapAccess;
+use serde::de::Visitor;
+use serde::ser::SerializeStruct;
+
 use self::defined_function::DefinedFunction;
 
 ///
 /// The `solc --standard-json` output contract EVM extra metadata.
 ///
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone)]
 pub struct ExtraMetadata {
-    /// The list of defined functions.
-    #[serde(default, rename = "recursiveFunctions")]
-    pub defined_functions: Vec<DefinedFunction>,
+    /// The defined functions keyed by their code segment and block tag.
+    pub defined_functions: HashMap<(solx_utils::CodeSegment, u64), DefinedFunction>,
 }
 
 impl ExtraMetadata {
@@ -25,29 +36,79 @@ impl ExtraMetadata {
         code_segment: solx_utils::CodeSegment,
         tag: &u64,
     ) -> Option<&DefinedFunction> {
-        for function in self.defined_functions.iter() {
-            match code_segment {
-                solx_utils::CodeSegment::Deploy => {
-                    if function
-                        .creation_tag
-                        .map(|creation_tag| (creation_tag as u64) == *tag)
-                        .unwrap_or_default()
-                    {
-                        return Some(function);
+        self.defined_functions.get(&(code_segment, *tag))
+    }
+}
+
+impl Serialize for ExtraMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let functions = self
+            .defined_functions
+            .values()
+            .map(|function| ((function.creation_tag, function.runtime_tag), function))
+            .collect::<BTreeMap<_, _>>()
+            .into_values()
+            .collect::<Vec<_>>();
+        let mut state = serializer.serialize_struct("ExtraMetadata", 1)?;
+        state.serialize_field("recursiveFunctions", &functions)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtraMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ExtraMetadataVisitor;
+
+        impl<'de> Visitor<'de> for ExtraMetadataVisitor {
+            type Value = ExtraMetadata;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("the EVM extra metadata object")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut extra_metadata = ExtraMetadata::default();
+                while let Some(key) = map.next_key::<String>()? {
+                    if key != "recursiveFunctions" {
+                        map.next_value::<IgnoredAny>()?;
+                        continue;
+                    }
+                    for function in map.next_value::<Vec<DefinedFunction>>()? {
+                        let creation_key = function
+                            .creation_tag
+                            .map(|tag| (solx_utils::CodeSegment::Deploy, tag as u64));
+                        let runtime_key = function
+                            .runtime_tag
+                            .map(|tag| (solx_utils::CodeSegment::Runtime, tag as u64));
+                        match (creation_key, runtime_key) {
+                            (Some(creation_key), Some(runtime_key)) => {
+                                extra_metadata
+                                    .defined_functions
+                                    .insert(creation_key, function.clone());
+                                extra_metadata
+                                    .defined_functions
+                                    .insert(runtime_key, function);
+                            }
+                            (Some(key), None) | (None, Some(key)) => {
+                                extra_metadata.defined_functions.insert(key, function);
+                            }
+                            (None, None) => {}
+                        }
                     }
                 }
-                solx_utils::CodeSegment::Runtime => {
-                    if function
-                        .runtime_tag
-                        .map(|runtime_tag| (runtime_tag as u64) == *tag)
-                        .unwrap_or_default()
-                    {
-                        return Some(function);
-                    }
-                }
+                Ok(extra_metadata)
             }
         }
 
-        None
+        deserializer.deserialize_map(ExtraMetadataVisitor)
     }
 }

--- a/solx/tests/cli/ethir.rs
+++ b/solx/tests/cli/ethir.rs
@@ -12,10 +12,18 @@ fn default() -> anyhow::Result<()> {
 
     let result = crate::cli::execute_solx(args)?;
 
+    // Guard the structure of the Ethereal IR dump: both segments, entry-function
+    // and per-segment block recovery, the stack-usage line, and rendered stacks.
     result
         .success()
         .stdout(predicate::str::contains("Deploy Ethereal IR:"))
-        .stdout(predicate::str::contains("block_"));
+        .stdout(predicate::str::contains("Runtime Ethereal IR:"))
+        .stdout(predicate::str::contains("function __entry {"))
+        .stdout(predicate::str::contains("stack_usage:"))
+        .stdout(predicate::str::contains("block_dt_"))
+        .stdout(predicate::str::contains("block_rt_"))
+        .stdout(predicate::str::contains(" - ["))
+        .stdout(predicate::str::contains(" + ["));
 
     Ok(())
 }


### PR DESCRIPTION
- perf(evmla): cut allocations in the Ethereal IR translator
- refactor(evmla): drop guessed collection capacities
- perf(evmla): index defined functions by segment and tag
- perf(evmla): hash the traversal maps with FxHash
- perf(evmla): drop dead runtime code from the deploy translation unit
- perf(evmla): drop dead Value.original propagation on the EVMLA path
- refactor(evmla): collapse dead block-hash vec to a scalar, fix predecessor dump attach
- perf(evmla): key visited_functions by block key, not the call-site stack
- perf(evmla): move block element stack output onto the working stack
- perf(evmla): carry the block initial-stack hash instead of the whole stack
