### PR TITLE
feat(slang): complete operator emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1157,7 +1157,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1638,7 +1638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3813,7 +3813,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4276,8 +4276,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slang_solidity_v2"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4289,8 +4289,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_ast"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint 0.4.6",
@@ -4306,8 +4306,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_common"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4320,13 +4320,13 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_cst"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 
 [[package]]
 name = "slang_solidity_v2_ir"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4334,8 +4334,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_parser"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4348,8 +4348,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_semantic"
-version = "1.3.6"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=96375f5409aaf2a5f4d2889318429b0d83882d6d#96375f5409aaf2a5f4d2889318429b0d83882d6d"
+version = "1.3.7"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
@@ -4800,7 +4800,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4809,7 +4809,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5408,7 +5408,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "96375f5409aaf2a5f4d2889318429b0d83882d6d"
+rev = "5dcb93f6fb52370d990ded14de94c082a7f6ba2c"

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -1,11 +1,12 @@
 /*
- * C wrappers for Sol dialect attribute and type creation.
+ * C wrappers for Sol dialect attribute and type creation and inspection.
  *
  * The Sol dialect's C API (mlir-c/Dialect/Sol.h) does not expose
  * constructors for several attributes (e.g. ContractKindAttr,
  * StateMutabilityAttr) or types (e.g. PointerType, AddressType,
- * ContractType). These thin wrappers call the generated C++ get()
- * methods via extern "C" linkage so Rust can create them through FFI.
+ * ContractType), nor kind predicates and accessors over them. These
+ * thin wrappers call the generated C++ methods via extern "C" linkage
+ * so Rust can reach them through FFI.
  */
 
 #include "mlir/Dialect/Sol/Sol.h"
@@ -130,6 +131,14 @@ MlirType solxCreateEnumType(MlirContext ctx, uint32_t max) {
 
 bool solxIsAddressType(MlirType ty) {
     return mlir::isa<mlir::sol::AddressType>(unwrap(ty));
+}
+
+bool solxIsBytesLikeType(MlirType ty) {
+    return mlir::sol::isBytesLikeType(unwrap(ty));
+}
+
+uint32_t solxBytesLikeTypeWidth(MlirType ty) {
+    return mlir::sol::getNumBytes(unwrap(ty));
 }
 
 } /* extern "C" */

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -158,6 +158,12 @@ unsafe extern "C" {
     /// Whether the type is a `sol::AddressType`, regardless of payability.
     pub fn solxIsAddressType(ty: mlir_sys::MlirType) -> bool;
 
+    /// Whether the type is bytes-like: `sol::FixedBytesType` or `sol::ByteType`.
+    pub fn solxIsBytesLikeType(ty: mlir_sys::MlirType) -> bool;
+
+    /// Returns the byte width of a bytes-like type.
+    pub fn solxBytesLikeTypeWidth(ty: mlir_sys::MlirType) -> u32;
+
     /// Returns the element type of a non-mapping reference type. For
     /// struct types, `struct_field_idx` selects the member.
     pub fn mlirSolGetEltType(ty: mlir_sys::MlirType, struct_field_idx: u64) -> mlir_sys::MlirType;

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -176,6 +176,17 @@ impl<'context> Type<'context> {
         unsafe { ffi::solxIsAddressType(self.inner.to_raw()) }
     }
 
+    /// Whether this is a bytes-like type: `sol::FixedBytesType` or `sol::ByteType`.
+    pub fn is_bytes_like(self) -> bool {
+        unsafe { ffi::solxIsBytesLikeType(self.inner.to_raw()) }
+    }
+
+    /// The byte width of this bytes-like type; the classification is the caller's, via
+    /// `is_bytes_like`.
+    pub fn bytes_like_width(self) -> u32 {
+        unsafe { ffi::solxBytesLikeTypeWidth(self.inner.to_raw()) }
+    }
+
     /// The integer attribute of `value` at this type, built via the arbitrary-width FFI constructor
     /// for values wider than `i64`.
     pub fn integer_attribute(self, value: &BigInt) -> Attribute<'context> {

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -58,11 +58,14 @@ impl<'context> Value<'context> {
         Self::constant(i64::from(value), Type::boolean(context.melior), context)
     }
 
-    /// Coerces to `target_type` under Solidity's implicit conversions with a `sol.cast`; a no-op at
-    /// the target type.
+    /// Coerces to `target_type` under Solidity's implicit conversions; a no-op at the target type. A
+    /// bytes-like target reinterprets via `sol.bytes_cast`; every other target is a `sol.cast`.
     pub fn coerce(self, target_type: Type<'context>, context: &Context<'context>) -> Self {
         if self.r#type() == target_type {
             return self;
+        }
+        if target_type.is_bytes_like() {
+            return self.bytes_cast(target_type, context);
         }
         self.cast(target_type, context)
     }
