### PR TITLE
ci: python3-venv instead of system-pip installs in the runner image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -11,9 +11,6 @@ LABEL org.opencontainers.image.source="https://github.com/NomicFoundation/solx"
 LABEL org.opencontainers.image.description="CI runner image for solx"
 
 ENV DEBIAN_FRONTEND=noninteractive
-# Ubuntu 26.04's Python is PEP-668 externally-managed; CI jobs pip-install
-# straight into the container (no venv), so lift the guard image-wide.
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # ── System packages ──────────────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -26,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         pkg-config \
         python3 \
-        python3-pip \
         python3-psutil \
+        python3-venv \
         jq \
         ca-certificates \
         gnupg \
@@ -46,8 +43,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Must match the LLVM version shipped inside rustc (1.93.0 → LLVM 21) so that
 # llvm-cov / llvm-profdata can read the profraw format emitted by instrumented
 # Rust binaries.
-# clang-format/clang-tidy (and python3-pip above) are not used by solx itself;
-# they serve solx-llvm's regression CI, which runs in this image.
+# clang-format/clang-tidy (and python3-venv/psutil above) are not used by solx
+# itself; they serve solx-llvm's regression CI, which runs in this image.
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
         | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
@@ -150,7 +147,10 @@ RUN set -eux \
     && clang-format --version \
     && clang-tidy --version \
     && command -v git-clang-format \
-    && python3 -m pip --version \
+    && python3 -c 'import psutil' \
+    && python3 -m venv /tmp/smoke-venv \
+    && /tmp/smoke-venv/bin/pip --version \
+    && rm -rf /tmp/smoke-venv \
     && lld -flavor gnu --version \
     && command -v llvm-cov \
     && command -v llvm-profdata \


### PR DESCRIPTION
Iteration on the docker image: switching pip to venv due to pip not working well. I've done a manual workflow push, published the image and tested it in https://github.com/NomicFoundation/solx-llvm/pull/103 which passed (https://github.com/NomicFoundation/solx-llvm/actions/runs/28878723529/job/85661043558?pr=103). 

# Claude summary

Follow-up to #513, prompted by the first real formatting-job run on solx-llvm PR #103: installing the repo's pinned Python requirements into the image's *system* interpreter is the wrong layer, and Debian actively fights it.

## What broke

With `PIP_BREAK_SYSTEM_PACKAGES=1` past PEP 668, pip still aborted: the pinned `pyjwt==2.13.0` collides with the image's Debian-owned PyJWT 2.10.1 (apt dependency tail), which pip cannot uninstall — apt packages ship no pip `RECORD` file. `pip --ignore-installed` works (installs to `/usr/local`, shadowing the distro copy), but it's collision-class whack-a-mouse semantics baked into a workflow flag.

## The boundary this PR restores

- **Image = environment**: interpreters, toolchain binaries, and libraries consumed by the build system itself (`python3-psutil` stays — lit imports it from the system interpreter inside the ninja-driven test runs).
- **Repo lockfiles = job-time installs into a venv**: solx-llvm's formatting job will create a venv and install its hashed `requirements_formatting_solx_llvm.txt` there. Complete isolation from the distro Python — no PEP-668 override, no shadowing, no uninstall collisions, ever.

So: add `python3-venv`, drop `python3-pip` and the `PIP_BREAK_SYSTEM_PACKAGES` override (nothing installs into the system interpreter anymore). Smoke test now exercises a real venv (create, check pip inside, remove) and `import psutil` explicitly.

## Rollout

Merging rebuilds the image (path filter). solx-llvm PR #103 then bumps its digest pins and switches its install step to the venv in one commit — until then its formatting job stays red, which it already is.