### PR TITLE
perf(codegen): output-gating optimizations

### DIFF
--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -209,7 +209,9 @@ impl<'ctx> Context<'ctx> {
         })?;
         run_init_verify.borrow_mut().finish();
 
-        let module_size_fallback = self.module.clone();
+        let needs_size_fallback = self.optimizer.settings() == &OptimizerSettings::cycles()
+            && self.optimizer.settings().is_fallback_to_size_enabled();
+        let module_size_fallback = needs_size_fallback.then(|| self.module.clone());
         let run_optimize_verify = profiler.start_evm_translation_unit(
             contract_path,
             self.code_segment,
@@ -319,9 +321,7 @@ impl<'ctx> Context<'ctx> {
             let mut warnings = Vec::with_capacity(1);
             let bytecode_size = bytecode_buffer.as_slice().len();
             if bytecode_size > bytecode_size_limit {
-                if self.optimizer.settings() == &OptimizerSettings::cycles()
-                    && self.optimizer.settings().is_fallback_to_size_enabled()
-                {
+                if needs_size_fallback {
                     crate::codegen::IS_SIZE_FALLBACK
                         .compare_exchange(
                             false,
@@ -331,7 +331,8 @@ impl<'ctx> Context<'ctx> {
                         )
                         .expect("Failed to set the global size fallback flag");
                     self.optimizer = Optimizer::new(OptimizerSettings::size());
-                    self.module = module_size_fallback;
+                    self.module = module_size_fallback
+                        .expect("cloned when the settings enable the size fallback");
                     for function in self.module.get_functions() {
                         Function::set_size_attributes(self.llvm, function);
                     }

--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -832,8 +832,7 @@ impl<'ctx> IContext<'ctx> for Context<'ctx> {
             inkwell::values::ValueKind::Instruction(inner) => Some(inner),
         };
         if let Some(instruction_value) = instruction_value {
-            let debug_location = self.create_debug_info_location();
-            instruction_value.set_debug_location(debug_location);
+            self.set_instruction_debug_location(instruction_value);
         }
 
         self.modify_call_site_value(arguments, call_site_value, function);

--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -245,7 +245,12 @@ impl<'ctx> Context<'ctx> {
         })?;
         run_optimize_verify.borrow_mut().finish();
 
-        let assembly_buffer = if output_assembly || self.output_config.is_some() {
+        let assembly_buffer = if output_assembly
+            || self
+                .output_config
+                .as_ref()
+                .is_some_and(|output_config| output_config.output_assembly)
+        {
             let run_emit_llvm_assembly = profiler.start_evm_translation_unit(
                 contract_path,
                 self.code_segment,

--- a/solx-codegen-evm/src/context/mod.rs
+++ b/solx-codegen-evm/src/context/mod.rs
@@ -89,6 +89,15 @@ pub trait IContext<'ctx> {
     fn create_debug_info_location(&self) -> Option<inkwell::debug_info::DILocation<'ctx>>;
 
     ///
+    /// Sets the current debug info location on the instruction when debug info is enabled.
+    ///
+    fn set_instruction_debug_location(&self, instruction: inkwell::values::InstructionValue<'ctx>) {
+        if self.debug_info().is_some() {
+            instruction.set_debug_location(self.create_debug_info_location());
+        }
+    }
+
+    ///
     /// Returns the output config reference.
     ///
     fn output_config(&self) -> Option<&OutputConfig>;
@@ -199,7 +208,7 @@ pub trait IContext<'ctx> {
             instruction
                 .set_alignment(solx_utils::BYTE_LENGTH_FIELD as u32)
                 .map_err(|error| anyhow::anyhow!(error))?;
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
 
         Ok(Pointer::new(r#type, Self::AddressSpace::stack(), pointer))
@@ -229,7 +238,7 @@ pub trait IContext<'ctx> {
             instruction
                 .set_alignment(alignment as u32)
                 .map_err(|error| anyhow::anyhow!(error))?;
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
 
         Ok(value)
@@ -259,7 +268,7 @@ pub trait IContext<'ctx> {
         instruction
             .set_alignment(alignment as u32)
             .map_err(|error| anyhow::anyhow!(error))?;
-        instruction.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction);
 
         Ok(())
     }
@@ -283,7 +292,7 @@ pub trait IContext<'ctx> {
         };
 
         if let Some(instruction) = value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
 
         Ok(Pointer::new(element_type, pointer.address_space, value))
@@ -309,7 +318,7 @@ pub trait IContext<'ctx> {
     {
         let value = operator(self.builder(), left, right, name)?;
         if let Some(instruction) = value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(value)
     }
@@ -328,7 +337,7 @@ pub trait IContext<'ctx> {
             .builder()
             .build_right_shift(left, right, sign_extend, name)?;
         if let Some(instruction) = value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(value)
     }
@@ -353,7 +362,7 @@ pub trait IContext<'ctx> {
     {
         let truncated_value = operator(self.builder(), value, target_type, name)?;
         if let Some(instruction) = truncated_value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(truncated_value)
     }
@@ -369,7 +378,7 @@ pub trait IContext<'ctx> {
     ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
         let extracted_value = self.builder().build_extract_value(value, index, name)?;
         if let Some(instruction) = extracted_value.as_instruction_value() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(extracted_value)
     }
@@ -385,7 +394,7 @@ pub trait IContext<'ctx> {
     ) -> anyhow::Result<inkwell::values::PointerValue<'ctx>> {
         let pointer_value = self.builder().build_int_to_ptr(value, target_type, name)?;
         if let Some(instruction) = pointer_value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(pointer_value)
     }
@@ -404,7 +413,7 @@ pub trait IContext<'ctx> {
             .builder()
             .build_int_compare(predicate, left, right, name)?;
         if let Some(instruction) = value.as_instruction() {
-            instruction.set_debug_location(self.create_debug_info_location());
+            self.set_instruction_debug_location(instruction);
         }
         Ok(value)
     }
@@ -427,7 +436,7 @@ pub trait IContext<'ctx> {
         let instruction_value = self
             .builder()
             .build_conditional_branch(comparison, then_block, else_block)?;
-        instruction_value.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction_value);
 
         Ok(())
     }