@@ -82,29 +85,6 @@ impl<'context> Value<'context> {
             return truncated.address_cast(target_type, context);
         }
         self.coerce(target_type, context)
-    }
-
-    /// Compares against `other` under `predicate`, the operands first reconciled to a common type:
-    /// their shared type when equal, otherwise the wider operand's integer type, preserving its
-    /// signedness.
-    pub fn compare_coerced(
-        self,
-        other: Self,
-        predicate: CmpPredicate,
-        context: &Context<'context>,
-    ) -> Self {
-        let lhs_type = self.r#type();
-        let rhs_type = other.r#type();
-        let common_type = if lhs_type == rhs_type {
-            lhs_type
-        } else if lhs_type.integer_bit_width() >= rhs_type.integer_bit_width() {
-            lhs_type
-        } else {
-            rhs_type
-        };
-        let left = self.coerce(common_type, context);
-        let right = other.coerce(common_type, context);
-        left.compare(right, predicate, context)
     }
 
     /// The `i1` truthiness of `self` via `sol.cmp ne 0`; a no-op when `self` is already `i1`.

--- a/solx-mlir/tests/lit/abi_coding.sol
+++ b/solx-mlir/tests/lit/abi_coding.sol
@@ -1,25 +1,19 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s --check-prefixes=CHECK,CHECK-SOLX
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s --check-prefixes=CHECK,CHECK-SOLC
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK-SOLX: sol.func @"encode(uint256,address)"
-// CHECK-SOLC: sol.func @encode_{{[0-9]+}}
+// CHECK: sol.func @{{.*encode.*}}
 // CHECK:   sol.encode {{.*}} : ui256, !sol.address : !sol.string<Memory>
-// CHECK-SOLX: sol.func @"encodePacked(uint256,address)"
-// CHECK-SOLC: sol.func @encodePacked_{{[0-9]+}}
+// CHECK: sol.func @{{.*encodePacked.*}}
 // CHECK:   sol.encode {{.*}} : ui256, !sol.address : !sol.string<Memory> {packed}
-// CHECK-SOLX: sol.func @"encodeWithSelector(bytes4,uint256)"
-// CHECK-SOLC: sol.func @encodeWithSelector_{{[0-9]+}}
+// CHECK: sol.func @{{.*encodeWithSelector.*}}
 // CHECK:   sol.encode selector(%{{.*}}) %{{.*}} : !sol.fixedbytes<4> ui256 : !sol.string<Memory>
-// CHECK-SOLX: sol.func @"encodeWithSelectorTwo(bytes4,uint256,address)"
-// CHECK-SOLC: sol.func @encodeWithSelectorTwo_{{[0-9]+}}
+// CHECK: sol.func @{{.*encodeWithSelectorTwo.*}}
 // CHECK:   sol.encode selector(%{{.*}}) %{{.*}}, %{{.*}} : !sol.fixedbytes<4> ui256, !sol.address : !sol.string<Memory>
-// CHECK-SOLX: sol.func @"encodeWithSignature(uint256)"
-// CHECK-SOLC: sol.func @encodeWithSignature_{{[0-9]+}}
+// CHECK: sol.func @{{.*encodeWithSignature.*}}
 // CHECK:   sol.constant 801029432 : ui32
 // CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
 // CHECK:   sol.encode selector(%{{.*}}) %{{.*}} : !sol.fixedbytes<4> ui256 : !sol.string<Memory>
