### PR TITLE
chore: update `slang` dependency to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,7 +4321,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4325,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4342,8 +4351,9 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
+ "fxhash",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "semver 1.0.28",
@@ -4355,12 +4365,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4369,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4383,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=09b2714253e2be6fa7bdc3e525cce88f224e3bf6#09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -4569,7 +4579,6 @@ dependencies = [
  "semver 1.0.28",
  "serde_json",
  "slang_solidity_v2",
- "slang_solidity_v2_common",
  "solx-codegen-evm",
  "solx-core",
  "solx-mlir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
-
-[workspace.dependencies.slang_solidity_v2_common]
-git = "https://github.com/NomicFoundation/slang.git"
-# TODO: pin to a release tag instead of a revision.
-rev = "09b2714253e2be6fa7bdc3e525cce88f224e3bf6"
+rev = "96375f5409aaf2a5f4d2889318429b0d83882d6d"

--- a/renovate.json
+++ b/renovate.json
@@ -69,12 +69,6 @@
       "enabled": false
     },
     {
-      "description": "slang_solidity_v2 and slang_solidity_v2_common are two workspace deps pinned to the same NomicFoundation/slang revision and must move in lockstep; group their digest updates into one PR so the two revs never drift apart. Note: matches on depName (Cargo.toml key), not packageName (the git URL for git-source deps).",
-      "matchManagers": ["cargo"],
-      "matchDepNames": ["slang_solidity_v2", "slang_solidity_v2_common"],
-      "groupName": "slang_solidity_v2"
-    },
-    {
       "description": "Pin reqwest to 0.12.x until web3 (tomusdrw, transitive) also moves off 0.12. solx-compiler-downloader uses reqwest with default-features = false and only [\"blocking\", \"json\"] — no TLS feature. While web3's reqwest 0.12 lock entry is the same major, cargo feature unification adds web3's TLS features (http-rustls-tls) to the shared compiled crate and HTTPS works for free. Splitting majors (0.12 here, 0.13 there) breaks unification, leaves the 0.13 build with no TLS, and HTTPS fails with `invalid URL, scheme is not http`. PR #399 hit exactly this and PR #406's URL switch couldn't fix it. `allowedVersions` keeps 0.12.x patch bumps (security fixes) flowing while blocking the 0.13 jump. Drop this rule when rust-web3 itself moves to reqwest 0.13.",
       "matchManagers": ["cargo"],
       "matchDepNames": ["reqwest"],

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -17,7 +17,6 @@ ruint.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 slang_solidity_v2.workspace = true
-slang_solidity_v2_common.workspace = true
 
 solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-core = { path = "../solx-core", features = ["mlir"] }

--- a/solx-slang/src/ast/contract/function/mod.rs
+++ b/solx-slang/src/ast/contract/function/mod.rs
@@ -302,7 +302,7 @@ impl<'state> FunctionEmitter<'state> {
     /// independently of the Slang AST representation.
     fn map_state_mutability(function: &FunctionDefinition) -> StateMutability {
         use slang_solidity_v2::ast::FunctionMutability;
-        match function.mutability() {
+        match function.attributes().mutability() {
             FunctionMutability::Pure => StateMutability::Pure,
             FunctionMutability::View => StateMutability::View,
             FunctionMutability::Payable => StateMutability::Payable,

--- a/solx-slang/src/ast/contract/mod.rs
+++ b/solx-slang/src/ast/contract/mod.rs
@@ -47,7 +47,10 @@ impl<'state, 'context> ContractEmitter<'state, 'context> {
         contract.functions().iter().any(|function| {
             matches!(function.kind(), FunctionKind::Receive)
                 || (matches!(function.kind(), FunctionKind::Fallback)
-                    && matches!(function.mutability(), FunctionMutability::Payable))
+                    && matches!(
+                        function.attributes().mutability(),
+                        FunctionMutability::Payable
+                    ))
         })
     }
 

--- a/solx-slang/src/slang/compilation_config.rs
+++ b/solx-slang/src/slang/compilation_config.rs
@@ -7,37 +7,38 @@ use std::path::Component;
 use std::path::Path;
 
 use slang_solidity_v2::compilation::CompilationBuilderConfig;
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2::diagnostics::kinds::compilation::MissingFile;
 use slang_solidity_v2::diagnostics::kinds::compilation::UnresolvedImport;
 
 /// Provides file reading and import resolution for the Slang compilation builder.
 pub struct CompilationConfig {
-    sources: BTreeMap<String, String>,
+    sources: BTreeMap<FileId, String>,
 }
 
 impl CompilationConfig {
-    /// Creates a new configuration from a map of file paths to source contents.
-    pub fn new(sources: BTreeMap<String, String>) -> Self {
+    /// Creates a new configuration from a map of file identifiers to source contents.
+    pub fn new(sources: BTreeMap<FileId, String>) -> Self {
         Self { sources }
     }
 }
 
 impl CompilationBuilderConfig for CompilationConfig {
-    fn read_file(&mut self, file_identifier: &str) -> Result<String, MissingFile> {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
         self.sources
-            .get(file_identifier)
+            .get(file_id)
             .cloned()
             .ok_or_else(|| MissingFile {
-                reason: format!("file not found {file_identifier}"),
+                reason: format!("file not found {file_id}"),
             })
     }
 
     fn resolve_import(
         &mut self,
-        source_file_identifier: &str,
+        source_file_id: &FileId,
         import_path: &str,
-    ) -> Result<String, UnresolvedImport> {
-        let path = import_path
+    ) -> Result<FileId, UnresolvedImport> {
+        let import_path = import_path
             .strip_prefix('"')
             .and_then(|stripped| stripped.strip_suffix('"'))
             .or_else(|| {
@@ -47,12 +48,13 @@ impl CompilationBuilderConfig for CompilationConfig {
             })
             .unwrap_or(import_path);
 
-        if self.sources.contains_key(path) {
-            return Ok(path.to_owned());
+        let candidate = FileId::from(import_path);
+        if self.sources.contains_key(&candidate) {
+            return Ok(candidate);
         }
 
-        if let Some(dir) = Path::new(source_file_identifier).parent() {
-            let resolved = dir.join(path);
+        if let Some(dir) = Path::new(source_file_id.as_str()).parent() {
+            let resolved = dir.join(import_path);
             let mut normalized = Vec::new();
             for component in resolved.components() {
                 match component {
@@ -66,14 +68,14 @@ impl CompilationBuilderConfig for CompilationConfig {
                 }
             }
             let clean: std::path::PathBuf = normalized.into_iter().collect();
-            let key = clean.to_string_lossy().replace('\\', "/");
+            let key = clean.to_string_lossy().replace('\\', "/").into();
             if self.sources.contains_key(&key) {
                 return Ok(key);
             }
         }
 
         Err(UnresolvedImport {
-            reason: format!("failed to resolve import {import_path} in {source_file_identifier}"),
+            reason: format!("failed to resolve import {import_path} in {source_file_id}"),
         })
     }
 }

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -10,9 +10,10 @@ use std::path::PathBuf;
 
 use slang_solidity_v2::compilation::CompilationBuilder;
 use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2::diagnostics::DiagnosticExtensions;
+use slang_solidity_v2::utils::EvmTarget;
 use slang_solidity_v2::utils::LanguageVersion;
-use slang_solidity_v2_common::evm_targets::EvmTarget;
 
 use solx_core::Frontend;
 use solx_standard_json::CollectableError;
@@ -51,8 +52,8 @@ impl Slang {
     ///
     /// Returns an error if the compilation builder fails to initialize or
     /// if import resolution fails.
-    pub fn compile(&self, sources: BTreeMap<String, String>) -> anyhow::Result<CompilationUnit> {
-        let paths: Vec<String> = sources.keys().cloned().collect();
+    fn compile(&self, sources: BTreeMap<FileId, String>) -> anyhow::Result<CompilationUnit> {
+        let file_ids: Vec<FileId> = sources.keys().cloned().collect();
         let configuration = CompilationConfig::new(sources);
         let version: LanguageVersion =
             self.version.default.clone().try_into().map_err(|error| {
@@ -65,8 +66,8 @@ impl Slang {
         // handles EVM-version targeting downstream, so admit every built-in here.
         let mut builder = CompilationBuilder::create(version, EvmTarget::LATEST, configuration);
 
-        for path in paths.iter() {
-            builder.add_file(path.clone());
+        for file_id in file_ids {
+            builder.add_file(file_id);
         }
 
         Ok(builder.build())
@@ -122,7 +123,7 @@ impl Frontend for Slang {
                     ));
                 continue;
             };
-            sources.insert(path.clone(), source_code.to_owned());
+            sources.insert(path.as_str().into(), source_code.to_owned());
         }
 
         let unit = self.compile(sources)?;
@@ -130,16 +131,16 @@ impl Frontend for Slang {
         output
             .errors
             .extend(unit.diagnostics().iter().map(|diagnostic| {
-                let file_identifier = diagnostic.file_id();
+                let file_id = diagnostic.file_id();
                 let text_range = diagnostic.text_range();
                 let source_location =
                     solx_standard_json::output::error::source_location::SourceLocation::new(
-                        file_identifier,
+                        file_id.to_string(),
                         text_range.start as isize,
                         text_range.end as isize,
                     );
                 solx_standard_json::OutputError::new_error_with_data(
-                    Some(file_identifier),
+                    Some(file_id.as_str()),
                     None,
                     diagnostic.message(),
                     Some(source_location),
@@ -147,10 +148,11 @@ impl Frontend for Slang {
                 )
             }));
 
-        for file_identifier in &unit.file_ids() {
-            if let Some(output_source) = output.sources.get_mut(file_identifier) {
+        for file in unit.files() {
+            let file_id = file.id();
+            if let Some(output_source) = output.sources.get_mut(file_id.as_str()) {
                 output_source.ast = Some(
-                    serde_json::to_value(unit.file(file_identifier).map(|file| file.ast()))
+                    serde_json::to_value(file.ast())
                         .map_err(|error| anyhow::anyhow!("AST serialization: {error}"))?,
                 );
             }
@@ -160,12 +162,8 @@ impl Frontend for Slang {
             return Ok(output);
         }
 
-        let file_identifiers = unit.file_ids();
-
-        for file_identifier in &file_identifiers {
-            let Some(file) = unit.file(file_identifier) else {
-                continue;
-            };
+        for file in unit.files() {
+            let file_id = file.id();
             let source_unit = file.ast();
             let melior = solx_mlir::Context::create_melior_context();
 
@@ -181,7 +179,7 @@ impl Frontend for Slang {
                 solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX
             );
             let capture_sol_dialect = input_json.settings.output_selection.check_selection(
-                file_identifier,
+                file_id.as_str(),
                 Some(contract_name.as_str()),
                 solx_standard_json::InputSelector::MLIR,
             );
@@ -201,7 +199,7 @@ impl Frontend for Slang {
 
             output
                 .contracts
-                .entry(file_identifier.to_string())
+                .entry(file_id.to_string())
                 .or_default()
                 .insert(contract_name, contract);
         }


### PR DESCRIPTION
- adopt the new Slang APIs like `FileId`
- remove the "internal" `slang_solidity_v2_common` dependency as it is no longer required
- update AST APIs to the latest version