### PR TITLE
ci: support solx-llvm's regression CI (image tools + optional artifact cache)

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -51,6 +51,15 @@ inputs:
     description: 'LLVM build type. Possible values are `Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`. [default: Release]'
     required: false
     default: 'Release'
+  enable-artifact-cache:
+    description: >-
+      Enable the whole-artifact cache layer (restore/save of target-llvm/target-final).
+      Disable it when the solx-llvm tree changes every run (e.g. solx-llvm's own
+      regression CI) or when later steps need the build directory: an artifact hit
+      skips the build entirely, so target-llvm/build-final would not exist.
+      When disabled, the `cache-hit` output is always empty.
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -65,6 +74,7 @@ runs:
       run: echo "hash=$(pacman -Q | sha256sum | head -c 8)" >> "${GITHUB_OUTPUT}"
 
     - name: Compute LLVM cache key
+      if: inputs.enable-artifact-cache == 'true'
       id: llvm-cache
       shell: bash
       working-directory: ${{ inputs.working-dir }}
@@ -96,6 +106,7 @@ runs:
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Restore LLVM artifact cache
+      if: inputs.enable-artifact-cache == 'true'
       id: llvm-artifact-cache
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
@@ -229,7 +240,7 @@ runs:
       run: ccache --show-stats
 
     - name: Save LLVM artifact cache
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
+      if: inputs.enable-artifact-cache == 'true' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
       uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libssl-dev \
         openssh-client \
         xz-utils \
+        # actions/cache compresses with zstd only if the binary is in the container;
+        # without it, it silently falls back to gzip (slower, larger entries).
+        zstd \
         libc6-dbg \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.source="https://github.com/NomicFoundation/solx"
 LABEL org.opencontainers.image.description="CI runner image for solx"
 
 ENV DEBIAN_FRONTEND=noninteractive
+# Ubuntu 26.04's Python is PEP-668 externally-managed; CI jobs pip-install
+# straight into the container (no venv), so lift the guard image-wide.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # ── System packages ──────────────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -23,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         pkg-config \
         python3 \
+        python3-pip \
         jq \
         ca-certificates \
         gnupg \
@@ -38,6 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Must match the LLVM version shipped inside rustc (1.93.0 → LLVM 21) so that
 # llvm-cov / llvm-profdata can read the profraw format emitted by instrumented
 # Rust binaries.
+# clang-format/clang-tidy (and python3-pip above) are not used by solx itself;
+# they serve solx-llvm's regression CI, which runs in this image.
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
         | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
@@ -45,6 +51,8 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
         > /etc/apt/sources.list.d/llvm-21.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         clang-21 \
+        clang-format-21 \
+        clang-tidy-21 \
         lld-21 \
         llvm-21 \
         libclang-rt-21-dev \
@@ -135,6 +143,10 @@ RUN set -eux \
     && cmake --version \
     && ninja --version \
     && clang --version \
+    && clang-format --version \
+    && clang-tidy --version \
+    && command -v git-clang-format \
+    && python3 -m pip --version \
     && lld -flavor gnu --version \
     && command -v llvm-cov \
     && command -v llvm-profdata \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         python3 \
         python3-pip \
+        python3-psutil \
         jq \
         ca-certificates \
         gnupg \


### PR DESCRIPTION
With `solx-llvm` having migrated to NomicFoundation we need to do the following:
* we need to move the a Matterlabs Docker container to NomicFoundation. solx already has a slightly trimmed version, so I've undone the trimming to make it work for both. 
* `solx-llvm` doesn't have its own LLVM build step in CI, instead it borrows the existing step in `solx` CI. I've added a flag so we don't use the whole artefact caching layer, as that will almost never be useful for `solx-llvm`, instead we'll purely rely on ccache.
* Added `zstd` to the container while I'm at it. This should improve compression size. It will cause one cold build per platform.

After this merges, I'll build the Dockerfile, update `solx` to use the new reference (not needed, but better to do now to make sure we didn't regress) and update `solx-llvm` repo to use it as well. 

# Summary

solx-llvm is migrating its regression CI off Matter Labs runners/images onto GitHub-hosted runners, reusing this repo's `solx-ci-runner` image and `build-llvm` composite action (which its workflow already consumes via a solx@main checkout). Two gaps on the solx side:

## Docker image: tools for solx-llvm's formatting + clang-tidy jobs

- Add `clang-format-21` / `clang-tidy-21` (the existing `update-alternatives` loop gives them unversioned names, and `git-clang-format` comes along in the same package).
- Add `python3-pip` and set `PIP_BREAK_SYSTEM_PACKAGES=1` — Ubuntu 26.04's Python is PEP-668 externally-managed, and CI jobs pip-install straight into the container.
- Extend the smoke test accordingly.

None of these are used by solx itself; merging this triggers `docker-ci-image.yaml` and the resulting digest is what solx-llvm's workflow will pin. solx's own workflows don't need a repin for these additive packages.

## Docker image: zstd for actions/cache compression

The `@actions/cache` toolkit probes for a `zstd` binary *inside the job container* and silently falls back to gzip when absent — which is what every containered cache step here (LLVM/solc artifact caches, ccache-action) has been doing. gzip entries are larger (pressure on the 10 GB repo quota) and slower to pack/unpack; for solx-llvm, whose only cache layer is a ~GB ccache entry, this matters even more. Adding `zstd` fixes both repos at once.

One expected side effect: the toolkit hashes the compression method into the cache version, so existing cache entries stop restoring once the new image rolls out — a one-time cold rebuild per key, absorbed by the nightly cache-warmup.

## build-llvm: optional whole-artifact cache layer

New `enable-artifact-cache` input, default `'true'` — a no-op for every existing caller (nothing passes it).

In solx the artifact cache is keyed on the solx-llvm *submodule* SHA, so it hits on most runs and skipping the build is the win. In solx-llvm the tree being built *is* the PR, so the key never usefully hits — and the two cases where it would fire are harmful: warmup runs on main would save a multi-GB `target-final` entry per merge (competing with ccache for the 10 GB repo quota), and a rerun on the same SHA would hit, skip the build, and fail the lit targets, which need the (uncached) `build-final` directory. solx-llvm will pass `'false'` and run with ccache as its only cache layer.

Gate-audited: with the restore step skipped its output is `''`, so every existing `cache-hit != 'true'` build gate still runs; the save step additionally requires the input enabled.