-// CHECK-SOLX: sol.func @"decode(bytes)"
-// CHECK-SOLC: sol.func @decode_{{[0-9]+}}
+// CHECK: sol.func @{{.*decode.*}}
 // CHECK:   sol.decode {{.*}} : !sol.string<Memory> -> ui256
 
 contract C {

--- a/solx-mlir/tests/lit/arithmetic.sol
+++ b/solx-mlir/tests/lit/arithmetic.sol
@@ -58,8 +58,8 @@
 // CHECK: sol.func @{{.*signed_mod.*}}
 // CHECK:   sol.mod %{{.*}}, %{{.*}} : si256
 
-// CHECK: sol.func @{{.*signed_shr.*}}
-// CHECK:   sol.shr %{{.*}}, %{{.*}} : si256
+// CHECK: sol.func @{{.*signed_exp.*}}
+// CHECK:   sol.cexp %{{.*}}, %{{.*}} : si256, ui8 -> si256
 
 contract C {
     function checked_add(uint256 a, uint256 b) public pure returns (uint256) {
@@ -140,7 +140,7 @@ contract C {
         return a % b;
     }
 
-    function signed_shr(int256 a, uint256 b) public pure returns (int256) {
-        return a >> b;
+    function signed_exp(int256 a, uint8 b) public pure returns (int256) {
+        return a ** b;
     }
 }

--- a/solx-mlir/tests/lit/bitwise.sol
+++ b/solx-mlir/tests/lit/bitwise.sol
@@ -4,23 +4,67 @@
 // CHECK: sol.func @{{.*bit_and.*}}
 // CHECK:   sol.and %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*bit_and_signed.*}}
+// CHECK:   sol.and %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @{{.*bit_and_fixed_bytes.*}}
+// CHECK:   sol.and %{{.*}}, %{{.*}} : !sol.fixedbytes<4>
+
 // CHECK: sol.func @{{.*bit_or.*}}
 // CHECK:   sol.or %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*bit_or_signed.*}}
+// CHECK:   sol.or %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @{{.*bit_or_fixed_bytes.*}}
+// CHECK:   sol.or %{{.*}}, %{{.*}} : !sol.fixedbytes<4>
 
 // CHECK: sol.func @{{.*bit_xor.*}}
 // CHECK:   sol.xor %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*bit_xor_signed.*}}
+// CHECK:   sol.xor %{{.*}}, %{{.*}} : si256
+
+// CHECK: sol.func @{{.*bit_xor_fixed_bytes.*}}
+// CHECK:   sol.xor %{{.*}}, %{{.*}} : !sol.fixedbytes<4>
+
 // CHECK: sol.func @{{.*bit_not.*}}
 // CHECK:   sol.not %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*bit_not_signed.*}}
+// CHECK:   sol.not %{{.*}} : si256
+
+// CHECK: sol.func @{{.*bit_not_fixed_bytes.*}}
+// CHECK:   sol.not %{{.*}} : !sol.fixedbytes<4>
 
 // CHECK: sol.func @{{.*shift_left.*}}
 // CHECK:   sol.shl %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*shift_left_mixed.*}}
+// CHECK:   sol.shl %{{.*}}, %{{.*}} : ui8, ui256
+
+// CHECK: sol.func @{{.*shift_left_fixed_bytes.*}}
+// CHECK:   sol.shl %{{.*}}, %{{.*}} : !sol.fixedbytes<4>, ui8
+
 // CHECK: sol.func @{{.*shift_right.*}}
 // CHECK:   sol.shr %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*shift_right_mixed.*}}
+// CHECK:   sol.shr %{{.*}}, %{{.*}} : si8, ui256
+
+// CHECK: sol.func @{{.*shift_right_fixed_bytes.*}}
+// CHECK:   sol.shr %{{.*}}, %{{.*}} : !sol.fixedbytes<4>, ui8
+
 contract C {
     function bit_and(uint256 a, uint256 b) public pure returns (uint256) {
+        return a & b;
+    }
+
+    function bit_and_signed(int256 a, int256 b) public pure returns (int256) {
+        return a & b;
+    }
+
+    function bit_and_fixed_bytes(bytes4 a, bytes4 b) public pure returns (bytes4) {
         return a & b;
     }
 
@@ -28,7 +72,23 @@ contract C {
         return a | b;
     }
 
+    function bit_or_signed(int256 a, int256 b) public pure returns (int256) {
+        return a | b;
+    }
+
+    function bit_or_fixed_bytes(bytes4 a, bytes4 b) public pure returns (bytes4) {
+        return a | b;
+    }
+
     function bit_xor(uint256 a, uint256 b) public pure returns (uint256) {
+        return a ^ b;
+    }
+
+    function bit_xor_signed(int256 a, int256 b) public pure returns (int256) {
+        return a ^ b;
+    }
+
+    function bit_xor_fixed_bytes(bytes4 a, bytes4 b) public pure returns (bytes4) {
         return a ^ b;
     }
 
@@ -36,11 +96,35 @@ contract C {
         return ~a;
     }
 
-    function shift_left(uint256 a, uint256 b) public pure returns (uint256) {
-        return a << b;
+    function bit_not_signed(int256 a) public pure returns (int256) {
+        return ~a;
     }
 
-    function shift_right(uint256 a, uint256 b) public pure returns (uint256) {
-        return a >> b;
+    function bit_not_fixed_bytes(bytes4 a) public pure returns (bytes4) {
+        return ~a;
+    }
+
+    function shift_left(uint256 value, uint256 amount) public pure returns (uint256) {
+        return value << amount;
+    }
+
+    function shift_left_mixed(uint8 value, uint256 amount) public pure returns (uint8) {
+        return value << amount;
+    }
+
+    function shift_left_fixed_bytes(bytes4 value, uint8 amount) public pure returns (bytes4) {
+        return value << amount;
+    }
+
+    function shift_right(uint256 value, uint256 amount) public pure returns (uint256) {
+        return value >> amount;
+    }
+
+    function shift_right_mixed(int8 value, uint256 amount) public pure returns (int8) {
+        return value >> amount;
+    }
+
+    function shift_right_fixed_bytes(bytes4 value, uint8 amount) public pure returns (bytes4) {
+        return value >> amount;
     }
 }

--- a/solx-mlir/tests/lit/comparison.sol
+++ b/solx-mlir/tests/lit/comparison.sol
@@ -4,23 +4,87 @@
 // CHECK: sol.func @{{.*eq.*}}
 // CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*eq_mixed.*}}
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*eq_fixed_bytes.*}}
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
+
+// CHECK: sol.func @{{.*eq_bool.*}}
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : i1
+
+// CHECK: sol.func @{{.*eq_address.*}}
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : !sol.address
+
 // CHECK: sol.func @{{.*ne.*}}
 // CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*ne_mixed.*}}
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*ne_fixed_bytes.*}}
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
+
+// CHECK: sol.func @{{.*ne_bool.*}}
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : i1
+
+// CHECK: sol.func @{{.*ne_address.*}}
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : !sol.address
 
 // CHECK: sol.func @{{.*lt.*}}
 // CHECK:   sol.cmp lt, %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*lt_mixed.*}}
+// CHECK:   sol.cmp lt, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*lt_fixed_bytes.*}}
+// CHECK:   sol.cmp lt, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
+
 // CHECK: sol.func @{{.*le.*}}
 // CHECK:   sol.cmp le, %{{.*}}, %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*le_mixed.*}}
+// CHECK:   sol.cmp le, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*le_fixed_bytes.*}}
+// CHECK:   sol.cmp le, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
 
 // CHECK: sol.func @{{.*gt.*}}
 // CHECK:   sol.cmp gt, %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*gt_mixed.*}}
+// CHECK:   sol.cmp gt, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*gt_fixed_bytes.*}}
+// CHECK:   sol.cmp gt, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
+
 // CHECK: sol.func @{{.*ge.*}}
 // CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : ui256
 
+// CHECK: sol.func @{{.*ge_mixed.*}}
+// CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : si16
+
+// CHECK: sol.func @{{.*ge_fixed_bytes.*}}
+// CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
+
 contract C {
     function eq(uint256 a, uint256 b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function eq_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function eq_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function eq_bool(bool a, bool b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function eq_address(address a, address b) public pure returns (bool) {
         return a == b;
     }
 
@@ -28,7 +92,31 @@ contract C {
         return a != b;
     }
 
+    function ne_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a != b;
+    }
+
+    function ne_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
+        return a != b;
+    }
+
+    function ne_bool(bool a, bool b) public pure returns (bool) {
+        return a != b;
+    }
+
+    function ne_address(address a, address b) public pure returns (bool) {
+        return a != b;
+    }
+
     function lt(uint256 a, uint256 b) public pure returns (bool) {
+        return a < b;
+    }
+
+    function lt_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a < b;
+    }
+
+    function lt_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
         return a < b;
     }
 
