### PR TITLE
fix(tester): resolve the Slang deploy target in source order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha3 0.12.0",
+ "slang_solidity_v2",
  "solx-benchmark-converter",
  "solx-codegen-evm",
  "solx-compiler-downloader",

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -171,11 +171,11 @@ impl Assembly {
 
         for (path, file) in contracts.iter() {
             for (name, deploy_code_assembly) in file.iter() {
-                let deploy_code_path = format!("{path}:{name}");
+                let deploy_code_path = solx_utils::ContractName::full_path(path, name);
                 let deploy_code_hash = deploy_code_assembly.hash();
 
                 let runtime_code_path =
-                    format!("{path}:{name}.{}", solx_utils::CodeSegment::Runtime);
+                    format!("{deploy_code_path}.{}", solx_utils::CodeSegment::Runtime);
                 let runtime_code_assembly = deploy_code_assembly.runtime_code()?;
                 let runtime_code_hash = runtime_code_assembly.hash();
 
@@ -187,8 +187,10 @@ impl Assembly {
         let mut assemblies = BTreeMap::new();
         for (path, file) in contracts.into_iter() {
             for (name, assembly) in file.into_iter() {
-                let full_path = format!("{path}:{name}");
-                assemblies.insert(full_path, assembly);
+                assemblies.insert(
+                    solx_utils::ContractName::full_path(path.as_str(), name.as_str()),
+                    assembly,
+                );
             }
         }
         assemblies

--- a/solx-tester/Cargo.toml
+++ b/solx-tester/Cargo.toml
@@ -36,6 +36,8 @@ rlp = "0.6"
 once_cell = "1.21"
 revm = "41.0"
 
+slang_solidity_v2 = { workspace = true, optional = true }
+
 solx-standard-json = { path = "../solx-standard-json" }
 solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-utils = { path = "../solx-utils" }
@@ -45,4 +47,4 @@ solx-compiler-downloader = { path = "../solx-compiler-downloader" }
 solx-dev = { path = "../solx-dev" }
 
 [features]
-slang-ast = []
+slang-ast = ["dep:slang_solidity_v2"]

--- a/solx-tester/src/compilers/output_ext.rs
+++ b/solx-tester/src/compilers/output_ext.rs
@@ -67,15 +67,13 @@ pub fn get_last_contract(
                 }
             }
 
-            // TODO: Slang frontend produces a CST instead of the solc AST, so
-            // `last_contract_name` cannot extract the name from the AST
-            // `nodes` array. Fall back to the contracts map directly.
             #[cfg(feature = "slang-ast")]
             for (path, _source) in sources.iter().rev() {
-                if let Some(contracts) = output.contracts.get(path) {
-                    if let Some((name, _)) = contracts.last_key_value() {
-                        return Ok(format!("{path}:{name}"));
-                    }
+                if let Some(contracts) = output.contracts.get(path)
+                    && let Some(source) = output_sources.get(path)
+                    && let Some(name) = last_slang_object_name(source, contracts)
+                {
+                    return Ok(format!("{path}:{name}"));
                 }
             }
 
@@ -176,4 +174,32 @@ fn last_contract_name(
         )
         .next_back()
         .ok_or_else(|| anyhow::anyhow!("The last contract not found in the AST"))
+}
+
+///
+/// Returns the name of the last deployable object in the Slang AST that was compiled: a contract,
+/// library, or interface. The Slang AST gives each its own node type, unlike the solc AST where
+/// all three are `ContractDefinition`s distinguished by `contractKind`.
+///
+#[cfg(feature = "slang-ast")]
+fn last_slang_object_name(
+    source: &solx_standard_json::output::source::Source,
+    contracts: &BTreeMap<String, solx_standard_json::output::contract::Contract>,
+) -> Option<String> {
+    source
+        .ast
+        .as_ref()?
+        .get("members")?
+        .as_array()?
+        .iter()
+        .rev()
+        .filter(|member| {
+            matches!(
+                member["type"].as_str(),
+                Some("ContractDefinition" | "LibraryDefinition" | "InterfaceDefinition")
+            )
+        })
+        .filter_map(|member| member["name"]["text"].as_str())
+        .find(|name| contracts.contains_key(*name))
+        .map(str::to_owned)
 }

--- a/solx-tester/src/compilers/output_ext.rs
+++ b/solx-tester/src/compilers/output_ext.rs
@@ -8,10 +8,11 @@ use std::collections::HashMap;
 use solx_standard_json::InputLanguage;
 use solx_standard_json::Output;
 use solx_standard_json::OutputError;
-#[cfg(feature = "slang-ast")]
-use solx_standard_json::output::contract::Contract;
 use solx_standard_json::output::source::Source;
 use solx_utils::ContractName;
+
+#[cfg(feature = "slang-ast")]
+use crate::compilers::solidity::slang_ast::SlangAst;
 
 ///
 /// Extracts method identifiers from all contracts in the output.
@@ -66,21 +67,14 @@ pub fn get_last_contract(
                     continue;
                 };
                 match last_contract_name(source) {
-                    Ok(name) => {
-                        return Ok(ContractName::full_path(path, name.as_str()));
-                    }
+                    Ok(name) => return Ok(ContractName::full_path(path, name.as_str())),
                     Err(_error) => continue,
                 }
             }
 
             #[cfg(feature = "slang-ast")]
-            for (path, _source) in sources.iter().rev() {
-                if let Some(contracts) = output.contracts.get(path)
-                    && let Some(source) = output_sources.get(path)
-                    && let Some(name) = last_slang_object_name(source, contracts)
-                {
-                    return Ok(ContractName::full_path(path, name.as_str()));
-                }
+            if let Some(full_path) = SlangAst::parse(sources).last_deployable(&output.contracts) {
+                return Ok(full_path);
             }
 
             anyhow::bail!("The last contract not found in the output")
@@ -178,32 +172,4 @@ fn last_contract_name(source: &Source) -> anyhow::Result<String> {
         )
         .next_back()
         .ok_or_else(|| anyhow::anyhow!("The last contract not found in the AST"))
-}
-
-///
-/// Returns the name of the last deployable object in the Slang AST that was compiled: a contract,
-/// library, or interface. The Slang AST gives each its own node type, unlike the solc AST where
-/// all three are `ContractDefinition`s distinguished by `contractKind`.
-///
-#[cfg(feature = "slang-ast")]
-fn last_slang_object_name(
-    source: &Source,
-    contracts: &BTreeMap<String, Contract>,
-) -> Option<String> {
-    source
-        .ast
-        .as_ref()?
-        .get("members")?
-        .as_array()?
-        .iter()
-        .rev()
-        .filter(|member| {
-            matches!(
-                member["type"].as_str(),
-                Some("ContractDefinition" | "LibraryDefinition" | "InterfaceDefinition")
-            )
-        })
-        .filter_map(|member| member["name"]["text"].as_str())
-        .find(|name| contracts.contains_key(*name))
-        .map(str::to_owned)
 }

--- a/solx-tester/src/compilers/output_ext.rs
+++ b/solx-tester/src/compilers/output_ext.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use solx_standard_json::InputLanguage;
 use solx_standard_json::Output;
 use solx_standard_json::OutputError;
+#[cfg(feature = "slang-ast")]
+use solx_standard_json::output::contract::Contract;
+use solx_standard_json::output::source::Source;
+use solx_utils::ContractName;
 
 ///
 /// Extracts method identifiers from all contracts in the output.
@@ -36,7 +40,7 @@ pub fn get_method_identifiers(
                     })?;
                 contract_identifiers.insert(entry.clone(), selector);
             }
