### PR TITLE
perf(debug-info): debug info build optimizations

### DIFF
--- a/solx-codegen-evm/src/codegen/context/solidity_data.rs
+++ b/solx-codegen-evm/src/codegen/context/solidity_data.rs
@@ -81,6 +81,7 @@ impl ISolidityData for SolidityData {
 
         debug_info
             .ast_nodes
+            .get(&solc_location.source_id)?
             .get(&start)
             .map(|ast_node| &ast_node.mapped_location)
     }

--- a/solx-core/src/compiler.rs
+++ b/solx-core/src/compiler.rs
@@ -350,7 +350,11 @@ impl<'arguments> Compiler<'arguments> {
 
         let linker_symbols = solc_input.settings.libraries.as_linker_symbols()?;
         solc_input.resolve_sources()?;
-        let debug_info = solc_output.get_debug_info(&solc_input.sources);
+        let debug_info = if output_selection.is_debug_info_set_for_any() {
+            Some(solc_output.get_debug_info(&solc_input.sources))
+        } else {
+            None
+        };
 
         let run_solx_project = profiler.start_pipeline_element("solx_Solidity_IR_Analysis");
         let project = Project::try_from_solidity_output(
@@ -358,7 +362,7 @@ impl<'arguments> Compiler<'arguments> {
             solc_input.settings.libraries.clone(),
             via_ir,
             &mut solc_output,
-            Some(debug_info),
+            debug_info,
             &solc_input.settings.output_selection,
             output_config.as_ref(),
         )?;
@@ -445,7 +449,15 @@ impl<'arguments> Compiler<'arguments> {
                 run_solc_standard_json.borrow_mut().finish();
 
                 solc_input.resolve_sources()?;
-                let function_definitions = solc_output.get_debug_info(&solc_input.sources);
+                let debug_info = if solc_input
+                    .settings
+                    .output_selection
+                    .is_debug_info_set_for_any()
+                {
+                    Some(solc_output.get_debug_info(&solc_input.sources))
+                } else {
+                    None
+                };
 
                 if solc_output.has_errors() {
                     solc_output.write_and_exit(&solc_input.settings.output_selection);
@@ -461,7 +473,7 @@ impl<'arguments> Compiler<'arguments> {
                     solc_input.settings.libraries.clone(),
                     via_ir,
                     &mut solc_output,
-                    Some(function_definitions),
+                    debug_info,
                     &solc_input.settings.output_selection,
                     output_config.as_ref(),
                 )?;

--- a/solx-core/src/compiler.rs
+++ b/solx-core/src/compiler.rs
@@ -350,7 +350,7 @@ impl<'arguments> Compiler<'arguments> {
 
         let linker_symbols = solc_input.settings.libraries.as_linker_symbols()?;
         solc_input.resolve_sources()?;
-        let debug_info = if output_selection.is_debug_info_set_for_any() {
+        let debug_info = if output_selection.is_debug_info_emitted_for_any() {
             Some(solc_output.get_debug_info(&solc_input.sources))
         } else {
             None
@@ -452,7 +452,7 @@ impl<'arguments> Compiler<'arguments> {
                 let debug_info = if solc_input
                     .settings
                     .output_selection
-                    .is_debug_info_set_for_any()
+                    .is_debug_info_emitted_for_any()
                 {
                     Some(solc_output.get_debug_info(&solc_input.sources))
                 } else {

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -539,8 +539,22 @@ impl Project {
                 #[cfg(feature = "mlir")]
                 let mlir = contract.mlir.take();
 
-                let mut deploy_debug_info = self.debug_info.clone();
-                let mut runtime_debug_info = self.debug_info.clone();
+                let mut deploy_debug_info = output_selection
+                    .check_selection(
+                        path.as_str(),
+                        contract_name.name.as_deref(),
+                        solx_standard_json::InputSelector::BytecodeDebugInfo,
+                    )
+                    .then(|| self.debug_info.clone())
+                    .flatten();
+                let mut runtime_debug_info = output_selection
+                    .check_selection(
+                        path.as_str(),
+                        contract_name.name.as_deref(),
+                        solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
+                    )
+                    .then(|| self.debug_info.clone())
+                    .flatten();
 
                 let (deploy_code_ir, runtime_code_ir): (ContractIR, ContractIR) = match contract.ir
                 {

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -539,22 +539,8 @@ impl Project {
                 #[cfg(feature = "mlir")]
                 let mlir = contract.mlir.take();
 
-                let mut deploy_debug_info = output_selection
-                    .check_selection(
-                        path.as_str(),
-                        contract_name.name.as_deref(),
-                        solx_standard_json::InputSelector::BytecodeDebugInfo,
-                    )
-                    .then(|| self.debug_info.clone())
-                    .flatten();
-                let mut runtime_debug_info = output_selection
-                    .check_selection(
-                        path.as_str(),
-                        contract_name.name.as_deref(),
-                        solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
-                    )
-                    .then(|| self.debug_info.clone())
-                    .flatten();
+                let mut deploy_debug_info: Option<solx_utils::DebugInfo> = None;
+                let mut runtime_debug_info: Option<solx_utils::DebugInfo> = None;
 
                 let (deploy_code_ir, runtime_code_ir): (ContractIR, ContractIR) = match contract.ir
                 {
@@ -562,22 +548,34 @@ impl Project {
                         let runtime_code: ContractYul =
                             *deploy_code.runtime_code.take().expect("Always exists");
 
-                        if let Some(ref mut debug_info) = deploy_debug_info {
-                            debug_info.retain_source_ids(
-                                &deploy_code.object.sources.keys().copied().collect(),
-                            );
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
-                        if let Some(ref mut debug_info) = runtime_debug_info {
-                            debug_info.retain_source_ids(
-                                &runtime_code.object.sources.keys().copied().collect(),
-                            );
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
+                        deploy_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::BytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &deploy_code.object.sources.keys().copied().collect(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
+                        runtime_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &runtime_code.object.sources.keys().copied().collect(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
 
                         (deploy_code.into(), runtime_code.into())
                     }
@@ -585,18 +583,34 @@ impl Project {
                         let runtime_code: ContractEVMLegacyAssembly =
                             *deploy_code.runtime_code.take().expect("Always exists");
 
-                        if let Some(ref mut debug_info) = deploy_debug_info {
-                            debug_info.retain_source_ids(&deploy_code.assembly.source_ids());
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
-                        if let Some(ref mut debug_info) = runtime_debug_info {
-                            debug_info.retain_source_ids(&runtime_code.assembly.source_ids());
-                            if let Some(contract_name) = contract_name.name.as_deref() {
-                                debug_info.retain_current_contract(contract_name);
-                            }
-                        }
+                        deploy_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::BytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &deploy_code.assembly.source_ids(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
+                        runtime_debug_info = self.debug_info.as_ref().and_then(|debug_info| {
+                            output_selection
+                                .check_selection(
+                                    path.as_str(),
+                                    contract_name.name.as_deref(),
+                                    solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo,
+                                )
+                                .then(|| {
+                                    debug_info.filter_to(
+                                        &runtime_code.assembly.source_ids(),
+                                        contract_name.name.as_deref(),
+                                    )
+                                })
+                        });
 
                         (deploy_code.into(), runtime_code.into())
                     }

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -563,13 +563,17 @@ impl Project {
                             *deploy_code.runtime_code.take().expect("Always exists");
 
                         if let Some(ref mut debug_info) = deploy_debug_info {
-                            debug_info.retain_source_ids(&deploy_code.object.sources);
+                            debug_info.retain_source_ids(
+                                &deploy_code.object.sources.keys().copied().collect(),
+                            );
                             if let Some(contract_name) = contract_name.name.as_deref() {
                                 debug_info.retain_current_contract(contract_name);
                             }
                         }
                         if let Some(ref mut debug_info) = runtime_debug_info {
-                            debug_info.retain_source_ids(&runtime_code.object.sources);
+                            debug_info.retain_source_ids(
+                                &runtime_code.object.sources.keys().copied().collect(),
+                            );
                             if let Some(contract_name) = contract_name.name.as_deref() {
                                 debug_info.retain_current_contract(contract_name);
                             }
@@ -581,16 +585,17 @@ impl Project {
                         let runtime_code: ContractEVMLegacyAssembly =
                             *deploy_code.runtime_code.take().expect("Always exists");
 
-                        // Filter debug info to current contract
-                        if let Some(ref mut debug_info) = deploy_debug_info
-                            && let Some(contract_name) = contract_name.name.as_deref()
-                        {
-                            debug_info.retain_current_contract(contract_name);
+                        if let Some(ref mut debug_info) = deploy_debug_info {
+                            debug_info.retain_source_ids(&deploy_code.assembly.source_ids());
+                            if let Some(contract_name) = contract_name.name.as_deref() {
+                                debug_info.retain_current_contract(contract_name);
+                            }
                         }
-                        if let Some(ref mut debug_info) = runtime_debug_info
-                            && let Some(contract_name) = contract_name.name.as_deref()
-                        {
-                            debug_info.retain_current_contract(contract_name);
+                        if let Some(ref mut debug_info) = runtime_debug_info {
+                            debug_info.retain_source_ids(&runtime_code.assembly.source_ids());
+                            if let Some(contract_name) = contract_name.name.as_deref() {
+                                debug_info.retain_current_contract(contract_name);
+                            }
                         }
 
                         (deploy_code.into(), runtime_code.into())

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -6,6 +6,7 @@ pub mod data;
 pub mod instruction;
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use std::sync::OnceLock;
 
@@ -126,6 +127,21 @@ impl Assembly {
                 }
             }
         }
+    }
+
+    ///
+    /// Returns the source IDs referenced by the assembly instructions.
+    ///
+    pub fn source_ids(&self) -> BTreeSet<usize> {
+        let mut source_ids = BTreeSet::new();
+        if let Some(code) = self.code.as_ref() {
+            for instruction in code.iter() {
+                if let Some(source) = instruction.source.filter(|&source| source >= 0) {
+                    source_ids.insert(source as usize);
+                }
+            }
+        }
+        source_ids
     }
 
     ///

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -170,12 +170,12 @@ impl Selection {
     pub fn is_bytecode_set_for_any(&self) -> bool {
         for file in self.inner.values() {
             for contract in file.values() {
-                if contract.contains(&Selector::EVM)
+                if contract.contains(&Selector::Any)
+                    || contract.contains(&Selector::EVM)
                     || contract.contains(&Selector::Bytecode)
                     || contract.contains(&Selector::BytecodeObject)
                     || contract.contains(&Selector::RuntimeBytecode)
                     || contract.contains(&Selector::RuntimeBytecodeObject)
-                    || contract.contains(&Selector::Any)
                 {
                     return true;
                 }
@@ -190,8 +190,11 @@ impl Selection {
     pub fn is_debug_info_set_for_any(&self) -> bool {
         for file in self.inner.values() {
             for contract in file.values() {
-                if contract.contains(&Selector::EVM)
+                if contract.contains(&Selector::Any)
+                    || contract.contains(&Selector::EVM)
+                    || contract.contains(&Selector::Bytecode)
                     || contract.contains(&Selector::BytecodeDebugInfo)
+                    || contract.contains(&Selector::RuntimeBytecode)
                     || contract.contains(&Selector::RuntimeBytecodeDebugInfo)
                 {
                     return true;

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -59,61 +59,68 @@ impl Selection {
     /// Checks if the output element of the specified contract is selected.
     ///
     pub fn check_selection(&self, path: &str, name: Option<&str>, selector: Selector) -> bool {
-        if let Some(file) = self.inner.get(Self::WILDCARD).or(self.inner.get(path)) {
-            if let (Some(any), selector @ Selector::AST | selector @ Selector::Benchmarks) =
-                (file.get(Self::ANY_CONTRACT).or(file.get(path)), selector)
-            {
-                return any.contains(&Selector::Any) || any.contains(&selector);
+        [Self::WILDCARD, path].into_iter().any(|file_key| {
+            let Some(file) = self.inner.get(file_key) else {
+                return false;
+            };
+            if matches!(selector, Selector::AST | Selector::Benchmarks) {
+                return [Self::ANY_CONTRACT, path].into_iter().any(|contract_key| {
+                    file.get(contract_key)
+                        .is_some_and(|any| any.contains(&Selector::Any) || any.contains(&selector))
+                });
             }
-            if let Some(contract) = file
-                .get(Self::WILDCARD)
-                .or(name.and_then(|name| file.get(name)))
-            {
-                match selector {
-                    Selector::MethodIdentifiers
-                    | Selector::EVMLegacyAssembly
-                    | Selector::GasEstimates
-                        if contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
+            [Some(Self::WILDCARD), name]
+                .into_iter()
+                .flatten()
+                .any(|contract_key| {
+                    let Some(contract) = file.get(contract_key) else {
+                        return false;
+                    };
+                    match selector {
+                        Selector::MethodIdentifiers
+                        | Selector::EVMLegacyAssembly
+                        | Selector::GasEstimates
+                            if contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        Selector::BytecodeObject
+                        | Selector::BytecodeLLVMAssembly
+                        | Selector::BytecodeOpcodes
+                        | Selector::BytecodeLinkReferences
+                        | Selector::BytecodeSourceMap
+                        | Selector::BytecodeDebugInfo
+                        | Selector::BytecodeFunctionDebugData
+                        | Selector::BytecodeGeneratedSources
+                            if contract.contains(&Selector::Bytecode)
+                                || contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        Selector::RuntimeBytecodeObject
+                        | Selector::RuntimeBytecodeLLVMAssembly
+                        | Selector::RuntimeBytecodeOpcodes
+                        | Selector::RuntimeBytecodeLinkReferences
+                        | Selector::RuntimeBytecodeImmutableReferences
+                        | Selector::RuntimeBytecodeSourceMap
+                        | Selector::RuntimeBytecodeDebugInfo
+                        | Selector::RuntimeBytecodeFunctionDebugData
+                        | Selector::RuntimeBytecodeGeneratedSources
+                            if contract.contains(&Selector::RuntimeBytecode)
+                                || contract.contains(&Selector::EVM) =>
+                        {
+                            true
+                        }
+                        selector
+                            if contract.contains(&Selector::Any)
+                                || contract.contains(&selector) =>
+                        {
+                            true
+                        }
+                        _ => false,
                     }
-                    Selector::BytecodeObject
-                    | Selector::BytecodeLLVMAssembly
-                    | Selector::BytecodeOpcodes
-                    | Selector::BytecodeLinkReferences
-                    | Selector::BytecodeSourceMap
-                    | Selector::BytecodeDebugInfo
-                    | Selector::BytecodeFunctionDebugData
-                    | Selector::BytecodeGeneratedSources
-                        if contract.contains(&Selector::Bytecode)
-                            || contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
-                    }
-                    Selector::RuntimeBytecodeObject
-                    | Selector::RuntimeBytecodeLLVMAssembly
-                    | Selector::RuntimeBytecodeOpcodes
-                    | Selector::RuntimeBytecodeLinkReferences
-                    | Selector::RuntimeBytecodeImmutableReferences
-                    | Selector::RuntimeBytecodeSourceMap
-                    | Selector::RuntimeBytecodeDebugInfo
-                    | Selector::RuntimeBytecodeFunctionDebugData
-                    | Selector::RuntimeBytecodeGeneratedSources
-                        if contract.contains(&Selector::RuntimeBytecode)
-                            || contract.contains(&Selector::EVM) =>
-                    {
-                        return true;
-                    }
-                    selector
-                        if contract.contains(&Selector::Any) || contract.contains(&selector) =>
-                    {
-                        return true;
-                    }
-                    _ => {}
-                }
-            }
-        }
-        false
+                })
+        })
     }
 
     ///
@@ -137,6 +144,21 @@ impl Selection {
                 }
             }
         }
+    }
+
+    ///
+    /// Requests the specified contract selector for every file via the `*` wildcard, so that `solc`
+    /// also emits it for dependencies located in files absent from the output selection. Needed
+    /// because dependency resolution hashes the assembly of every referenced contract, including
+    /// contracts instantiated from files a per-file selection does not list.
+    ///
+    pub fn set_selector_for_all_files(&mut self, selector: Selector) {
+        self.inner
+            .entry(Self::WILDCARD.to_owned())
+            .or_default()
+            .entry(Self::WILDCARD.to_owned())
+            .or_default()
+            .insert(selector);
     }
 
     ///

--- a/solx-standard-json/src/input/settings/selection/mod.rs
+++ b/solx-standard-json/src/input/settings/selection/mod.rs
@@ -187,7 +187,31 @@ impl Selection {
     ///
     /// Checks if the debug info is requested for at least one contract.
     ///
+    /// Used to reject debug info requests for non-Solidity input, so umbrella selectors
+    /// such as `evm.bytecode` do not count: they must remain valid for all languages.
+    ///
     pub fn is_debug_info_set_for_any(&self) -> bool {
+        for file in self.inner.values() {
+            for contract in file.values() {
+                if contract.contains(&Selector::EVM)
+                    || contract.contains(&Selector::BytecodeDebugInfo)
+                    || contract.contains(&Selector::RuntimeBytecodeDebugInfo)
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    ///
+    /// Checks if the debug info will be emitted for at least one contract.
+    ///
+    /// Unlike [`Self::is_debug_info_set_for_any`], this also counts every umbrella selector
+    /// under which `check_selection` emits debug info: the `*` wildcard and the `evm` /
+    /// `evm.bytecode` / `evm.deployedBytecode` groups.
+    ///
+    pub fn is_debug_info_emitted_for_any(&self) -> bool {
         for file in self.inner.values() {
             for contract in file.values() {
                 if contract.contains(&Selector::Any)

--- a/solx-standard-json/src/output/mod.rs
+++ b/solx-standard-json/src/output/mod.rs
@@ -170,25 +170,32 @@ impl Output {
 
         for (path, source) in self.sources.iter() {
             if let Some(ref ast_json) = source.ast {
+                let content = sources
+                    .get(path)
+                    .and_then(|source| source.content())
+                    .unwrap_or_default();
+                let line_index = solx_utils::DebugInfoLineIndex::new(content);
+
                 contract_definitions.extend(Source::get_ast_nodes(
-                    &Source::contract_definition,
+                    &|path: &str, ast: &serde_json::Value| {
+                        Source::contract_definition(path, ast, &line_index)
+                    },
                     path.as_str(),
                     ast_json,
-                    sources,
                 ));
 
                 function_definitions.extend(Source::get_ast_nodes(
-                    &Source::function_definition,
+                    &|path: &str, ast: &serde_json::Value| {
+                        Source::function_definition(path, ast, &line_index)
+                    },
                     path.as_str(),
                     ast_json,
-                    sources,
                 ));
 
                 ast_nodes.extend(Source::get_ast_nodes(
-                    &Source::ast_node,
+                    &|path: &str, ast: &serde_json::Value| Source::ast_node(path, ast, &line_index),
                     path.as_str(),
                     ast_json,
-                    sources,
                 ));
             }
         }

--- a/solx-standard-json/src/output/mod.rs
+++ b/solx-standard-json/src/output/mod.rs
@@ -159,7 +159,8 @@ impl Output {
             HashMap::new();
         let mut function_definitions: HashMap<usize, solx_utils::DebugInfoFunctionDefinition> =
             HashMap::new();
-        let mut ast_nodes: HashMap<usize, solx_utils::DebugInfoAstNode> = HashMap::new();
+        let mut ast_nodes: HashMap<usize, HashMap<usize, solx_utils::DebugInfoAstNode>> =
+            HashMap::new();
 
         // Build source_id -> path mapping
         let source_ids: BTreeMap<usize, String> = self
@@ -192,11 +193,18 @@ impl Output {
                     ast_json,
                 ));
 
-                ast_nodes.extend(Source::get_ast_nodes(
-                    &|path: &str, ast: &serde_json::Value| Source::ast_node(path, ast, &line_index),
-                    path.as_str(),
-                    ast_json,
-                ));
+                ast_nodes.insert(
+                    source.id,
+                    Source::get_ast_nodes(
+                        &|path: &str, ast: &serde_json::Value| {
+                            Source::ast_node(path, ast, &line_index)
+                        },
+                        path.as_str(),
+                        ast_json,
+                    )
+                    .into_iter()
+                    .collect(),
+                );
             }
         }
 

--- a/solx-standard-json/src/output/source.rs
+++ b/solx-standard-json/src/output/source.rs
@@ -6,8 +6,6 @@ use std::collections::BTreeMap;
 
 use boolinator::Boolinator;
 
-use crate::input::source::Source as StandardJsonInputSource;
-
 ///
 /// The `solc --standard-json` output source.
 ///
@@ -34,31 +32,26 @@ impl Source {
     ///
     /// Returns the list of messages for some specific parts of the AST.
     ///
-    pub fn get_ast_nodes<K, V, F>(
-        getter: &F,
-        path: &str,
-        ast: &serde_json::Value,
-        sources: &BTreeMap<String, StandardJsonInputSource>,
-    ) -> BTreeMap<K, V>
+    pub fn get_ast_nodes<K, V, F>(getter: &F, path: &str, ast: &serde_json::Value) -> BTreeMap<K, V>
     where
         K: std::cmp::Ord,
         V: solx_utils::IDebugInfoAstNode<Key = K>,
-        F: Fn(&str, &serde_json::Value, &BTreeMap<String, StandardJsonInputSource>) -> Option<V>,
+        F: Fn(&str, &serde_json::Value) -> Option<V>,
     {
         let mut ast_nodes = BTreeMap::new();
-        if let Some(ast_node) = getter(path, ast, sources) {
+        if let Some(ast_node) = getter(path, ast) {
             ast_nodes.insert(ast_node.index_id(), ast_node);
         }
 
         match ast {
             serde_json::Value::Array(array) => {
                 for element in array.iter() {
-                    ast_nodes.extend(Self::get_ast_nodes(getter, path, element, sources));
+                    ast_nodes.extend(Self::get_ast_nodes(getter, path, element));
                 }
             }
             serde_json::Value::Object(object) => {
                 for (_key, value) in object.iter() {
-                    ast_nodes.extend(Self::get_ast_nodes(getter, path, value, sources));
+                    ast_nodes.extend(Self::get_ast_nodes(getter, path, value));
                 }
             }
             _ => {}
@@ -73,7 +66,7 @@ impl Source {
     pub fn contract_definition(
         path: &str,
         ast: &serde_json::Value,
-        sources: &BTreeMap<String, StandardJsonInputSource>,
+        line_index: &solx_utils::DebugInfoLineIndex<'_>,
     ) -> Option<solx_utils::DebugInfoContractDefinition> {
         let ast = ast.as_object()?;
 
@@ -86,15 +79,8 @@ impl Source {
             solx_utils::DebugInfoSolcLocationOrdering::Ast,
         )
         .ok()?;
-        let source_code = sources
-            .get(path)
-            .and_then(|source| source.content.as_deref());
-        let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
-            path.to_owned(),
-            solc_location.start,
-            solc_location.end,
-            source_code,
-        );
+        let mapped_location =
+            line_index.mapped_location(path.to_owned(), solc_location.start, solc_location.end);
 
         Some(solx_utils::DebugInfoContractDefinition::new(
             ast_id,
@@ -110,7 +96,7 @@ impl Source {
     pub fn function_definition(
         path: &str,
         ast: &serde_json::Value,
-        sources: &BTreeMap<String, StandardJsonInputSource>,
+        line_index: &solx_utils::DebugInfoLineIndex<'_>,
     ) -> Option<solx_utils::DebugInfoFunctionDefinition> {
         let ast = ast.as_object()?;
 
@@ -127,15 +113,8 @@ impl Source {
             solx_utils::DebugInfoSolcLocationOrdering::Ast,
         )
         .ok()?;
-        let source_code = sources
-            .get(path)
-            .and_then(|source| source.content.as_deref());
-        let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
-            path.to_owned(),
-            solc_location.start,
-            solc_location.end,
-            source_code,
-        );
+        let mapped_location =
+            line_index.mapped_location(path.to_owned(), solc_location.start, solc_location.end);
 
         Some(solx_utils::DebugInfoFunctionDefinition::new(
             ast_id,
@@ -151,7 +130,7 @@ impl Source {
     pub fn ast_node(
         path: &str,
         ast: &serde_json::Value,
-        sources: &BTreeMap<String, StandardJsonInputSource>,
+        line_index: &solx_utils::DebugInfoLineIndex<'_>,
     ) -> Option<solx_utils::DebugInfoAstNode> {
         let ast = ast.as_object()?;
 
@@ -161,15 +140,8 @@ impl Source {
             solx_utils::DebugInfoSolcLocationOrdering::Ast,
         )
         .ok()?;
-        let source_code = sources
-            .get(path)
-            .and_then(|source| source.content.as_deref());
-        let mapped_location = solx_utils::DebugInfoMappedLocation::from_solc_location(
-            path.to_owned(),
-            solc_location.start,
-            solc_location.end,
-            source_code,
-        );
+        let mapped_location =
+            line_index.mapped_location(path.to_owned(), solc_location.start, solc_location.end);
 
         Some(solx_utils::DebugInfoAstNode::new(
             ast_id,

--- a/solx-utils/src/debug_info/line_index.rs
+++ b/solx-utils/src/debug_info/line_index.rs
@@ -1,0 +1,65 @@
+//!
+//! Source code line index.
+//!
+
+use crate::debug_info::mapped_location::MappedLocation;
+
+///
+/// Source code line index.
+///
+/// Maps each source line to its starting byte offset, so that a `solc` byte offset can be resolved
+/// to a line and column with a binary search instead of a scan from the beginning of the file.
+///
+pub struct LineIndex<'a> {
+    /// Byte offset and text of each source line.
+    lines: Vec<(usize, &'a str)>,
+}
+
+impl<'a> LineIndex<'a> {
+    ///
+    /// Builds the line index for the source code.
+    ///
+    pub fn new(source_code: &'a str) -> Self {
+        let lines = source_code
+            .lines()
+            .scan(0usize, |cursor, line| {
+                let start = *cursor;
+                *cursor += line.len() + 1;
+                Some((start, line))
+            })
+            .collect();
+        Self { lines }
+    }
+
+    ///
+    /// Resolves a `solc` byte offset range to a line-column location.
+    ///
+    pub fn mapped_location(&self, path: String, start: isize, end: isize) -> MappedLocation {
+        if start < 0 || end < 0 || end < start {
+            return MappedLocation::new(path);
+        }
+        let start = start as usize;
+        let end = end as usize;
+
+        let line = self
+            .lines
+            .partition_point(|&(offset, _)| offset < start)
+            .saturating_sub(1);
+        let &(cursor, source_line) = match self.lines.get(line) {
+            Some(entry) => entry,
+            None => return MappedLocation::new(path),
+        };
+        if start > cursor + source_line.len() + 1 {
+            return MappedLocation::new(path);
+        }
+
+        let column = start - cursor;
+        let (line, column) = if column == source_line.len() + 1 {
+            (line + 2, 1)
+        } else {
+            (line + 1, column + 1)
+        };
+        let length = end - start;
+        MappedLocation::new_with_location(path, line, column, length, Some(source_line.to_owned()))
+    }
+}

--- a/solx-utils/src/debug_info/mapped_location.rs
+++ b/solx-utils/src/debug_info/mapped_location.rs
@@ -2,6 +2,8 @@
 //! Line-column source code location.
 //!
 
+use crate::debug_info::line_index::LineIndex;
+
 ///
 /// Line-column source code location.
 ///
@@ -63,41 +65,12 @@ impl MappedLocation {
         end: isize,
         source_code: Option<&str>,
     ) -> Self {
-        let source_code = match source_code {
-            Some(source_code) => source_code,
-            None => return Self::new(path),
-        };
-        if start < 0 || end < 0 || end < start {
-            return Self::new(path);
-        }
-        let start = start as usize;
-        let end = end as usize;
-
-        let mut cursor = 0;
-        for (line, source_line) in source_code.lines().enumerate() {
-            let cursor_next = cursor + source_line.len() + 1;
-
-            if cursor <= start && start <= cursor_next {
-                let column = start - cursor;
-                let (line, column) = if column == source_line.len() + 1 {
-                    (line + 2, 1)
-                } else {
-                    (line + 1, start - cursor + 1)
-                };
-                let length = end - start;
-                return Self::new_with_location(
-                    path,
-                    line,
-                    column,
-                    length,
-                    Some(source_line.to_owned()),
-                );
+        match source_code {
+            Some(source_code) if start >= 0 && end >= start => {
+                LineIndex::new(source_code).mapped_location(path, start, end)
             }
-
-            cursor = cursor_next;
+            _ => Self::new(path),
         }
-
-        Self::new(path)
     }
 }
 

--- a/solx-utils/src/debug_info/mod.rs
+++ b/solx-utils/src/debug_info/mod.rs
@@ -30,9 +30,9 @@ pub struct DebugInfo {
     /// Solidity AST function definitions.
     /// The key is the AST node ID.
     pub function_definitions: HashMap<usize, FunctionDefinition>,
-    /// Generic Solidity AST nodes.
-    /// The key is the start byte offset.
-    pub ast_nodes: HashMap<usize, AstNode>,
+    /// Generic Solidity AST nodes, grouped by source ID.
+    /// The outer key is the source ID; the inner key is the start byte offset.
+    pub ast_nodes: HashMap<usize, HashMap<usize, AstNode>>,
     /// Source ID to source file path mapping.
     #[serde(default)]
     pub source_ids: BTreeMap<usize, String>,
@@ -45,7 +45,7 @@ impl DebugInfo {
     pub fn new(
         contract_definitions: HashMap<String, ContractDefinition>,
         function_definitions: HashMap<usize, FunctionDefinition>,
-        ast_nodes: HashMap<usize, AstNode>,
+        ast_nodes: HashMap<usize, HashMap<usize, AstNode>>,
         source_ids: BTreeMap<usize, String>,
     ) -> Self {
         Self {
@@ -57,25 +57,38 @@ impl DebugInfo {
     }
 
     ///
-    /// Retains only the debug info for the specified source IDs.
+    /// Builds the debug info restricted to the given source IDs and, when set, the current contract.
+    /// Only the retained sources' AST nodes are cloned.
     ///
-    pub fn retain_source_ids(&mut self, source_ids: &BTreeSet<usize>) {
-        self.contract_definitions.retain(|_, contract_definition| {
-            source_ids.contains(&contract_definition.solc_location.source_id)
-        });
-        self.function_definitions.retain(|_, function_definition| {
-            source_ids.contains(&function_definition.solc_location.source_id)
-        });
-        self.ast_nodes
-            .retain(|_, ast_node| source_ids.contains(&ast_node.solc_location.source_id));
-    }
-
-    ///
-    /// Retains only the contract definition of the current contract.
-    ///
-    pub fn retain_current_contract(&mut self, contract_name: &str) {
-        self.contract_definitions
-            .retain(|name, _| name == contract_name);
+    pub fn filter_to(&self, source_ids: &BTreeSet<usize>, contract_name: Option<&str>) -> Self {
+        Self {
+            contract_definitions: self
+                .contract_definitions
+                .iter()
+                .filter(|(name, contract_definition)| {
+                    source_ids.contains(&contract_definition.solc_location.source_id)
+                        && contract_name.is_none_or(|current| current == name.as_str())
+                })
+                .map(|(name, contract_definition)| (name.clone(), contract_definition.clone()))
+                .collect(),
+            function_definitions: self
+                .function_definitions
+                .iter()
+                .filter(|(_, function_definition)| {
+                    source_ids.contains(&function_definition.solc_location.source_id)
+                })
+                .map(|(id, function_definition)| (*id, function_definition.clone()))
+                .collect(),
+            ast_nodes: source_ids
+                .iter()
+                .filter_map(|source_id| {
+                    self.ast_nodes
+                        .get(source_id)
+                        .map(|nodes| (*source_id, nodes.clone()))
+                })
+                .collect(),
+            source_ids: self.source_ids.clone(),
+        }
     }
 }
 

--- a/solx-utils/src/debug_info/mod.rs
+++ b/solx-utils/src/debug_info/mod.rs
@@ -12,6 +12,7 @@ pub mod mapped_location;
 pub mod solc_location;
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 
 use self::ast_node::AstNode;
@@ -58,15 +59,15 @@ impl DebugInfo {
     ///
     /// Retains only the debug info for the specified source IDs.
     ///
-    pub fn retain_source_ids(&mut self, source_ids: &BTreeMap<usize, String>) {
+    pub fn retain_source_ids(&mut self, source_ids: &BTreeSet<usize>) {
         self.contract_definitions.retain(|_, contract_definition| {
-            source_ids.contains_key(&contract_definition.solc_location.source_id)
+            source_ids.contains(&contract_definition.solc_location.source_id)
         });
         self.function_definitions.retain(|_, function_definition| {
-            source_ids.contains_key(&function_definition.solc_location.source_id)
+            source_ids.contains(&function_definition.solc_location.source_id)
         });
         self.ast_nodes
-            .retain(|_, ast_node| source_ids.contains_key(&ast_node.solc_location.source_id));
+            .retain(|_, ast_node| source_ids.contains(&ast_node.solc_location.source_id));
     }
 
     ///

--- a/solx-utils/src/debug_info/mod.rs
+++ b/solx-utils/src/debug_info/mod.rs
@@ -7,6 +7,7 @@
 pub mod ast_node;
 pub mod contract_definition;
 pub mod function_definition;
+pub mod line_index;
 pub mod mapped_location;
 pub mod solc_location;
 

--- a/solx-utils/src/lib.rs
+++ b/solx-utils/src/lib.rs
@@ -37,6 +37,7 @@ pub use self::debug_info::IDebugInfoAstNode;
 pub use self::debug_info::ast_node::AstNode as DebugInfoAstNode;
 pub use self::debug_info::contract_definition::ContractDefinition as DebugInfoContractDefinition;
 pub use self::debug_info::function_definition::FunctionDefinition as DebugInfoFunctionDefinition;
+pub use self::debug_info::line_index::LineIndex as DebugInfoLineIndex;
 pub use self::debug_info::mapped_location::MappedLocation as DebugInfoMappedLocation;
 pub use self::debug_info::solc_location::SolcLocation as DebugInfoSolcLocation;
 pub use self::debug_info::solc_location::ordering::Ordering as DebugInfoSolcLocationOrdering;

--- a/solx/src/solc.rs
+++ b/solx/src/solc.rs
@@ -95,7 +95,7 @@ impl solx_core::Frontend for Solc {
         input_json
             .settings
             .output_selection
-            .set_selector(input_json.settings.via_ir.into());
+            .set_selector_for_all_files(input_json.settings.via_ir.into());
 
         let original_optimizer = input_json.settings.optimizer.to_owned();
         input_json.settings.optimizer.mode = None;

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -121,6 +121,28 @@ fn yul_standard_json_output_has_contracts() -> anyhow::Result<()> {
 }
 
 #[cfg(feature = "solc")]
+#[test]
+fn yul_bytecode_umbrella_selection_is_not_rejected() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("yul_bytecode_umbrella.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("\"object\""))
+        .stdout(
+            predicate::str::contains("Debug info is only supported for Solidity source code input")
+                .not(),
+        );
+
+    Ok(())
+}
+
+#[cfg(feature = "solc")]
 #[test_case(crate::common::standard_json!("metadata_hash_ipfs_and_metadata.json"), true, true)]
 #[test_case(crate::common::standard_json!("metadata_hash_ipfs_no_metadata.json"), true, false)]
 #[test_case(crate::common::standard_json!("metadata_hash_none_and_metadata.json"), false, true)]

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -285,6 +285,22 @@ fn select_specific_bytecode(path: &str, expected_key: &str) -> anyhow::Result<()
     Ok(())
 }
 
+#[test_case(crate::common::standard_json!("select_evm_bytecode_debug_info.json"), "bytecode")]
+#[test_case(crate::common::standard_json!("select_evm_deployed_bytecode_debug_info.json"), "deployedBytecode")]
+fn select_specific_debug_info(path: &str, expected_key: &str) -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &["--standard-json", path];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains(expected_key))
+        .stdout(predicate::str::contains("\"debugInfo\"").count(1));
+
+    Ok(())
+}
+
 #[cfg(feature = "solc")]
 #[test]
 fn via_ir_output_structure() -> anyhow::Result<()> {

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -510,3 +510,39 @@ fn select_ast_only() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn select_wildcard_and_per_file_are_unioned() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("select_wildcard_and_per_file.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("\"abi\""))
+        .stdout(predicate::str::contains("\"bytecode\""));
+
+    Ok(())
+}
+
+#[test]
+fn select_per_file_cross_file_dependency() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("select_cross_file_dependency.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("Contract path not found for hash").not())
+        .stdout(predicate::str::contains("\"bytecode\""));
+
+    Ok(())
+}

--- a/solx/tests/data/standard_json_input/select_cross_file_dependency.json
+++ b/solx/tests/data/standard_json_input/select_cross_file_dependency.json
@@ -1,0 +1,23 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\nimport \"./B.sol\";\ncontract A {\n    function deploy() public returns (address) {\n        return address(new B());\n    }\n}"
+    },
+    "B.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\ncontract B {\n    uint256 public x;\n}"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "A.sol": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}

--- a/solx/tests/data/standard_json_input/select_evm_bytecode_debug_info.json
+++ b/solx/tests/data/standard_json_input/select_evm_bytecode_debug_info.json
@@ -1,0 +1,22 @@
+{
+  "language": "Solidity",
+  "sources":
+  {
+    "A":
+    {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C {}"
+    }
+  },
+  "settings": {
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode.debugInfo"
+        ]
+      }
+    },
+    "metadata": {
+      "useLiteralContent": true
+    }
+  }
+}

--- a/solx/tests/data/standard_json_input/select_evm_deployed_bytecode_debug_info.json
+++ b/solx/tests/data/standard_json_input/select_evm_deployed_bytecode_debug_info.json
@@ -1,0 +1,22 @@
+{
+  "language": "Solidity",
+  "sources":
+  {
+    "A":
+    {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.0; contract C {}"
+    }
+  },
+  "settings": {
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.deployedBytecode.debugInfo"
+        ]
+      }
+    },
+    "metadata": {
+      "useLiteralContent": true
+    }
+  }
+}

--- a/solx/tests/data/standard_json_input/select_wildcard_and_per_file.json
+++ b/solx/tests/data/standard_json_input/select_wildcard_and_per_file.json
@@ -1,0 +1,25 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity >=0.0;\ncontract C {}"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi"
+        ]
+      },
+      "A": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}

--- a/solx/tests/data/standard_json_input/yul_bytecode_umbrella.json
+++ b/solx/tests/data/standard_json_input/yul_bytecode_umbrella.json
@@ -1,0 +1,22 @@
+{
+  "language": "Yul",
+  "sources": {
+    "Test": {
+      "content": "object \"Return\" { code { { return(0, 0) } } object \"Return_deployed\" { code { { return(0, 0) } } } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode",
+          "evm.deployedBytecode"
+        ]
+      }
+    },
+    "libraries": {}
+  }
+}


### PR DESCRIPTION
- perf(core): build debug info only when it is requested
- perf(debug-info): resolve AST locations via a per-source line index
- perf(debug-info): prune per-unit debug info to referenced sources on the EVMLA path