@@ -36,11 +124,35 @@ contract C {
         return a <= b;
     }
 
+    function le_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a <= b;
+    }
+
+    function le_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
+        return a <= b;
+    }
+
     function gt(uint256 a, uint256 b) public pure returns (bool) {
         return a > b;
     }
 
+    function gt_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a > b;
+    }
+
+    function gt_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
+        return a > b;
+    }
+
     function ge(uint256 a, uint256 b) public pure returns (bool) {
+        return a >= b;
+    }
+
+    function ge_mixed(int8 a, int16 b) public pure returns (bool) {
+        return a >= b;
+    }
+
+    function ge_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
         return a >= b;
     }
 }

--- a/solx-mlir/tests/lit/compound_assignment.sol
+++ b/solx-mlir/tests/lit/compound_assignment.sol
@@ -2,54 +2,84 @@
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func @{{.*add_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.cadd
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.cadd %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*sub_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.csub
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.csub %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*mul_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.cmul
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.cmul %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*div_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.cdiv
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.cdiv %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*mod_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.mod
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.mod %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*and_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.and
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.and %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*or_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.or
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.or %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*xor_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.xor
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.xor %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*shl_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.shl
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.shl %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 // CHECK: sol.func @{{.*shr_assign.*}}
-// CHECK:   sol.store %arg0, %[[PTR:.*]] :
-// CHECK:   sol.shr
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK:   sol.shr %[[OLD]], %[[RHS]]
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
 contract C {
     function add_assign(uint256 x, uint256 y) public pure returns (uint256) {

--- a/solx-mlir/tests/lit/compound_assignment.sol
+++ b/solx-mlir/tests/lit/compound_assignment.sol
@@ -1,5 +1,5 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+// RUN: solx --emit-mlir=sol %s | FileCheck --check-prefixes=CHECK,CHECK-SOLX %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck --check-prefixes=CHECK,CHECK-SOLC %s
 
 // CHECK: sol.func @{{.*add_assign.*}}
 // CHECK:   sol.store %arg0, %[[XPTR:.*]] :
@@ -81,6 +81,26 @@
 // CHECK:   sol.shr %[[OLD]], %[[RHS]]
 // CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
+// CHECK: sol.func @{{.*shl_assign_mixed.*}}
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK-SOLX:   sol.shl %[[OLD]], %[[RHS]] : ui256, ui8
+// CHECK-SOLC:   %[[SHL_AMOUNT:.*]] = sol.cast %[[RHS]] : ui8 to ui256
+// CHECK-SOLC:   sol.shl %[[OLD]], %[[SHL_AMOUNT]] : ui256, ui256
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
+
+// CHECK: sol.func @{{.*shr_assign_mixed.*}}
+// CHECK:   sol.store %arg0, %[[XPTR:.*]] :
+// CHECK:   sol.store %arg1, %[[YPTR:.*]] :
+// CHECK:   %[[RHS:.*]] = sol.load %[[YPTR]]
+// CHECK:   %[[OLD:.*]] = sol.load %[[XPTR]]
+// CHECK-SOLX:   sol.shr %[[OLD]], %[[RHS]] : ui256, ui8
+// CHECK-SOLC:   %[[SHR_AMOUNT:.*]] = sol.cast %[[RHS]] : ui8 to ui256
+// CHECK-SOLC:   sol.shr %[[OLD]], %[[SHR_AMOUNT]] : ui256, ui256
+// CHECK:   sol.store %{{.*}}, %[[XPTR]]
+
 contract C {
     function add_assign(uint256 x, uint256 y) public pure returns (uint256) {
         x += y;
@@ -128,6 +148,16 @@ contract C {
     }
 
     function shr_assign(uint256 x, uint256 y) public pure returns (uint256) {
+        x >>= y;
+        return x;
+    }
+
+    function shl_assign_mixed(uint256 x, uint8 y) public pure returns (uint256) {
+        x <<= y;
+        return x;
+    }
+
+    function shr_assign_mixed(uint256 x, uint8 y) public pure returns (uint256) {
         x >>= y;
         return x;
     }

--- a/solx-mlir/tests/lit/scoping.sol
+++ b/solx-mlir/tests/lit/scoping.sol
@@ -1,5 +1,5 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s --check-prefixes=CHECK,CHECK-SOLX
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s --check-prefixes=CHECK,CHECK-SOLC
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func @{{.*nested_scope.*}}
 // CHECK:   sol.alloca : !sol.ptr<ui256, Stack>
@@ -9,13 +9,8 @@
 // CHECK:   sol.constant 42
 // CHECK:   %[[X_PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
 // CHECK:   sol.store %{{.*}}, %[[X_PTR]]
-// CHECK-SOLC:   %[[Z_PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
-// CHECK-SOLC:   %[[ZERO:.*]] = sol.constant 0 : ui256
-// CHECK-SOLC:   sol.store %[[ZERO]], %[[Z_PTR]]
-// CHECK-SOLC:   %[[R:.*]] = sol.load %[[Z_PTR]]
-// CHECK-SOLC:   sol.return %[[R]] : ui256
-// CHECK-SOLX:   %[[ZERO:.*]] = sol.constant 0 : ui256
-// CHECK-SOLX:   sol.return %[[ZERO]] : ui256
+// CHECK:   sol.constant 0 : ui256
+// CHECK:   sol.return %{{.*}} : ui256
 
 contract C {
     function nested_scope() public pure returns (uint256) {

--- a/solx-slang/src/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/contract/function/expression/arithmetic.rs
@@ -34,10 +34,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// `a ** b`, both operands coerced to the binder's result type.
+    /// `a ** b`, the base coerced to the binder's result type and the exponent kept at its own type.
     pub fn exponentiation(&mut self, node: &ExponentiationExpression) -> Value<'context> {
-        let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
-        lhs.exponentiate(rhs, self.checked, self)
+        let result_type = self.typing(node.get_type());
+        let base = self.coerced(&node.left_operand(), result_type);
+        let exponent = self.expression(&node.right_operand());
+        base.exponentiate(exponent, self.checked, self)
     }
 }

--- a/solx-slang/src/contract/function/expression/array.rs
+++ b/solx-slang/src/contract/function/expression/array.rs
@@ -25,7 +25,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let element_values = node
             .items()
             .iter()
-            .map(|item| self.expression(&item).coerce(element_type, self))
+            .map(|item| self.coerced(&item, element_type))
             .collect::<Vec<_>>();
         Value::array_literal(
             &element_values,

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -10,9 +10,10 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `lhs = rhs` and the compound `lhs op= rhs`, lowered through the left operand's place. The
-    /// right operand is fully evaluated before the place's old value is read, matching solc's
-    /// evaluation order; plain `=` stores the right operand without the read-modify load.
+    /// Plain `=` and the compound `op=` forms, lowered through the left operand's place. The right
+    /// operand is evaluated before the place's old value is read; `=` coerces and stores it without
+    /// the read-modify load, a shift compound keeps it at its own type, and every other compound
+    /// coerces it to the place's type.
     pub fn assignment(&mut self, node: &AssignmentExpression) -> Value<'context> {
         let (place, element_type) = self.expression_place(&node.left_operand());
         if place.r#type() == element_type {
@@ -20,9 +21,13 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 "assignment through a reference-typed place in storage or calldata is not yet supported"
             );
         }
-        let rhs = self
-            .expression(&node.right_operand())
-            .coerce(element_type, self);
+        let rhs = match node.operator() {
+            AssignmentExpressionOperator::LessThanLessThanEqual(_)
+            | AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => {
+                self.expression(&node.right_operand())
+            }
+            _ => self.coerced(&node.right_operand(), element_type),
+        };
         let stored =
             match node.operator() {
                 AssignmentExpressionOperator::Equal(_) => rhs,
@@ -53,9 +58,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 AssignmentExpressionOperator::LessThanLessThanEqual(_) => {
                     place.load(element_type, self).shl(rhs, self)
                 }
-                AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_)
-                | AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(_) => {
+                AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => {
                     place.load(element_type, self).shr(rhs, self)
+                }
+                AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(_) => {
+                    unreachable!("Solidity has no >>> operator")
                 }
             };
         place.store(stored, self);

--- a/solx-slang/src/contract/function/expression/bitwise.rs
+++ b/solx-slang/src/contract/function/expression/bitwise.rs
@@ -34,14 +34,18 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         lhs.bitxor(rhs, self)
     }
 
-    /// `a << b` and `a >> b`, both operands coerced to the binder's result type.
+    /// `a << b` and `a >> b`, the shifted value coerced to the binder's result type and the shift
+    /// amount kept at its own type.
     pub fn shift(&mut self, node: &ShiftExpression) -> Value<'context> {
-        let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+        let result_type = self.typing(node.get_type());
+        let value = self.coerced(&node.left_operand(), result_type);
+        let amount = self.expression(&node.right_operand());
         match node.operator() {
-            ShiftExpressionOperator::LessThanLessThan(_) => lhs.shl(rhs, self),
-            ShiftExpressionOperator::GreaterThanGreaterThan(_)
-            | ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => lhs.shr(rhs, self),
+            ShiftExpressionOperator::LessThanLessThan(_) => value.shl(amount, self),
+            ShiftExpressionOperator::GreaterThanGreaterThan(_) => value.shr(amount, self),
+            ShiftExpressionOperator::GreaterThanGreaterThanGreaterThan(_) => {
+                unreachable!("Solidity has no >>> operator")
+            }
         }
     }
 }

--- a/solx-slang/src/contract/function/expression/call/arguments.rs
+++ b/solx-slang/src/contract/function/expression/call/arguments.rs
@@ -32,7 +32,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .zip(ordered)
             .map(|(parameter, argument)| {
                 let parameter_type = self.typing(parameter.get_type());
-                let value = self.expression(&argument).coerce(parameter_type, self);
+                let value = self.coerced(&argument, parameter_type);
                 (parameter, value)
             })
             .collect()

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -131,12 +131,13 @@ impl Call {
                 Some(solx_utils::DataLocation::Memory),
             );
             let field_address = struct_address.gep_field(index, field_type, scope);
-            field_address.store(scope.expression(&argument).coerce(field_type, scope), scope);
+            field_address.store(scope.coerced(&argument, field_type), scope);
         }
         vec![struct_address.into()]
     }
 