@@ -448,7 +457,7 @@ pub trait IContext<'ctx> {
         let instruction_value = self
             .builder()
             .build_unconditional_branch(destination_block)?;
-        instruction_value.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction_value);
 
         Ok(())
     }
@@ -468,7 +477,7 @@ pub trait IContext<'ctx> {
         let instruction_value = self
             .builder()
             .build_switch(value, default_block, branches)?;
-        instruction_value.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction_value);
         Ok(())
     }
 
@@ -534,8 +543,7 @@ pub trait IContext<'ctx> {
             inkwell::values::ValueKind::Instruction(inner) => Some(inner),
         };
         if let Some(instruction_value) = instruction_value {
-            let debug_location = self.create_debug_info_location();
-            instruction_value.set_debug_location(debug_location);
+            self.set_instruction_debug_location(instruction_value);
         }
 
         call_site_value.set_alignment_attribute(inkwell::attributes::AttributeLoc::Param(0), 1);
@@ -554,7 +562,7 @@ pub trait IContext<'ctx> {
         }
 
         let instruction_value = self.builder().build_return(value)?;
-        instruction_value.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction_value);
         Ok(())
     }
 
@@ -569,7 +577,7 @@ pub trait IContext<'ctx> {
         }
 
         let instruction_value = self.builder().build_unreachable()?;
-        instruction_value.set_debug_location(self.create_debug_info_location());
+        self.set_instruction_debug_location(instruction_value);
         Ok(())
     }
 


### PR DESCRIPTION
- perf(codegen): clone the size-fallback module only when reachable
- perf(codegen): emit assembly text only when a consumer wants it
- perf(codegen): skip the debug-location FFI call when debug info is off

---
Removed from PR:
- perf(codegen): verify LLVM IR only in debug builds
