### PR TITLE
fix(ci): derive Boost MinGW compiler tag on Windows

### DIFF
--- a/.github/actions/prepare-msys/action.yml
+++ b/.github/actions/prepare-msys/action.yml
@@ -40,5 +40,13 @@ runs:
       shell: msys2 {0}
       run: |
         rustup set default-host x86_64-pc-windows-gnu
-        echo "$(cygpath '${{ steps.msys2.outputs.msys2-location }}')/mingw64/bin" >> "${GITHUB_PATH}"
-        echo "$(cygpath "$USERPROFILE")/.cargo/bin" >> "${GITHUB_PATH}"
+        echo '${{ steps.msys2.outputs.msys2-location }}\mingw64\bin' >> "${GITHUB_PATH}"
+        echo "${USERPROFILE}\\.cargo\\bin" >> "${GITHUB_PATH}"
+
+    # Added to GITHUB_PATH after mingw64\bin, so it lands earlier in PATH:
+    # non-msys2 steps must resolve python3 to the stock CPython, not the
+    # pip-less MinGW python that mingw-w64-x86_64-python puts in mingw64\bin.
+    - name: Install Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: '3.14'

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -150,6 +150,14 @@ jobs:
           results-xml: 'slang-unit-tests-results.xml'
           check-name: 'Slang Unit Tests Results'
 
+      - name: Verify lit tools run outside MSYS2
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          ls -la "${RUNNER_TEMP}/lit-tools"
+          FileCheck --version
+          solc --version
+
       - name: Run MLIR lit tests
         shell: bash
         env:

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -115,13 +115,14 @@ jobs:
       - name: Preserve lit tools before disk cleanup
         shell: bash
         run: |
+          EXE=${{ runner.os == 'Windows' && '.exe' || '' }}
           LIT=llvm-lit${{ runner.os == 'Windows' && '.py' || '' }}
           mkdir -p "${RUNNER_TEMP}/lit-tools"
           cp -r \
-            target-llvm/target-final/bin/FileCheck \
+            target-llvm/target-final/bin/FileCheck${EXE} \
             target-llvm/target-final/bin/${LIT} \
             solx-llvm/llvm/utils/lit \
-            solx-solidity/build/solc/solc \
+            solx-solidity/build/solc/solc${EXE} \
             "${RUNNER_TEMP}/lit-tools/"
           echo "${RUNNER_TEMP}/lit-tools" >> "${GITHUB_PATH}"
           echo "PYTHONPATH=${RUNNER_TEMP}/lit-tools/lit" >> "${GITHUB_ENV}"

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -98,10 +98,13 @@ jobs:
           git -C solx-solidity fetch origin main
           git -C solx-solidity checkout FETCH_HEAD
 
+      # Release: RelWithDebInfo bakes -g3 debug info into the statically
+      # linked solc.exe, producing a ~2 GB PE that the Windows loader
+      # rejects ("Exec format error"), and the lit tests execute solc.
       - name: Build solc
         uses: ./.github/actions/build-solc
         with:
-          cmake-build-type: RelWithDebInfo
+          cmake-build-type: Release
           enable-mlir: 'true'
 
       # bindgen's embedded clang needs to know it's targeting MinGW,