-    /// Converts the conversion's one operand to the call's result type under the explicit `T(x)` cast.
+    /// Converts the conversion's one operand to the call's result type through an explicit `T(x)`
+    /// cast.
     fn type_conversion<'context>(
         call: &FunctionCallExpression,
         arguments: &PositionalArguments,
@@ -147,7 +148,7 @@ impl Call {
             .next()
             .expect("classification admits exactly one argument");
         let target_type = scope.typing(call.get_type());
-        vec![scope.expression(&operand).convert(target_type, scope)]
+        vec![scope.converted(&operand, target_type)]
     }
 
     /// Statement-style built-ins (`assert`, `require`, `revert`) produce no value.
@@ -186,9 +187,7 @@ impl Call {
                     Some(expression) => {
                         let string_memory_type =
                             MlirType::string(scope.melior, solx_utils::DataLocation::Memory);
-                        let message_value = scope
-                            .expression(&expression)
-                            .coerce(string_memory_type, scope);
+                        let message_value = scope.coerced(&expression, string_memory_type);
                         (
                             vec![message_value],
                             Some(Self::ERROR_STRING_SIGNATURE.to_owned()),
@@ -386,12 +385,7 @@ impl Call {
                 let Some(value_argument) = value_argument else {
                     return Some(new_slot);
                 };
-                Place::from(new_slot).store(
-                    scope
-                        .expression(&value_argument)
-                        .coerce(element_type, scope),
-                    scope,
-                );
+                Place::from(new_slot).store(scope.coerced(&value_argument, element_type), scope);
                 None
             }
             _ => unimplemented!("unsupported member call: {}", access.member().name()),

--- a/solx-slang/src/contract/function/expression/comparison.rs
+++ b/solx-slang/src/contract/function/expression/comparison.rs
@@ -13,21 +13,20 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `a == b` and `a != b`, comparing the operands under the reconciled predicate.
+    /// `a == b` and `a != b`, the operands coerced to the type the binder reconciles them to.
     pub fn equality(&mut self, node: &EqualityExpression) -> Value<'context> {
         let predicate = match node.operator() {
             EqualityExpressionOperator::EqualEqual(_) => CmpPredicate::Eq,
             EqualityExpressionOperator::BangEqual(_) => CmpPredicate::Ne,
         };
-        self.expression(&node.left_operand()).compare_coerced(
-            self.expression(&node.right_operand()),
-            predicate,
-            self,
-        )
+        let common = self.typing(node.common_operand_type());
+        let left = self.coerced(&node.left_operand(), common);
+        let right = self.coerced(&node.right_operand(), common);
+        left.compare(right, predicate, self)
     }
 
-    /// `a < b`, `a <= b`, `a > b`, and `a >= b`, comparing the operands under the reconciled
-    /// predicate.
+    /// `a < b`, `a <= b`, `a > b`, and `a >= b`, the operands coerced to the type the binder
+    /// reconciles them to.
     pub fn inequality(&mut self, node: &InequalityExpression) -> Value<'context> {
         let predicate = match node.operator() {
             InequalityExpressionOperator::LessThan(_) => CmpPredicate::Lt,
@@ -35,10 +34,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             InequalityExpressionOperator::GreaterThan(_) => CmpPredicate::Gt,
             InequalityExpressionOperator::GreaterThanEqual(_) => CmpPredicate::Ge,
         };
-        self.expression(&node.left_operand()).compare_coerced(
-            self.expression(&node.right_operand()),
-            predicate,
-            self,
-        )
+        let common = self.typing(node.common_operand_type());
+        let left = self.coerced(&node.left_operand(), common);
+        let right = self.coerced(&node.right_operand(), common);
+        left.compare(right, predicate, self)
     }
 }

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -118,6 +118,25 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
+    /// Emits an expression and coerces its value to `target_type`.
+    pub fn coerced(
+        &mut self,
+        expression: &Expression,
+        target_type: MlirType<'context>,
+    ) -> Value<'context> {
+        self.expression(expression).coerce(target_type, self)
+    }
+
+    /// Emits an expression and converts its value to `target_type` through an explicit `T(x)` cast,
+    /// the explicit sibling of `coerced`.
+    pub fn converted(
+        &mut self,
+        expression: &Expression,
+        target_type: MlirType<'context>,
+    ) -> Value<'context> {
+        self.expression(expression).convert(target_type, self)
+    }
+
     /// Evaluates both operands of a binary expression and coerces them to the binder's result type.
     pub fn coerced_operands(
         &mut self,
@@ -126,8 +145,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         right: &Expression,
     ) -> (Value<'context>, Value<'context>) {
         let result_type = self.typing(slang_type);
-        let lhs = self.expression(left).coerce(result_type, self);
-        let rhs = self.expression(right).coerce(result_type, self);
-        (lhs, rhs)
+        (
+            self.coerced(left, result_type),
+            self.coerced(right, result_type),
+        )
     }
 }

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -24,9 +24,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             }
             PrefixExpressionOperator::Tilde(_) => {
                 let result_type = self.typing(node.get_type());
-                self.expression(&node.operand())
-                    .coerce(result_type, self)
-                    .not(self)
+                self.coerced(&node.operand(), result_type).not(self)
             }
             PrefixExpressionOperator::Bang(_) => {
                 let value = self.expression(&node.operand());
@@ -42,7 +40,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 match magnitude {
                     Some(magnitude) => Value::constant_from_bigint(&-magnitude, result_type, self),
                     None => {
-                        let value = self.expression(&node.operand()).coerce(result_type, self);
+                        let value = self.coerced(&node.operand(), result_type);
                         Value::zero(result_type, self).subtract(value, self.checked, self)
                     }
                 }

--- a/solx-slang/src/contract/function/statement/variable_declaration.rs
+++ b/solx-slang/src/contract/function/statement/variable_declaration.rs
@@ -36,7 +36,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let declared_type = self.typing(node.declaration().get_type());
         match node.value() {
             Some(initializer) => {
-                let value = self.expression(&initializer).coerce(declared_type, self);
+                let value = self.coerced(&initializer, declared_type);
                 self.define_local(node.declaration().name().name(), declared_type, |_scope| {
                     value
                 });

--- a/solx-slang/src/contract/state_variable.rs
+++ b/solx-slang/src/contract/state_variable.rs
@@ -39,11 +39,10 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             }
             let (storage_ref, element_type) =
                 self.state_variable_place(&state_variable, &slot_name);
-            let value = self.expression(&initializer);
             if storage_ref.r#type() == element_type {
-                storage_ref.copy_from(value, self);
+                storage_ref.copy_from(self.expression(&initializer), self);
             } else {
-                storage_ref.store(value.coerce(element_type, self), self);
+                storage_ref.store(self.coerced(&initializer, element_type), self);
             }
         }
     }

--- a/solx-slang/src/type.rs
+++ b/solx-slang/src/type.rs
@@ -97,7 +97,9 @@ impl<'context> SourceUnitScope<'context> {
                 );
                 MlirType::array(
                     self.melior,
-                    ArraySize::Fixed(fixed_array_type.size() as u64),
+                    ArraySize::Fixed(
+                        u64::try_from(fixed_array_type.size()).expect("fixed array size fits u64"),
+                    ),
                     element_type,
                     location,
                 )


### PR DESCRIPTION
Completes operator emission on the Slang frontend:

- Comparison reconciles mixed operand types to the wider integer operand, or the widest fixed-bytes width.
- Shift and exponentiation keep their right operand at its own type.
- Bitwise, shift, and negation operators apply directly to fixed-bytes values.
