### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -1,13 +1,4 @@
 [[allow.exact]]
-crate = "rustls-webpki"
-version = "0.103.13"
-
-[[allow.exact]]
-crate = "anyhow"
-version = "1.0.103"
-# RUSTSEC-2026-0190: downcast_mut unsoundness. Security fix; bypass 7-day cooldown. See PR #493.
-
-[[allow.exact]]
 crate = "crossbeam-epoch"
 version = "0.9.20"
 # RUSTSEC-2026-0204: invalid pointer deref in fmt::Pointer. Security fix; bypass 7-day cooldown.

--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -6,3 +6,8 @@ version = "0.103.13"
 crate = "anyhow"
 version = "1.0.103"
 # RUSTSEC-2026-0190: downcast_mut unsoundness. Security fix; bypass 7-day cooldown. See PR #493.
+
+[[allow.exact]]
+crate = "crossbeam-epoch"
+version = "0.9.20"
+# RUSTSEC-2026-0204: invalid pointer deref in fmt::Pointer. Security fix; bypass 7-day cooldown.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Quick advisory fix to unblock CI. Needed a cooldown exception. Package looks fine. I cleaned up old cooldown exceptions while I was at it.

# Summary

Fixes the `cargo-checks` job, which is red on `main` and every PR — not because of any code change, but because the live RustSec DB started flagging our pinned `crossbeam-epoch`.

## What broke

`cargo-deny` runs first in the `cargo-checks` composite action (before check/fmt/clippy/udeps), so **RUSTSEC-2026-0204** fails the whole job regardless of a PR's contents:

> Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` — only `>=0.9.20` fixes it.

The crate is transitive (`rayon → rayon-core → crossbeam-deque → crossbeam-epoch`) and those pointers are never formatted for `Display`, so the practical risk to solx is nil — but the advisory still gates CI.

## The fix

- **Bump `crossbeam-epoch` 0.9.18 → 0.9.20** (`Cargo.lock`, single-crate, no cascade).
- **Allowlist the fresh version for cooldown.** 0.9.20 was published 2026-07-06, inside the 7-day cooldown window, and a `Cargo.lock` change matches the `code` paths-filter — so it would otherwise fail the `cooldown-check` job. Added an `[[allow.exact]]` entry, mirroring the existing `anyhow`/RUSTSEC-2026-0190 precedent.

## Cleanup (bundled)

Dropped two `[[allow.exact]]` entries that have aged past the 7-day cooldown and no longer do anything: `rustls-webpki 0.103.13` (2026-04-21) and `anyhow 1.0.103` (2026-06-25). The allowlist is now just the one currently-needed `crossbeam-epoch` entry.

## Verification

Both gated checks pass locally (no LLVM build required):

- `cargo deny check --allow unmaintained --hide-inclusion-graph` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo-cooldown-check cooldown-check` → `Dependency graph passed cooldown check ✅` (skips `crossbeam-epoch@0.9.20` via allowlist)