--- a/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/llvm/platforms/x86_64_windows_gnu.rs
@@ -60,6 +60,7 @@ pub fn build(
                 "-DCMAKE_C_COMPILER='clang'",
                 "-DCMAKE_CXX_COMPILER='clang++'",
                 "-DLLVM_USE_LINKER='lld'",
+                "-DCMAKE_EXE_LINKER_FLAGS='-static'",
             ])
             .args(crate::llvm::platforms::shared::shared_build_opts_projects(
                 enable_mlir,

--- a/solx-dev/src/solc/platforms/x86_64_windows_gnu.rs
+++ b/solx-dev/src/solc/platforms/x86_64_windows_gnu.rs
@@ -42,7 +42,7 @@ pub fn build(
     let ninja_available = crate::utils::exists("ninja").is_ok();
 
     // Fix Boost library names for Windows (remove version suffix)
-    fix_boost_library_names(boost_config)?;
+    let boost_compiler = fix_boost_library_names(boost_config)?;
 
     let mut cmake = Command::new("cmake");
     cmake.current_dir(build_dir);
@@ -80,7 +80,7 @@ pub fn build(
         cmake.arg(arg);
     }
     // Windows-specific Boost flags
-    cmake.arg("-DBoost_COMPILER=-mgw15");
+    cmake.arg(format!("-DBoost_COMPILER={boost_compiler}"));
     cmake.arg("-DBoost_ARCHITECTURE=-x64");
 
     // MLIR configuration
@@ -123,12 +123,15 @@ pub fn build(
 }
 
 ///
-/// Fix Boost library names for Windows.
+/// Fix Boost library names for Windows and report the MinGW compiler tag.
 ///
-/// The Boost build creates versioned library names like `libboost_system-mgw15-...`.
-/// CMake expects them without the version suffix, so we create copies.
+/// The Boost build tags versioned libraries like `libboost_system-mgw16-...` with
+/// the MinGW GCC major version. CMake expects the unsuffixed names, and its
+/// `BoostConfig` rejects any variant whose tag differs from `Boost_COMPILER`, so the
+/// tag (`-mgw16`) is read back from the built libraries rather than hardcoded to a
+/// GCC version that drifts with the toolchain.
 ///
-fn fix_boost_library_names(boost_config: &BoostConfig) -> anyhow::Result<()> {
+fn fix_boost_library_names(boost_config: &BoostConfig) -> anyhow::Result<String> {
     let lib_dir = boost_config.lib_dir();
 
     let libraries = [
@@ -143,6 +146,7 @@ fn fix_boost_library_names(boost_config: &BoostConfig) -> anyhow::Result<()> {
         "libboost_unit_test_framework",
     ];
 
+    let mut compiler_tag = None;
     for lib_base in libraries {
         // Find the versioned library file
         let entries: Vec<PathBuf> = std::fs::read_dir(&lib_dir)?
@@ -164,6 +168,13 @@ fn fix_boost_library_names(boost_config: &BoostConfig) -> anyhow::Result<()> {
         });
 
         if let Some(versioned_lib) = versioned_lib {
+            if compiler_tag.is_none() {
+                compiler_tag = versioned_lib
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(|name| name.split('-').nth(1))
+                    .map(|tag| format!("-{tag}"));
+            }
             let target_lib = lib_dir.join(format!("{lib_base}.a"));
             std::fs::copy(&versioned_lib, &target_lib)?;
             eprintln!(
@@ -174,5 +185,10 @@ fn fix_boost_library_names(boost_config: &BoostConfig) -> anyhow::Result<()> {
         }
     }
 
-    Ok(())
+    compiler_tag.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unable to determine the Boost MinGW compiler tag from libraries in {}",
+            lib_dir.display()
+        )
+    })
 }

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -307,6 +307,7 @@ fn select_specific_bytecode(path: &str, expected_key: &str) -> anyhow::Result<()
     Ok(())
 }
 
+#[cfg(feature = "solc")]
 #[test_case(crate::common::standard_json!("select_evm_bytecode_debug_info.json"), "bytecode")]
 #[test_case(crate::common::standard_json!("select_evm_deployed_bytecode_debug_info.json"), "deployedBytecode")]
 fn select_specific_debug_info(path: &str, expected_key: &str) -> anyhow::Result<()> {
@@ -511,6 +512,7 @@ fn select_ast_only() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "solc")]
 #[test]
 fn select_wildcard_and_per_file_are_unioned() -> anyhow::Result<()> {
     crate::common::setup()?;
@@ -529,6 +531,7 @@ fn select_wildcard_and_per_file_are_unioned() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "solc")]
 #[test]
 fn select_per_file_cross_file_dependency() -> anyhow::Result<()> {
     crate::common::setup()?;


### PR DESCRIPTION
Windows CI fails in the solc build whenever a runner actually rebuilds Boost. MSYS2 now ships MinGW `gcc-16.1.0-5`, and Boost stamps its static libraries with the compiler's major version (`libboost_system-mgw16-mt-s-x64-1_83.a`). The configure step hardcoded `-DBoost_COMPILER=-mgw15`, so once Boost is built with GCC 16, CMake's `BoostConfig` rejects every component ("No suitable build variant has been found") and configure fails.

This is why the same commit both passes and fails: the variable is the solc build cache, not the compiler. A job that restores a cached solc/Boost `build/` (baked earlier while MSYS2 still shipped GCC 15, so Boost was tagged `mgw15`) skips the build and the broken configure entirely and stays green; a job that misses the cache rebuilds Boost with GCC 16 and hits the `mgw16` vs `-mgw15` mismatch. The solc cache key carries the solx-solidity submodule SHA and the `mlir` flag, so a submodule bump, the mlir leg, or plain cache eviction each trigger the miss. `main` is green only because its cache keeps hitting — it fails the next time it has to rebuild solc on Windows.

Rather than bump the pin (which just moves the break to GCC 17), this reads the tag back from the libraries Boost actually built: the second dash-delimited field of the versioned filename, taken from the same scan that already aliases them. It matches the cached `mgw15` libs and freshly built `mgw16` libs alike, and tracks whatever MinGW GCC MSYS2 provides.

Probably fixes the Windows CI in https://github.com/NomicFoundation/solx/pull/528 and other PRs that will probably start failing from now on.
