### PR TITLE
ci: bump solx-ci-runner image to ea317f4

### DIFF
--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -38,10 +38,10 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
           - name: "Windows"
             runner: windows-2025
     runs-on: ${{ matrix.runner }}
@@ -117,10 +117,10 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
           - name: "Windows"
             runner: windows-2025
     runs-on: ${{ matrix.runner }}
@@ -175,7 +175,7 @@ jobs:
   warm-llvm-sanitizer:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       volumes: *free-disk-volumes
     name: "LLVM · Sanitizer"
     steps:
@@ -216,7 +216,7 @@ jobs:
   warm-llvm-coverage:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       volumes: *free-disk-volumes
     name: "LLVM · Coverage"
     steps:
@@ -258,7 +258,7 @@ jobs:
   warm-llvm-integration:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       volumes: *free-disk-volumes
     name: "LLVM + solc · Integration"
     steps:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -44,7 +44,7 @@ jobs:
       pull-requests: write
       packages: read
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
     env:
       BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
       SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -47,7 +47,7 @@ jobs:
       packages: read
     runs-on: solx-linux-amd64-self-hosted
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       options: -m 110g
     steps:
       - name: Checkout PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,8 +115,8 @@ jobs:
           WINDOWS='{"name":"Windows","runner":"windows-2025","release-suffix":"windows-amd64-gnu"}'
           MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-15-intel","release-suffix":"macosx-amd64"}'
           MACOS_ARM64='{"name":"MacOS-arm64","runner":"macos-15","release-suffix":"macosx-arm64"}'
-          LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"ubuntu-24.04","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
-          LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"ubuntu-24.04-arm","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
+          LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"ubuntu-24.04","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
+          LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"ubuntu-24.04-arm","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
           # Disable platforms for non-tag builds if user requested
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ] && [ "${GITHUB_REF_TYPE}" != tag ]; then
             [ "${{ github.event.inputs.release_windows_amd64 }}" != true ] && WINDOWS=
@@ -227,7 +227,7 @@ jobs:
     name: Prepare release bundle
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
     needs: [build]
     outputs:
       release_title: ${{ steps.release.outputs.release_title }}

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: [label-check, cooldown-check]
     runs-on: solx-linux-amd64-self-hosted
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       options: -m 110g
     env:
       TARGET: x86_64-unknown-linux-gnu

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -50,11 +50,11 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
             target: "x86_64-unknown-linux-gnu"
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
             target: "aarch64-unknown-linux-gnu"
           - name: "Windows"
             runner: windows-2025

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
       # Host tooling bind-mounted so the free-disk-space action can reclaim
       # ~24 GB before the cold LLVM build fills the runner's 14 GB budget.
       # Anchor shared with build-and-test below; keep in sync with the
@@ -150,11 +150,11 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
             target: "x86_64-unknown-linux-gnu"
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
             target: "aarch64-unknown-linux-gnu"
           - name: "Windows"
             runner: windows-2025


### PR DESCRIPTION
Follow up from https://github.com/NomicFoundation/solx/pull/515 and https://github.com/NomicFoundation/solx/pull/513. Bumping solx to use the same image solx-llvm is using. Not strictly needed, but better to do the bump ASAP to prevent unexpected regressions when we do need a Dockerfile change for solx repo. 


# Claude summary

Bumps the `solx-ci-runner` container image from `ea…` (old) to tag **`ea317f4`**, whose main addition is a Python **venv** plus a few other small toolchain bits.

## What changed

Swapped the pinned digest across every workflow that runs inside the container:

```
old  sha256:79b926f62cddf00086b8a385f89e3f3281e2f37b993491e773f17d7549f7363a
new  sha256:a3e9312d6442e028a4b9eed17ea597380ae86abf3ff4d45ba957d5a10a805790
```

18 occurrences across 7 files:

| Workflow | Occurrences |
|---|---|
| `cache-warmup.yaml` | 7 |
| `test.yaml` | 3 |
| `release.yaml` | 3 |
| `slang-tests.yaml` | 2 |
| `coverage.yaml` | 1 |
| `integration-tests.yaml` | 1 |
| `sanitizer.yaml` | 1 |

## Notes

- The pinned digest is the **multi-arch manifest index**, not a per-platform child — `release.yaml` feeds a single digest to both the amd64 and arm64 runners, so it has to resolve for both.
- `docker-ci-image.yaml` is untouched (it references the bare image name, no digest).
- The new image is expected to be a superset of the old one, so it shouldn't affect test behavior — this PR is largely "bump and let CI confirm."
- actionlint: no new findings (pre-existing self-hosted-runner-label / shellcheck warnings only).
