### PR TITLE
chore: bump Rust toolchain to 1.97.1

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # ── LLVM 21 (system toolchain for coverage, sanitizers, lipo) ────────────────
 # llvm-cov / llvm-profdata must read the profraw format emitted by
-# instrumented Rust binaries. rustc 1.96.1 embeds LLVM 22 — one major ahead
+# instrumented Rust binaries. rustc 1.97.1 embeds LLVM 22 — one major ahead
 # of these tools — but still emits format versions LLVM 21 reads. Re-check on
 # every toolchain bump: a format bump breaks the coverage job with an opaque
 # profdata error.
@@ -182,7 +182,7 @@ RUN curl -fsSL -o valgrind-${VALGRIND_VERSION}.tar.bz2 \
 # weight in the dev image. rust-src serves the -Zbuild-std actions
 # (build-rust, rust-unit-tests). On a bump, re-check the LLVM section
 # comment in base (rustc's embedded LLVM major moves).
-ARG RUST_VERSION=1.96.1
+ARG RUST_VERSION=1.97.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile default \
     && . "$HOME/.cargo/env" \

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -38,10 +38,10 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
           - name: "Windows"
             runner: windows-2025
     runs-on: ${{ matrix.runner }}
@@ -117,10 +117,10 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
           - name: "Windows"
             runner: windows-2025
     runs-on: ${{ matrix.runner }}
@@ -175,7 +175,7 @@ jobs:
   warm-llvm-sanitizer:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       volumes: *free-disk-volumes
     name: "LLVM · Sanitizer"
     steps:
@@ -216,7 +216,7 @@ jobs:
   warm-llvm-coverage:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       volumes: *free-disk-volumes
     name: "LLVM · Coverage"
     steps:
@@ -258,7 +258,7 @@ jobs:
   warm-llvm-integration:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       volumes: *free-disk-volumes
     name: "LLVM + solc · Integration"
     steps:

--- a/.github/workflows/compile-benchmark.yaml
+++ b/.github/workflows/compile-benchmark.yaml
@@ -55,7 +55,7 @@ jobs:
     # once the queue clears.
     runs-on: solx-linux-amd64
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       options: -m 110g
     # Warm caches: ~10 min builds + ~20 min benchmark. Worst case: a PR that
     # bumps solx-llvm (or its build scripts) builds both the PR and main LLVM

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -44,7 +44,7 @@ jobs:
       pull-requests: write
       packages: read
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
     env:
       BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
       SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -50,7 +50,7 @@ jobs:
       packages: read
     runs-on: solx-linux-amd64-self-hosted
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       options: -m 110g
     steps:
       - name: Checkout PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,8 +115,8 @@ jobs:
           WINDOWS='{"name":"Windows","runner":"windows-2025","release-suffix":"windows-amd64-gnu"}'
           MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-15-intel","release-suffix":"macosx-amd64"}'
           MACOS_ARM64='{"name":"MacOS-arm64","runner":"macos-15","release-suffix":"macosx-arm64"}'
-          LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"ubuntu-24.04","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
-          LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"ubuntu-24.04-arm","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
+          LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"ubuntu-24.04","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
+          LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"ubuntu-24.04-arm","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
           # Disable platforms for non-tag builds if user requested
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ] && [ "${GITHUB_REF_TYPE}" != tag ]; then
             [ "${{ github.event.inputs.release_windows_amd64 }}" != true ] && WINDOWS=
@@ -227,7 +227,7 @@ jobs:
     name: Prepare release bundle
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
     needs: [build]
     outputs:
       release_title: ${{ steps.release.outputs.release_title }}

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: [label-check, cooldown-check]
     runs-on: solx-linux-amd64-self-hosted
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       options: -m 110g
     env:
       TARGET: x86_64-unknown-linux-gnu

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -50,11 +50,11 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
             target: "x86_64-unknown-linux-gnu"
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
             target: "aarch64-unknown-linux-gnu"
           - name: "Windows"
             runner: windows-2025

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+      image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       # Host tooling bind-mounted so the free-disk-space-linux action can reclaim
       # ~24 GB before the cold LLVM build fills the runner's 14 GB budget.
       # Anchor shared with build-and-test below; keep in sync with the
@@ -193,11 +193,11 @@ jobs:
             runner: macos-15
           - name: "Linux x86 gnu"
             runner: ubuntu-24.04
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
             target: "x86_64-unknown-linux-gnu"
           - name: "Linux ARM64 gnu"
             runner: ubuntu-24.04-arm
-            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:2c8db6eea1393f7b1824d632597f9ac3f8ca7ae34d63b301e80c11a13d896583
+            image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
             target: "aarch64-unknown-linux-gnu"
           - name: "Windows"
             runner: windows-2025

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ cargo build --release
 
 ## Code Conventions
 
-- Rust edition 2024, toolchain 1.96.0
+- Rust edition 2024, toolchain 1.97.1
 - `missing_docs` warning is enabled globally — all public items need doc comments
 - Release builds strip debug symbols (`strip = true`)
 - macOS minimum deployment target: 11.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.96.1"
+channel = "1.97.1"


### PR DESCRIPTION
Closes #547.

Bumps the pinned Rust toolchain to **1.97.1**, which carries the upstream LLVM fix for the enum-niche miscompilation that was crashing `solx-tester` on macOS x86-64.

# Claude summary

## Why

`solx-tester` is killed by SIGSEGV within seconds on **macOS x86-64** whenever it processes the Ethereum semantic-test corpus. The root cause is not in solx: it's a rustc/LLVM enum-niche miscompilation present in 1.95/1.96 ([rust-lang/rust#159035](https://github.com/rust-lang/rust/issues/159035), P-critical `I-miscompile`), resolved by the LLVM point-bump in the **1.97.1** release. See #547 for the full autopsy (lldb crash site, toolchain probes showing 1.95/1.96 crash and fixed-LLVM nightly clean).

No source changes are needed — this is a toolchain pin bump.

## What changed

| File | Change |
|---|---|
| `rust-toolchain.toml` | `1.96.1` → `1.97.1` (drives native runners; resolves lazily in-container) |
| `.github/docker/Dockerfile` | `ARG RUST_VERSION` → `1.97.1`, keeping the baked CI-image toolchain aligned with the pin; updated the adjacent LLVM comment |
| `CLAUDE.md` | toolchain line |

## Coverage-job safety check

The Dockerfile comment flags that the coverage job's `llvm-cov`/`llvm-profdata` (system LLVM 21) must read the profraw format emitted by instrumented binaries. 1.97.1 embeds **LLVM 22.1.6** vs 1.96.1's **22.1.2** — same major, so the profraw format compatibility is unchanged. No coverage-tooling bump required.

## CI runner image

This PR also bumps `ARG RUST_VERSION`, so the `solx-ci-runner` image is rebuilt and the pinned digest repinned across the workflows that run in-container:

- [ ] Rebuild the image (`docker-ci-image.yaml`) and repin the runner digest (currently `sha256:2c8db6ea…3d896583`, 19 references across `sanitizer`, `test`, `release`, `integration-tests`, `compile-benchmark`, `slang-tests`, `cache-warmup`, `coverage`).

Until the repin lands, in-container jobs still get 1.97.1 — the container resolves `rust-toolchain.toml` lazily on first use — at the cost of a per-job toolchain download.

## Verification

- [ ] Green on the `mac-tester-debug` `macos-15-large` leg with the real 1.97.1 toolchain (no nightly hack) — confirms the Intel SIGSEGV is gone (#547 checklist).
- Local `cargo check` is green under 1.97.1 for the core crates + `solx-codegen-evm`.
