### PR TITLE
fix: EVM assembly correctness — debug-info line mapping + per-file outputSelection

### DIFF
--- a/solx-codegen-evm/src/codegen/context/solidity_data.rs
+++ b/solx-codegen-evm/src/codegen/context/solidity_data.rs
@@ -81,6 +81,7 @@ impl ISolidityData for SolidityData {
 
         debug_info
             .ast_nodes
+            .get(&solc_location.source_id)?
             .get(&start)
             .map(|ast_node| &ast_node.mapped_location)
     }

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -539,22 +539,8 @@ impl Project {
                 #[cfg(feature = "mlir")]
                 let mlir = contract.mlir.take();
 
-                let mut deploy_debug_info = output_selection
-                    .check_selection(
-                        path.as_str(),
-                        contract_name.name.as_deref(),
-                        solx_standard_json::InputSelector::BytecodeDebugInfo,
-                    )
-                    .then(|| self.debug_info.clone())
-                    .flatten();
-                let mut runtime_debug_info = output_selection
-                    .check_selection(
-                        path.as_str(),
-                        contract_name.name.as_deref(),
-                        solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
-                    )
-                    .then(|| self.debug_info.clone())
-                    .flatten();
+                let mut deploy_debug_info: Option<solx_utils::DebugInfo> = None;
+                let mut runtime_debug_info: Option<solx_utils::DebugInfo> = None;
 
                 let (deploy_code_ir, runtime_code_ir): (ContractIR, ContractIR) = match contract.ir
                 {
@@ -562,22 +548,34 @@ impl Project {
                         let runtime_code: ContractYul =
                             *deploy_code.runtime_code.take().expect("Always exists");
 
-                        if let Some(ref mut debug_info) = deploy_debug_info {
-                            debug_info.retain_source_ids(
-                                &deploy_code.object.sources.keys().copied().collect(),
-                            );
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
-                        if let Some(ref mut debug_info) = runtime_debug_info {
-                            debug_info.retain_source_ids(
-                                &runtime_code.object.sources.keys().copied().collect(),
-                            );
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
+                        deploy_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::BytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &deploy_code.object.sources.keys().copied().collect(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
+                        runtime_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &runtime_code.object.sources.keys().copied().collect(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
 
                         (deploy_code.into(), runtime_code.into())
                     }
@@ -585,18 +583,34 @@ impl Project {
                         let runtime_code: ContractEVMLegacyAssembly =
                             *deploy_code.runtime_code.take().expect("Always exists");
 
-                        if let Some(ref mut debug_info) = deploy_debug_info {
-                            debug_info.retain_source_ids(&deploy_code.assembly.source_ids());
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
-                        if let Some(ref mut debug_info) = runtime_debug_info {
-                            debug_info.retain_source_ids(&runtime_code.assembly.source_ids());
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
+                        deploy_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::BytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &deploy_code.assembly.source_ids(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
+                        runtime_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &runtime_code.assembly.source_ids(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
 
                         (deploy_code.into(), runtime_code.into())
                     }

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -59,61 +59,68 @@ impl Selection {
     /// Checks if the output element of the specified contract is selected.
     ///
     pub fn check_selection(&self, path: &str, name: Option<&str>, selector: Selector) -> bool {
-        if let Some(file) = self.inner.get(Self::WILDCARD).or(self.inner.get(path)) {
-            if let (Some(any), selector @ Selector::AST | selector @ Selector::Benchmarks) =
-                (file.get(Self::ANY_CONTRACT).or(file.get(path)), selector)
-            {
-                return any.contains(&Selector::Any) || any.contains(&selector);
+        [Self::WILDCARD, path].into_iter().any(|file_key| {
+            let Some(file) = self.inner.get(file_key) else {
+                return false;
+            };
+            if matches!(selector, Selector::AST | Selector::Benchmarks) {
+                return [Self::ANY_CONTRACT, path].into_iter().any(|contract_key| {
+                    file.get(contract_key)
+                        .is_some_and(|any| any.contains(&Selector::Any) || any.contains(&selector))
+                });
             }
-            if let Some(contract) = file
-                .get(Self::WILDCARD)
-                .or(name.and_then(|name| file.get(name)))
-            {
-                match selector {
-                    Selector::MethodIdentifiers
-                    | Selector::EVMLegacyAssembly
-                    | Selector::GasEstimates
-                        if contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
+            [Some(Self::WILDCARD), name]
+                .into_iter()
+                .flatten()
+                .any(|contract_key| {
+                    let Some(contract) = file.get(contract_key) else {
+                        return false;
+                    };
+                    match selector {
+                        Selector::MethodIdentifiers
+                        | Selector::EVMLegacyAssembly
+                        | Selector::GasEstimates
+                            if contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        Selector::BytecodeObject
+                        | Selector::BytecodeLLVMAssembly
+                        | Selector::BytecodeOpcodes
+                        | Selector::BytecodeLinkReferences
+                        | Selector::BytecodeSourceMap
+                        | Selector::BytecodeDebugInfo
+                        | Selector::BytecodeFunctionDebugData
+                        | Selector::BytecodeGeneratedSources
+                            if contract.contains(&Selector::Bytecode)
+                                || contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        Selector::RuntimeBytecodeObject
+                        | Selector::RuntimeBytecodeLLVMAssembly
+                        | Selector::RuntimeBytecodeOpcodes
+                        | Selector::RuntimeBytecodeLinkReferences
+                        | Selector::RuntimeBytecodeImmutableReferences
+                        | Selector::RuntimeBytecodeSourceMap
+                        | Selector::RuntimeBytecodeDebugInfo
+                        | Selector::RuntimeBytecodeFunctionDebugData
+                        | Selector::RuntimeBytecodeGeneratedSources
+                            if contract.contains(&Selector::RuntimeBytecode)
+                                || contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        selector
+                            if contract.contains(&Selector::Any)
+                                || contract.contains(&selector) =>
+                        {
+                            true
+                        }
+                        _ => false,
                     }
-                    Selector::BytecodeObject
-                    | Selector::BytecodeLLVMAssembly
-                    | Selector::BytecodeOpcodes
-                    | Selector::BytecodeLinkReferences
-                    | Selector::BytecodeSourceMap
-                    | Selector::BytecodeDebugInfo
-                    | Selector::BytecodeFunctionDebugData
-                    | Selector::BytecodeGeneratedSources
-                        if contract.contains(&Selector::Bytecode)
-                            || contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
-                    }
-                    Selector::RuntimeBytecodeObject
-                    | Selector::RuntimeBytecodeLLVMAssembly
-                    | Selector::RuntimeBytecodeOpcodes
-                    | Selector::RuntimeBytecodeLinkReferences
-                    | Selector::RuntimeBytecodeImmutableReferences
-                    | Selector::RuntimeBytecodeSourceMap
-                    | Selector::RuntimeBytecodeDebugInfo
-                    | Selector::RuntimeBytecodeFunctionDebugData
-                    | Selector::RuntimeBytecodeGeneratedSources
-                        if contract.contains(&Selector::RuntimeBytecode)
-                            || contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
-                    }
-                    selector
-                        if contract.contains(&Selector::Any) || contract.contains(&selector) =>
-                    {
-                        return true;
-                    }
-                    _ => {}
-                }
-            }
-        }
-        false
+                })
+        })
     }
 
     ///
@@ -137,6 +144,21 @@ impl Selection {
                 }
             }
         }
+    }
+
+    ///
+    /// Requests the specified contract selector for every file via the `*` wildcard, so that `solc`
+    /// also emits it for dependencies located in files absent from the output selection. Needed
+    /// because dependency resolution hashes the assembly of every referenced contract, including
+    /// contracts instantiated from files a per-file selection does not list.
+    ///
+    pub fn set_selector_for_all_files(&mut self, selector: Selector) {
+        self.inner
+            .entry(Self::WILDCARD.to_owned())
+            .or_default()
+            .entry(Self::WILDCARD.to_owned())
+            .or_default()
+            .insert(selector);
     }
 
     ///

--- a/solx-standard-json/src/output/mod.rs
+++ b/solx-standard-json/src/output/mod.rs
@@ -159,7 +159,8 @@ impl Output {
             HashMap::new();
         let mut function_definitions: HashMap<usize, solx_utils::DebugInfoFunctionDefinition> =
             HashMap::new();
-        let mut ast_nodes: HashMap<usize, solx_utils::DebugInfoAstNode> = HashMap::new();
+        let mut ast_nodes: HashMap<usize, HashMap<usize, solx_utils::DebugInfoAstNode>> =
+            HashMap::new();
 
         // Build source_id -> path mapping
         let source_ids: BTreeMap<usize, String> = self
@@ -192,11 +193,18 @@ impl Output {
                     ast_json,
                 ));
 
-                ast_nodes.extend(Source::get_ast_nodes(
-                    &|path: &str, ast: &serde_json::Value| Source::ast_node(path, ast, &line_index),
-                    path.as_str(),
-                    ast_json,
-                ));
+                ast_nodes.insert(
+                    source.id,
+                    Source::get_ast_nodes(
+                        &|path: &str, ast: &serde_json::Value| {
+                            Source::ast_node(path, ast, &line_index)
+                        },
+                        path.as_str(),
+                        ast_json,
+                    )
+                    .into_iter()
+                    .collect(),
+                );
             }
         }
 

--- a/solx-utils/src/debug_info/mod.rs
+++ b/solx-utils/src/debug_info/mod.rs
@@ -30,9 +30,9 @@ pub struct DebugInfo {
     /// Solidity AST function definitions.
     /// The key is the AST node ID.
     pub function_definitions: HashMap<usize, FunctionDefinition>,
-    /// Generic Solidity AST nodes.
-    /// The key is the start byte offset.
-    pub ast_nodes: HashMap<usize, AstNode>,
+    /// Generic Solidity AST nodes, grouped by source ID.
+    /// The outer key is the source ID; the inner key is the start byte offset.
+    pub ast_nodes: HashMap<usize, HashMap<usize, AstNode>>,
     /// Source ID to source file path mapping.
     #[serde(default)]
     pub source_ids: BTreeMap<usize, String>,
@@ -45,7 +45,7 @@ impl DebugInfo {
     pub fn new(
         contract_definitions: HashMap<String, ContractDefinition>,
         function_definitions: HashMap<usize, FunctionDefinition>,
-        ast_nodes: HashMap<usize, AstNode>,
+        ast_nodes: HashMap<usize, HashMap<usize, AstNode>>,
         source_ids: BTreeMap<usize, String>,
     ) -> Self {
         Self {
@@ -57,25 +57,38 @@ impl DebugInfo {
     }
 
     ///
-    /// Retains only the debug info for the specified source IDs.
+    /// Builds the debug info restricted to the given source IDs and, when set, the current contract.
+    /// Only the retained sources' AST nodes are cloned.
     ///
-    pub fn retain_source_ids(&mut self, source_ids: &BTreeSet<usize>) {
-        self.contract_definitions.retain(|_, contract_definition| {
-            source_ids.contains(&contract_definition.solc_location.source_id)
-        });
-        self.function_definitions.retain(|_, function_definition| {
-            source_ids.contains(&function_definition.solc_location.source_id)
-        });
-        self.ast_nodes
-            .retain(|_, ast_node| source_ids.contains(&ast_node.solc_location.source_id));
-    }
-
-    ///
-    /// Retains only the contract definition of the current contract.
-    ///
-    pub fn retain_current_contract(&mut self, contract_name: &str) {
-        self.contract_definitions
-            .retain(|name, _| name == contract_name);
+    pub fn filter_to(&self, source_ids: &BTreeSet<usize>, contract_name: Option<&str>) -> Self {
+        Self {
+            contract_definitions: self
+                .contract_definitions
+                .iter()
+                .filter(|(name, contract_definition)| {
+                    source_ids.contains(&contract_definition.solc_location.source_id)
+                        && contract_name.is_none_or(|current| current == name.as_str())
+                })
+                .map(|(name, contract_definition)| (name.clone(), contract_definition.clone()))
+                .collect(),
+            function_definitions: self
+                .function_definitions
+                .iter()
+                .filter(|(_, function_definition)| {
+                    source_ids.contains(&function_definition.solc_location.source_id)
+                })
+                .map(|(id, function_definition)| (*id, function_definition.clone()))
+                .collect(),
+            ast_nodes: source_ids
+                .iter()
+                .filter_map(|source_id| {
+                    self.ast_nodes
+                        .get(source_id)
+                        .map(|nodes| (*source_id, nodes.clone()))
+                })
+                .collect(),
+            source_ids: self.source_ids.clone(),
+        }
     }
 }
 

--- a/solx/src/solc.rs
+++ b/solx/src/solc.rs
@@ -95,7 +95,7 @@ impl solx_core::Frontend for Solc {
         input_json
             .settings
             .output_selection
-            .set_selector(input_json.settings.via_ir.into());
+            .set_selector_for_all_files(input_json.settings.via_ir.into());
 
         let original_optimizer = input_json.settings.optimizer.to_owned();
         input_json.settings.optimizer.mode = None;

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -510,3 +510,39 @@ fn select_ast_only() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn select_wildcard_and_per_file_are_unioned() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("select_wildcard_and_per_file.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("\"abi\""))
+        .stdout(predicate::str::contains("\"bytecode\""));
+
+    Ok(())
+}
+
+#[test]
+fn select_per_file_cross_file_dependency() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("select_cross_file_dependency.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("Contract path not found for hash").not())
+        .stdout(predicate::str::contains("\"bytecode\""));
+
+    Ok(())
+}

--- a/solx/tests/data/standard_json_input/select_cross_file_dependency.json
+++ b/solx/tests/data/standard_json_input/select_cross_file_dependency.json
@@ -1,0 +1,23 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\nimport \"./B.sol\";\ncontract A {\n    function deploy() public returns (address) {\n        return address(new B());\n    }\n}"
+    },
+    "B.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\ncontract B {\n    uint256 public x;\n}"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "A.sol": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}

--- a/solx/tests/data/standard_json_input/select_wildcard_and_per_file.json
+++ b/solx/tests/data/standard_json_input/select_wildcard_and_per_file.json
@@ -1,0 +1,25 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\ncontract C {}"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi"
+        ]
+      },
+      "A": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
- **Debug info** — key AST nodes by `(source_id, offset)` instead of offset alone, so nodes at the same offset in different files no longer collide and resolve to another file's line/column.
- **outputSelection** — `check_selection` now unions the `"*"` wildcard and per-file entries; previously a `"*"` entry silently disabled all per-file selectors.
- **outputSelection** — request the EVM legacy assembly for all files on the solc call, so a contract instantiating one from an unselected file compiles and resolves its dependency instead of aborting with `Contract path not found for hash`.
