### PR TITLE
ci: adopt cargo-cooldown-check v0.2.0, drop its cache step and config

### DIFF
--- a/.cargo/cooldown-allowlist.toml
+++ b/.cargo/cooldown-allowlist.toml
@@ -1,4 +1,2 @@
-[[allow.exact]]
-crate = "crossbeam-epoch"
-version = "0.9.20"
-# RUSTSEC-2026-0204: invalid pointer deref in fmt::Pointer. Security fix; bypass 7-day cooldown.
+# Allowlist for cargo-cooldown-check.
+# Add `[[allow.exact]]` entries to skip cooldown for a freshly published crate version.

--- a/.cargo/cooldown.toml
+++ b/.cargo/cooldown.toml
@@ -1,2 +1,1 @@
 cooldown_minutes = 10080 # 7 days
-cache_dir = "./target/solx-cache/cargo-cooldown-check"

--- a/.github/actions/cooldown-check/action.yml
+++ b/.github/actions/cooldown-check/action.yml
@@ -9,13 +9,4 @@ runs:
   steps:
     - uses: ./.github/actions/setup-rust
 
-    - name: Cache cooldown data
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
-      with:
-        path: |
-          **/target/solx-cache/cargo-cooldown-check
-        key: cooldown-check-v1-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          cooldown-check-v1-${{ runner.os }}-
-
-    - uses: NomicFoundation/cargo-cooldown-check@2d71adb59987bfb3e5d0f0191893d2961e6ae679 # v0.1.2
+    - uses: NomicFoundation/cargo-cooldown-check@0e9231d9dc6084e8ed2e2eee2fa812f27776cab8 # v0.2.0


### PR DESCRIPTION
Adapts solx CI to use [cargo-cooldown-check v0.2.0](https://github.com/NomicFoundation/cargo-cooldown-check/releases/tag/v0.2.0). Biggest change is that we now use the cargo.io sparse index, via cargo metadata. In practice this means only a single retrieval call (done just by the Rust tooling) so at this point cargo-cooldown-check does not need a cache any more.

Done this pro-actively as we had EDR CI failing more and more with HTTP 429s, e.g. https://github.com/NomicFoundation/edr/actions/runs/29261715856/job/86856954133?pr=1556.

# Claude Summary
Adopts [cargo-cooldown-check v0.2.0](https://github.com/NomicFoundation/cargo-cooldown-check/releases/tag/v0.2.0), which resolves publish times from cargo's own sparse-index cache instead of the rate-limited crates.io API (the cause of intermittent HTTP 429 aborts on large dependency graphs). Steady state performs no network I/O at all.

**Changes:**

- `.github/actions/cooldown-check/action.yml` (the single edit point for all seven workflows running the check): action pin bumped to v0.2.0, and the `Cache cooldown data` step deleted — the tool is now stateless, so there is nothing left to cache.
- `.cargo/cooldown.toml`: retired `cache_dir` key removed (v0.2.0 ignores it either way).
- `.cargo/cooldown-allowlist.toml`: pruned the expired crossbeam-epoch 0.9.20 entry (RUSTSEC-2026-0204 bypass; published 2026-07-06, so it now clears the 7-day window on its own). Added the same explanatory header the edr/slang allowlists carry.

**Verified** by running the v0.2.0 release binary against this workspace with the new config: passes, with git-pinned dependencies (slang, web3 forks) skipped as before.