### PR TITLE
chore: point solx-llvm submodule at NomicFoundation org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = 0.8.34
 [submodule "solx-llvm"]
 	path = solx-llvm
-	url = https://github.com/matter-labs/solx-llvm
+	url = https://github.com/NomicFoundation/solx-llvm
 	branch = main

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For reference, see [llvm-sys](https://crates.io/crates/llvm-sys) and [Local LLVM
   - Apache License, Version 2.0 ([LICENSE-APACHE](./solx-standard-json/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
   - MIT license ([LICENSE-MIT](./solx-standard-json/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 - [`solx-solidity`](https://github.com/NomicFoundation/solx-solidity/) is licensed under [GNU General Public License v3.0](https://github.com/NomicFoundation/solx-solidity/blob/0.8.34/LICENSE.txt)
-- [`solx-llvm`](https://github.com/matter-labs/solx-llvm) is licensed under the terms of Apache License, Version 2.0 with LLVM Exceptions, ([LICENSE](https://github.com/matter-labs/solx-llvm/blob/main/LICENSE) or https://llvm.org/LICENSE.txt)
+- [`solx-llvm`](https://github.com/NomicFoundation/solx-llvm) is licensed under the terms of Apache License, Version 2.0 with LLVM Exceptions, ([LICENSE](https://github.com/NomicFoundation/solx-llvm/blob/main/LICENSE) or https://llvm.org/LICENSE.txt)
 
 Additionally, this repository vendors tests and test projects that preserve their original licenses:
 

--- a/docs/src/internals/01-architecture.md
+++ b/docs/src/internals/01-architecture.md
@@ -8,7 +8,7 @@ The compiler consists of three repositories:
 
 1. [solx](https://github.com/NomicFoundation/solx) — The main compiler executable and Rust crates that translate Yul and EVM assembly to LLVM IR.
 2. [solx-solidity](https://github.com/NomicFoundation/solx-solidity) — An LLVM-friendly fork of the Solidity compiler that emits Yul and EVM assembly.
-3. [solx-llvm](https://github.com/matter-labs/solx-llvm) — A fork of the LLVM framework with an EVM target backend.
+3. [solx-llvm](https://github.com/NomicFoundation/solx-llvm) — A fork of the LLVM framework with an EVM target backend.
 
 ## Compilation Pipeline
 

--- a/docs/src/user-guide/01-installation.md
+++ b/docs/src/user-guide/01-installation.md
@@ -162,7 +162,7 @@ This repository maintains intuitive and stable naming for the executables and pr
 
 ### Building LLVM manually
 
-If you prefer building [the LLVM framework](https://github.com/matter-labs/solx-llvm) manually, include the following flags in your CMake command:
+If you prefer building [the LLVM framework](https://github.com/NomicFoundation/solx-llvm) manually, include the following flags in your CMake command:
 
 ```shell
 # We recommend using the latest version of CMake.

--- a/solx-dev/src/llvm/platforms/shared.rs
+++ b/solx-dev/src/llvm/platforms/shared.rs
@@ -33,7 +33,7 @@ pub const SHARED_BUILD_OPTS: [&str; 23] = [
     "-DLLVM_OPTIMIZED_TABLEGEN='Off'",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
     "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from $PATH, not from registry
-    "-DBUG_REPORT_URL='https://github.com/matter-labs/solx-llvm/issues'",
+    "-DBUG_REPORT_URL='https://github.com/NomicFoundation/solx-llvm/issues'",
 ];
 
 /// LLVM binaries always built and copied into the install prefix after


### PR DESCRIPTION
The `solx-llvm` LLVM fork moved from the `matter-labs` org to `NomicFoundation`. This updates the submodule URL and any reference to the old org that needed to be updated.

# Claude summary

## Changes
- **`.gitmodules`** — submodule URL → `NomicFoundation/solx-llvm`
- **`solx-dev/src/llvm/platforms/shared.rs`** — `BUG_REPORT_URL` baked into LLVM builds
- **`README.md`** — link + LICENSE blob URL
- **`docs/src/internals/01-architecture.md`** — link
- **`docs/src/user-guide/01-installation.md`** — link

## Notes
- The submodule's pinned commit SHA is unchanged — this only redirects where it's fetched from, assuming NomicFoundation's mirror has the same history.
- Left untouched: the `solx-tester/.../matter_labs/` test-corpus dirs and the `matter-labs/compiler-infra` credit comment in `.github/docker/Dockerfile` — neither concerns the LLVM fork.