### PR TITLE
[scaffolding] PR-side --ethir dump capture for #499 (do not merge)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -310,6 +310,32 @@ jobs:
         with:
           target: ${{ matrix.target || '' }}
 
+      # TEMPORARY (remove before merge): record the full Ethereal IR dump for the
+      # main-vs-PR review, and assert it is deterministic across two runs.
+      - name: Capture Ethereal IR dump
+        if: matrix.name == 'Linux x86 gnu'
+        shell: bash
+        env:
+          BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
+          SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          contract=solx/tests/data/contracts/solidity/Test.sol
+          cargo run --quiet --bin solx --target "${TARGET}" -- "${contract}" --ethir >ethir-dump.txt
+          cargo run --quiet --bin solx --target "${TARGET}" -- "${contract}" --ethir >ethir-dump-second.txt
+          if ! diff ethir-dump.txt ethir-dump-second.txt; then
+            echo "::error::--ethir output is not deterministic across runs"
+            exit 1
+          fi
+
+      - name: Upload Ethereal IR dump
+        if: matrix.name == 'Linux x86 gnu'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ethir-dump
+          path: ethir-dump.txt
+
   # Special job that allows some of the jobs to be skipped or failed
   # requiring others to be successful
   pr-checks:

--- a/solx-evm-assembly/src/ethereal_ir/function/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/mod.rs
@@ -1269,6 +1269,8 @@ impl Function {
             capture_stacks,
         )?;
 
+        // Keep this set in sync with the `stack_hash.expect()` readers in `block::element`:
+        // those arms panic if their instruction is not captured here.
         if matches!(
             block_element.instruction.name,
             InstructionName::Tag | InstructionName::JUMP | InstructionName::JUMPI

--- a/solx/tests/cli/ethir.rs
+++ b/solx/tests/cli/ethir.rs
@@ -12,10 +12,45 @@ fn default() -> anyhow::Result<()> {
 
     let result = crate::cli::execute_solx(args)?;
 
+    // Tier 1: predecessor-invariant structure -- green on both main and the PR.
+    // Both segments dump with recovered functions and blocks, and the per-element
+    // stacks render, exercising the `capture_stacks` reconstruction path. The two
+    // segments carry only their own blocks (`dt_` vs `rt_`), and `stack_usage` /
+    // ` + [` cover the `finalize` size and the reconstructed stack output.
     result
         .success()
         .stdout(predicate::str::contains("Deploy Ethereal IR:"))
-        .stdout(predicate::str::contains("block_"));
+        .stdout(predicate::str::contains("Runtime Ethereal IR:"))
+        .stdout(predicate::str::contains("function __entry {"))
+        .stdout(predicate::str::contains("stack_usage:"))
+        .stdout(predicate::str::contains("block_dt_"))
+        .stdout(predicate::str::contains("block_rt_"))
+        .stdout(predicate::str::contains(" - ["))
+        .stdout(predicate::str::contains(" + ["));
+
+    Ok(())
+}
+
+/// Tier 2: locks the predecessor-attachment fix (PR commit `c306640f`). When a block
+/// key has multiple instances, the incoming predecessor must attach to the instance
+/// whose initial stack matches the visited hash -- not to the last-created instance.
+/// This assertion is expected to be red on `main` (pre-fix) and green on the PR.
+///
+/// Stub: the exact `block_<seg>_<tag>/<instance>: (predecessors: <key>/<inst>)` line
+/// the fix corrects depends on instance numbering that can only be read from the
+/// generated dump. Fill from the first CI `--ethir` artifact, then drop `#[ignore]`.
+#[test]
+#[ignore = "stub: fill the predecessor assertion from the first CI --ethir dump artifact"]
+fn predecessor_attaches_to_matching_instance() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[crate::common::TEST_SOLIDITY_CONTRACT, "--ethir"];
+
+    let _result = crate::cli::execute_solx(args)?;
+    // TODO: pin the corrected predecessor line, e.g.
+    // .stdout(predicate::str::contains(
+    //     "block_rt_<tag>/1: (predecessors: rt_<key>/<inst>)",
+    // ));
 
     Ok(())
 }


### PR DESCRIPTION
# Claude summary

Scaffolding to capture the **PR-side** Ethereal IR dump for #499, to diff against the `main` baseline captured in #520. **Not for merge — throwaway branch, based on #499.**

## Purpose

- Produce the `ethir-dump` artifact built from #499's code, and confirm the strengthened `--ethir` CLI test is green on the PR.
- Diff this against #520's `main` dump. The only dump-affecting change in #499 is the predecessor-attachment fix (`c306640f`), which only shows on a *revisited* multi-instance block. The `main` dump has a single multi-instance block (`rt_2`) with no such revisit, so the diff is **expected to be empty** — which would confirm the "byte-identical Ethereal IR text" claim.

## Contents (on top of #499)

- `test(evmla): strengthen the --ethir CLI test` — the durable test; lands on #499 once validated.
- `ci: TEMPORARY --ethir dump capture` — throwaway artifact + determinism step, removed before merge.

Related: #499, #520