-            method_identifiers.insert(format!("{path}:{name}"), contract_identifiers);
+            method_identifiers.insert(ContractName::full_path(path, name), contract_identifiers);
         }
     }
     Ok(method_identifiers)
@@ -62,7 +66,9 @@ pub fn get_last_contract(
                     continue;
                 };
                 match last_contract_name(source) {
-                    Ok(name) => return Ok(format!("{path}:{name}")),
+                    Ok(name) => {
+                        return Ok(ContractName::full_path(path, name.as_str()));
+                    }
                     Err(_error) => continue,
                 }
             }
@@ -73,7 +79,7 @@ pub fn get_last_contract(
                     && let Some(source) = output_sources.get(path)
                     && let Some(name) = last_slang_object_name(source, contracts)
                 {
-                    return Ok(format!("{path}:{name}"));
+                    return Ok(ContractName::full_path(path, name.as_str()));
                 }
             }
 
@@ -89,7 +95,7 @@ pub fn get_last_contract(
                 .and_then(|(path, contracts)| {
                     contracts
                         .first_key_value()
-                        .map(|(name, _contract)| format!("{path}:{name}"))
+                        .map(|(name, _contract)| ContractName::full_path(path, name))
                 })
                 .ok_or_else(|| {
                     anyhow::anyhow!("The sources are empty. Found errors: {:?}", output.errors)
@@ -114,7 +120,7 @@ pub fn extract_bytecode_builds(
     let mut builds = HashMap::with_capacity(output.contracts.len());
     for (file, source) in output.contracts.iter() {
         for (name, contract) in source.iter() {
-            let path = format!("{file}:{name}");
+            let path = ContractName::full_path(file, name);
             let deploy_code = match contract
                 .evm
                 .as_ref()
@@ -153,9 +159,7 @@ pub fn errors_opt(output: &Output) -> Option<&[OutputError]> {
 ///
 /// Returns the name of the last contract in the AST.
 ///
-fn last_contract_name(
-    source: &solx_standard_json::output::source::Source,
-) -> anyhow::Result<String> {
+fn last_contract_name(source: &Source) -> anyhow::Result<String> {
     source
         .ast
         .as_ref()
@@ -183,8 +187,8 @@ fn last_contract_name(
 ///
 #[cfg(feature = "slang-ast")]
 fn last_slang_object_name(
-    source: &solx_standard_json::output::source::Source,
-    contracts: &BTreeMap<String, solx_standard_json::output::contract::Contract>,
+    source: &Source,
+    contracts: &BTreeMap<String, Contract>,
 ) -> Option<String> {
     source
         .ast

--- a/solx-tester/src/compilers/solidity/dwarf.rs
+++ b/solx-tester/src/compilers/solidity/dwarf.rs
@@ -8,6 +8,7 @@ use object::Object;
 use object::ObjectSection;
 
 use solx_standard_json::Output;
+use solx_utils::ContractName;
 
 ///
 /// Validates DWARF debug information embedded in compiled contract bytecodes.
@@ -32,7 +33,7 @@ impl DwarfValidator {
     pub fn validate_output(output: &Output) -> anyhow::Result<()> {
         for (file_path, contracts) in output.contracts.iter() {
             for (contract_name, contract) in contracts.iter() {
-                let label = format!("{file_path}:{contract_name}");
+                let label = ContractName::full_path(file_path, contract_name);
 
                 let Some(evm) = contract.evm.as_ref() else {
                     continue;

--- a/solx-tester/src/compilers/solidity/mod.rs
+++ b/solx-tester/src/compilers/solidity/mod.rs
@@ -5,6 +5,8 @@
 pub mod cache_key;
 pub mod dwarf;
 pub mod mode;
+#[cfg(feature = "slang-ast")]
+pub mod slang_ast;
 pub mod subprocess;
 
 use std::collections::BTreeMap;

--- a/solx-tester/src/compilers/solidity/mode.rs
+++ b/solx-tester/src/compilers/solidity/mode.rs
@@ -4,6 +4,10 @@
 
 use itertools::Itertools;
 
+use solx_solc_test_adapter::ABIEncoderV1Only;
+use solx_solc_test_adapter::CompileViaYul;
+use solx_solc_test_adapter::Params;
+
 use crate::compilers::mode::Mode as ModeWrapper;
 use crate::compilers::mode::imode::IMode;
 use crate::compilers::mode::llvm_options::LLVMOptions;
@@ -131,16 +135,16 @@ impl Mode {
     ///
     /// Checks if the mode is compatible with the Ethereum tests params.
     ///
-    pub fn check_ethereum_tests_params(&self, params: &solx_solc_test_adapter::Params) -> bool {
+    pub fn check_ethereum_tests_params(&self, params: &Params) -> bool {
         #[cfg(feature = "slang-ast")]
-        if params.abi_encoder_v1_only == solx_solc_test_adapter::ABIEncoderV1Only::True {
+        if params.abi_encoder_v1_only == ABIEncoderV1Only::True {
             return false;
         }
         if self.via_ir {
-            params.compile_via_yul != solx_solc_test_adapter::CompileViaYul::False
-                && params.abi_encoder_v1_only != solx_solc_test_adapter::ABIEncoderV1Only::True
+            params.compile_via_yul != CompileViaYul::False
+                && params.abi_encoder_v1_only != ABIEncoderV1Only::True
         } else {
-            params.compile_via_yul != solx_solc_test_adapter::CompileViaYul::True
+            params.compile_via_yul != CompileViaYul::True
         }
     }
 

--- a/solx-tester/src/compilers/solidity/mode.rs
+++ b/solx-tester/src/compilers/solidity/mode.rs
@@ -11,6 +11,8 @@ use solx_solc_test_adapter::Params;
 use crate::compilers::mode::Mode as ModeWrapper;
 use crate::compilers::mode::imode::IMode;
 use crate::compilers::mode::llvm_options::LLVMOptions;
+#[cfg(feature = "slang-ast")]
+use crate::compilers::solidity::slang_ast::SlangAst;
 
 ///
 /// Unified Solidity mode for all toolchains.
@@ -76,35 +78,12 @@ impl Mode {
 
     ///
     /// Checks if the mode is compatible with the source code pragmas. Under the Slang frontend,
-    /// tests pinned to `pragma abicoder v1` are incompatible: Slang parses the pragma as an inert
-    /// node and always encodes with v2 semantics.
+    /// tests pinned to `pragma abicoder v1` are incompatible.
     ///
     pub fn check_pragmas(&self, sources: &[(String, String)]) -> bool {
         #[cfg(feature = "slang-ast")]
-        {
-            let mut v1_pinned = false;
-            let mut v2_declared = false;
-            for line in sources
-                .iter()
-                .flat_map(|(_, source_code)| source_code.lines())
-            {
-                let mut split = line.split_whitespace();
-                match (
-                    split.next(),
-                    split.next(),
-                    split.next().map(|version| version.trim_end_matches(';')),
-                ) {
-                    (Some("pragma"), Some("abicoder"), Some("v1")) => v1_pinned = true,
-                    (Some("pragma"), Some("abicoder"), Some("v2"))
-                    | (Some("pragma"), Some("experimental"), Some("ABIEncoderV2")) => {
-                        v2_declared = true;
-                    }
-                    _ => {}
-                }
-            }
-            if v1_pinned && !v2_declared {
-                return false;
-            }
+        if SlangAst::parse(sources).is_abi_encoder_v1_pinned() {
+            return false;
         }
 
         // Strip pre-release for pragma matching since semver pre-release versions

--- a/solx-tester/src/compilers/solidity/mode.rs
+++ b/solx-tester/src/compilers/solidity/mode.rs
@@ -71,9 +71,38 @@ impl Mode {
     }
 
     ///
-    /// Checks if the mode is compatible with the source code pragmas.
+    /// Checks if the mode is compatible with the source code pragmas. Under the Slang frontend,
+    /// tests pinned to `pragma abicoder v1` are incompatible: Slang parses the pragma as an inert
+    /// node and always encodes with v2 semantics.
     ///
     pub fn check_pragmas(&self, sources: &[(String, String)]) -> bool {
+        #[cfg(feature = "slang-ast")]
+        {
+            let mut v1_pinned = false;
+            let mut v2_declared = false;
+            for line in sources
+                .iter()
+                .flat_map(|(_, source_code)| source_code.lines())
+            {
+                let mut split = line.split_whitespace();
+                match (
+                    split.next(),
+                    split.next(),
+                    split.next().map(|version| version.trim_end_matches(';')),
+                ) {
+                    (Some("pragma"), Some("abicoder"), Some("v1")) => v1_pinned = true,
+                    (Some("pragma"), Some("abicoder"), Some("v2"))
+                    | (Some("pragma"), Some("experimental"), Some("ABIEncoderV2")) => {
+                        v2_declared = true;
+                    }
+                    _ => {}
+                }
+            }
+            if v1_pinned && !v2_declared {
+                return false;
+            }
+        }
+
         // Strip pre-release for pragma matching since semver pre-release versions
         // have special matching rules that don't work well with Solidity pragmas.
         // E.g., ">=0.8.0" should match "0.8.34-develop" but semver doesn't agree.
@@ -103,6 +132,10 @@ impl Mode {
     /// Checks if the mode is compatible with the Ethereum tests params.
     ///
     pub fn check_ethereum_tests_params(&self, params: &solx_solc_test_adapter::Params) -> bool {
+        #[cfg(feature = "slang-ast")]
+        if params.abi_encoder_v1_only == solx_solc_test_adapter::ABIEncoderV1Only::True {
+            return false;
+        }
         if self.via_ir {
             params.compile_via_yul != solx_solc_test_adapter::CompileViaYul::False
                 && params.abi_encoder_v1_only != solx_solc_test_adapter::ABIEncoderV1Only::True

--- a/solx-tester/src/compilers/solidity/slang_ast.rs
+++ b/solx-tester/src/compilers/solidity/slang_ast.rs
@@ -1,0 +1,164 @@
+//!
+//! Typed Slang view of a test's Solidity sources.
+//!
+
+use std::collections::BTreeMap;
+
+use slang_solidity_v2::ast::AbicoderVersion;
+use slang_solidity_v2::ast::ExperimentalFeature;
+use slang_solidity_v2::ast::Pragma;
+use slang_solidity_v2::ast::SourceUnitMember;
+use slang_solidity_v2::compilation::CompilationBuilder;
+use slang_solidity_v2::compilation::CompilationBuilderConfig;
+use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2::compilation::FileId;
+use slang_solidity_v2::diagnostics::kinds::compilation::MissingFile;
+use slang_solidity_v2::diagnostics::kinds::compilation::UnresolvedImport;
+use slang_solidity_v2::utils::EvmTarget;
+use slang_solidity_v2::utils::LanguageVersion;
+
+use solx_standard_json::output::contract::Contract;
+use solx_utils::ContractName;
+
+///
+/// Typed Slang parse of a test's sources.
+///
+/// The tester parses sources itself because the AST JSON emitted by the compiler is
+/// serialize-only upstream and cannot be read back into typed nodes. Parsing at the
+/// latest language version and EVM target mirrors the Slang frontend pipeline.
+///
+pub struct SlangAst {
+    /// The parsed compilation unit.
+    unit: CompilationUnit,
+    /// The file identifiers in test source order, which the path-sorted unit does not retain.
+    files: Vec<FileId>,
+}
+
+impl SlangAst {
+    ///
+    /// Parses the test sources.
+    ///
+    pub fn parse(sources: &[(String, String)]) -> Self {
+        let files: Vec<FileId> = sources
+            .iter()
+            .map(|(path, _source_code)| FileId::from(path.as_str()))
+            .collect();
+        let mut builder = CompilationBuilder::create(
+            LanguageVersion::LATEST,
+            EvmTarget::LATEST,
+            TestSources(
+                sources
+                    .iter()
+                    .map(|(path, source_code)| (FileId::from(path.as_str()), source_code.clone()))
+                    .collect(),
+            ),
+        );
+        for file_id in files.iter() {
+            builder.add_file(file_id.clone());
+        }
+        Self {
+            unit: builder.build(),
+            files,
+        }
+    }
+
+    ///
+    /// Whether the sources pin `pragma abicoder v1` without declaring v2 anywhere.
+    ///
+    /// Slang always encodes with v2 semantics, so a v1-pinned test is not reproducible
+    /// under the Slang frontend.
+    ///
+    pub fn is_abi_encoder_v1_pinned(&self) -> bool {
+        let mut v1_pinned = false;
+        let mut v2_declared = false;
+        for file in self.unit.files() {
+            for member in file.ast().members().iter() {
+                let SourceUnitMember::PragmaDirective(directive) = member else {
+                    continue;
+                };
+                match directive.pragma() {
+                    Pragma::AbicoderPragma(pragma) => match pragma.version() {
+                        AbicoderVersion::AbicoderV1Keyword(_) => v1_pinned = true,
+                        AbicoderVersion::AbicoderV2Keyword(_) => v2_declared = true,
+                    },
+                    Pragma::ExperimentalPragma(pragma) => {
+                        if matches!(
+                            pragma.feature(),
+                            ExperimentalFeature::ABIEncoderV2Keyword(_)
+                        ) {
+                            v2_declared = true;
+                        }
+                    }
+                    Pragma::VersionPragma(_) => {}
+                }
+            }
+        }
+        v1_pinned && !v2_declared
+    }
+
+    ///
+    /// The full path of the last compiled deployable object, a contract, interface, or
+    /// library, in test source order: the deploy target of a test that does not name one.
+    ///
+    pub fn last_deployable(
+        &self,
+        contracts: &BTreeMap<String, BTreeMap<String, Contract>>,
+    ) -> Option<String> {
+        for file_id in self.files.iter().rev() {
+            let Some(compiled) = contracts.get(file_id.as_str()) else {
+                continue;
+            };
+            let members: Vec<SourceUnitMember> = self
+                .unit
+                .file(file_id)
+                .expect("every test source is added to the compilation unit")
+                .ast()
+                .members()
+                .iter()
+                .collect();
+            for member in members.iter().rev() {
+                let name = match member {
+                    SourceUnitMember::ContractDefinition(definition) => definition.name().name(),
+                    SourceUnitMember::InterfaceDefinition(definition) => definition.name().name(),
+                    SourceUnitMember::LibraryDefinition(definition) => definition.name().name(),
+                    _ => continue,
+                };
+                if compiled.contains_key(name.as_str()) {
+                    return Some(ContractName::full_path(file_id.as_str(), name.as_str()));
+                }
+            }
+        }
+        None
+    }
+}
+
+///
+/// Serves source contents to the compilation builder.
+///
+/// Import resolution is an exact lookup among the test's own files: the tester's queries
+/// are syntactic, so an unresolved import costs nothing beyond an unused diagnostic.
+///
+struct TestSources(BTreeMap<FileId, String>);
+
+impl CompilationBuilderConfig for TestSources {
+    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
+        self.0.get(file_id).cloned().ok_or_else(|| MissingFile {
+            reason: format!("file not found {file_id}"),
+        })
+    }
+
+    fn resolve_import(
+        &mut self,
+        source_file_id: &FileId,
+        import_path: &str,
+    ) -> Result<FileId, UnresolvedImport> {
+        let candidate = FileId::from(import_path);
+        if self.0.contains_key(&candidate) {
+            Ok(candidate)
+        } else {
+            Err(UnresolvedImport {
+                reason: format!("failed to resolve import {import_path} in {source_file_id}"),
+            })
+        }
+    }
+}

--- a/solx-tester/src/compilers/solidity/slang_ast.rs
+++ b/solx-tester/src/compilers/solidity/slang_ast.rs
@@ -5,7 +5,6 @@
 use std::collections::BTreeMap;
 
 use slang_solidity_v2::ast::AbicoderVersion;
-use slang_solidity_v2::ast::ExperimentalFeature;
 use slang_solidity_v2::ast::Pragma;
 use slang_solidity_v2::ast::SourceUnitMember;
 use slang_solidity_v2::compilation::CompilationBuilder;
@@ -63,37 +62,25 @@ impl SlangAst {
     }
 
     ///
-    /// Whether the sources pin `pragma abicoder v1` without declaring v2 anywhere.
+    /// Whether any source pins `pragma abicoder v1`.
     ///
     /// Slang always encodes with v2 semantics, so a v1-pinned test is not reproducible
     /// under the Slang frontend.
     ///
     pub fn is_abi_encoder_v1_pinned(&self) -> bool {
-        let mut v1_pinned = false;
-        let mut v2_declared = false;
         for file in self.unit.files() {
             for member in file.ast().members().iter() {
                 let SourceUnitMember::PragmaDirective(directive) = member else {
                     continue;
                 };
-                match directive.pragma() {
-                    Pragma::AbicoderPragma(pragma) => match pragma.version() {
-                        AbicoderVersion::AbicoderV1Keyword(_) => v1_pinned = true,
-                        AbicoderVersion::AbicoderV2Keyword(_) => v2_declared = true,
-                    },
-                    Pragma::ExperimentalPragma(pragma) => {
-                        if matches!(
-                            pragma.feature(),
-                            ExperimentalFeature::ABIEncoderV2Keyword(_)
-                        ) {
-                            v2_declared = true;
-                        }
-                    }
-                    Pragma::VersionPragma(_) => {}
+                if let Pragma::AbicoderPragma(pragma) = directive.pragma()
+                    && matches!(pragma.version(), AbicoderVersion::AbicoderV1Keyword(_))
+                {
+                    return true;
                 }
             }
         }
-        v1_pinned && !v2_declared
+        false
     }
 
     ///

--- a/solx-tester/src/directories/ethereum/test.rs
+++ b/solx-tester/src/directories/ethereum/test.rs
@@ -8,6 +8,8 @@ use std::sync::Mutex;
 
 use revm::primitives::Address;
 
+use solx_utils::ContractName;
+
 use crate::compilers::Compiler;
 use crate::compilers::mode::Mode;
 use crate::directories::Buildable;
@@ -158,7 +160,8 @@ impl EthereumTest {
                             name.clone(),
                             format!("0x{}", crate::utils::address_as_string(&address)),
                         );
-                    libraries_addresses.insert(format!("{source}:{name}"), address);
+                    libraries_addresses
+                        .insert(ContractName::full_path(source.as_str(), name), address);
                 }
                 solx_solc_test_adapter::FunctionCall::Account { input, expected } => {
                     let address = solx_solc_test_adapter::account_address(*input);

--- a/solx-tester/src/directories/ethereum/test.rs
+++ b/solx-tester/src/directories/ethereum/test.rs
@@ -91,6 +91,10 @@ impl EthereumTest {
         if !mode.check_ethereum_tests_params(&self.test.params) {
             return None;
         }
+        #[cfg(feature = "slang-ast")]
+        if !mode.check_pragmas(&self.test.sources) {
+            return None;
+        }
         Some(())
     }
 

--- a/solx-tester/src/directories/matter_labs/test/mod.rs
+++ b/solx-tester/src/directories/matter_labs/test/mod.rs
@@ -14,6 +14,8 @@ use std::sync::Mutex;
 
 use revm::primitives::Address;
 
+use solx_utils::ContractName;
+
 use crate::compilers::Compiler;
 use crate::compilers::mode::Mode;
 use crate::directories::Buildable;
@@ -132,7 +134,7 @@ impl MatterLabsTest {
                 let file_path_unified =
                     crate::utils::path_to_string_normalized(file_path.as_path());
                 *path_string = if let Some(contract_name) = contract_name {
-                    format!("{file_path_unified}:{contract_name}")
+                    ContractName::full_path(file_path_unified.as_str(), contract_name)
                 } else {
                     file_path_unified.clone()
                 };
@@ -225,7 +227,7 @@ impl MatterLabsTest {
     ) {
         if contracts.is_empty() {
             let contract_name = if is_multi_contract {
-                format!("{}:{}", self.selector.path, SIMPLE_TESTS_CONTRACT_NAME)
+                ContractName::full_path(self.selector.path.as_str(), SIMPLE_TESTS_CONTRACT_NAME)
             } else {
                 self.selector.path.to_string()
             };
@@ -260,7 +262,10 @@ impl MatterLabsTest {
                     name.to_owned(),
                     format!("0x{}", crate::utils::address_as_string(&address)),
                 );
-                library_addresses.insert(format!("{file_path_string}:{name}"), address);
+                library_addresses.insert(
+                    ContractName::full_path(file_path_string.as_str(), name),
+                    address,
+                );
             }
             libraries.insert(file_path_string, file_libraries);
         }

--- a/solx-tester/src/lib.rs
+++ b/solx-tester/src/lib.rs
@@ -71,6 +71,7 @@ impl<'a> SolxTester<'a> {
     const SOLIDITY_UPSTREAM: &'static str = "solx-solidity/test/libsolidity/semanticTests";
 
     /// The Yul simple tests directory.
+    #[cfg(not(feature = "slang-ast"))]
     const YUL_SIMPLE: &'static str = "tests/yul";
 
     /// The LLVM IR simple tests directory.
@@ -135,6 +136,7 @@ impl<'a> SolxTester<'a> {
         )?);
         let toolchain = solidity_compiler.toolchain();
 
+        #[cfg(not(feature = "slang-ast"))]
         let yul_compiler = Arc::new(SolidityCompiler::new(
             solidity_compiler_path.clone(),
             solx_standard_json::InputLanguage::Yul,
@@ -163,6 +165,7 @@ impl<'a> SolxTester<'a> {
             solidity_compiler.clone(),
         )?);
 
+        #[cfg(not(feature = "slang-ast"))]
         tests.extend(self.directory::<MatterLabsDirectory>(
             Self::YUL_SIMPLE,
             solx_utils::EXTENSION_YUL,

--- a/solx-tester/src/test/case/input/mod.rs
+++ b/solx-tester/src/test/case/input/mod.rs
@@ -17,6 +17,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use solx_utils::ContractName;
+
 use crate::compilers::mode::Mode;
 use crate::directories::matter_labs::test::metadata::case::input::Input as MatterLabsTestInput;
 use crate::revm::REVM;
@@ -231,7 +233,7 @@ impl Input {
                 let source = crate::utils::str_to_string_normalized(
                     source.as_deref().unwrap_or(last_source),
                 );
-                let library = format!("{source}:{name}");
+                let library = ContractName::full_path(source.as_str(), name);
                 let instance = instances
                     .get(library.as_str())
                     .ok_or_else(|| anyhow::anyhow!("Library `{library}` not found"))?;

--- a/solx-utils/src/contract_name.rs
+++ b/solx-utils/src/contract_name.rs
@@ -30,7 +30,7 @@ impl ContractName {
     ///
     pub fn new(path: String, name: Option<String>) -> Self {
         let full_path = match name.as_ref() {
-            Some(name) => format!("{path}:{name}"),
+            Some(name) => Self::full_path(path.as_str(), name),
             None => path.clone(),
         };
 
@@ -39,6 +39,13 @@ impl ContractName {
             name,
             full_path,
         }
+    }
+
+    ///
+    /// Builds the full identifier of a named contract: `<path>:<name>`.
+    ///
+    pub fn full_path(path: &str, name: &str) -> String {
+        format!("{path}:{name}")
     }
 
     ///

--- a/solx-utils/src/libraries.rs
+++ b/solx-utils/src/libraries.rs
@@ -4,6 +4,8 @@
 
 use std::collections::BTreeMap;
 
+use crate::ContractName;
+
 ///
 /// The unified representation of Solidity libraries.
 ///
@@ -24,7 +26,7 @@ impl Libraries {
         let mut linker_symbols = BTreeMap::new();
         for (file, contracts) in self.inner.iter() {
             for (name, address) in contracts.iter() {
-                let path = format!("{file}:{name}");
+                let path = ContractName::full_path(file, name);
 
                 let address_stripped = address.strip_prefix("0x").unwrap_or(address.as_str());
                 let address_vec = hex::decode(address_stripped).map_err(|error| {


### PR DESCRIPTION
Makes slang-ast tester measurement honest:

- The deploy target is resolved from the Slang AST in source order over all three deployable node types (contract, library, interface), replacing the alphabetical pick that deployed the wrong contract in multi-contract sources; failed resolution is now an error instead of a fallback.
- Tests the Slang frontend cannot reproduce are filtered out: `pragma abicoder v1` sources (Slang always encodes v2) and the Yul test tree. All additions are gated on `slang-ast`; the default tester is unchanged.
- The `<path>:<name>` contract identifier is owned by `ContractName::full_path` and routed through it at all tester call sites.