### PR TITLE
feat(slang): complete literal and value-type conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2595,7 +2595,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "melior"
 version = "0.26.9"
-source = "git+https://github.com/NomicFoundation/melior?rev=193e8252ca5d2774555b3e2f29ec8b97f28f5d38#193e8252ca5d2774555b3e2f29ec8b97f28f5d38"
+source = "git+https://github.com/NomicFoundation/melior?rev=52fa2611004e9553803de8dd5e6d44bb327af2da#52fa2611004e9553803de8dd5e6d44bb327af2da"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "melior-macro"
 version = "0.19.5"
-source = "git+https://github.com/NomicFoundation/melior?rev=193e8252ca5d2774555b3e2f29ec8b97f28f5d38#193e8252ca5d2774555b3e2f29ec8b97f28f5d38"
+source = "git+https://github.com/NomicFoundation/melior?rev=52fa2611004e9553803de8dd5e6d44bb327af2da#52fa2611004e9553803de8dd5e6d44bb327af2da"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -13,7 +13,7 @@ cc = "1.2.60"
 anyhow.workspace = true
 clap.workspace = true
 num.workspace = true
-melior = { git = "https://github.com/NomicFoundation/melior", rev = "193e8252ca5d2774555b3e2f29ec8b97f28f5d38", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "52fa2611004e9553803de8dd5e6d44bb327af2da", features = ["ods-dialects", "helpers"] }
 serde.workspace = true
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -20,8 +20,8 @@ sol_ops! {
     Value::constant(value: i64, result_type: ty) -> value {
         ConstantOperation.value(int_attr(value, result_type)).result(result_type)
     }
-    Value::string_literal(text: str) -> value {
-        StringLitOperation.value(str_attr(text)).addr(memory())
+    Value::string_literal(text: bytes) -> value {
+        StringLitOperation.value(bytes_attr(text)).addr(memory())
     }
     Value::array_literal(elements: values, array_type: ty) -> value {
         ArrayLitOperation.ins(many(elements)).addr(array_type)

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -47,6 +47,15 @@ impl<'context> Type<'context> {
         Self::new(MlirType::from(IntegerType::signed(context, bits as u32)))
     }
 
+    /// The integer type of `bits`, `si<bits>` or `ui<bits>` as `is_signed` selects.
+    pub fn integer(context: &'context melior::Context, bits: usize, is_signed: bool) -> Self {
+        if is_signed {
+            Self::signed(context, bits)
+        } else {
+            Self::unsigned(context, bits)
+        }
+    }
+
     /// The boolean type: a signless `i1`.
     pub fn boolean(context: &'context melior::Context) -> Self {
         Self::new(MlirType::from(IntegerType::new(

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -5,6 +5,7 @@
 use melior::ir::Value as MlirValue;
 use melior::ir::ValueLike;
 use num::BigInt;
+use num::bigint::Sign;
 
 use crate::CmpPredicate;
 use crate::Context;
@@ -58,31 +59,59 @@ impl<'context> Value<'context> {
         Self::constant(i64::from(value), Type::boolean(context.melior), context)
     }
 
-    /// Coerces to `target_type` under Solidity's implicit conversions; a no-op at the target type. A
-    /// bytes-like target reinterprets via `sol.bytes_cast`; every other target is a `sol.cast`.
+    /// Materialises the `bytesN` constant of a string or hex literal: `bytes` left-aligned in
+    /// `target_type`'s width, right-zero-padded, built as the unsigned integer of that width and
+    /// reinterpreted with `sol.bytes_cast`.
+    pub fn left_aligned_bytes(
+        mut bytes: Vec<u8>,
+        target_type: Type<'context>,
+        context: &Context<'context>,
+    ) -> Self {
+        bytes.resize(target_type.bytes_like_width() as usize, 0);
+        let integer = Self::constant_from_bigint(
+            &BigInt::from_bytes_be(Sign::Plus, &bytes),
+            Type::unsigned(context.melior, bytes.len() * solx_utils::BIT_LENGTH_BYTE),
+            context,
+        );
+        integer.bytes_cast(target_type, context)
+    }
+
+    /// Coerces to `target_type` under Solidity's implicit conversions.
     pub fn coerce(self, target_type: Type<'context>, context: &Context<'context>) -> Self {
         if self.r#type() == target_type {
             return self;
         }
-        if target_type.is_bytes_like() {
+        if self.r#type().is_bytes_like() {
             return self.bytes_cast(target_type, context);
+        }
+        if target_type.is_bytes_like() {
+            let integer_type = Type::unsigned(
+                context.melior,
+                target_type.bytes_like_width() as usize * solx_utils::BIT_LENGTH_BYTE,
+            );
+            return self
+                .cast(integer_type, context)
+                .bytes_cast(target_type, context);
         }
         self.cast(target_type, context)
     }
 
-    /// Converts to `target_type` under an explicit `T(x)` cast the binder has admitted. An address
-    /// target truncates an integer operand to `ui160` before `sol.address_cast` — the conversion
-    /// Solidity forbids implicitly, hence its home here rather than in `coerce`; every other target
-    /// shares `coerce`'s dispatch.
-    pub fn convert(self, target_type: Type<'context>, context: &Context<'context>) -> Self {
+    /// Converts to `target_type` under an explicit `T(x)` cast.
+    pub fn convert(mut self, target_type: Type<'context>, context: &Context<'context>) -> Self {
+        if self.r#type() == target_type {
+            return self;
+        }
+        if self.r#type().is_address() {
+            return self.address_cast(target_type, context);
+        }
         if target_type.is_address() {
-            let truncated = if self.r#type().is_integer() {
-                let ui160 = Type::unsigned(context.melior, solx_utils::BIT_LENGTH_ETH_ADDRESS);
-                self.cast(ui160, context)
-            } else {
-                self
-            };
-            return truncated.address_cast(target_type, context);
+            if self.r#type().is_integer() {
+                self = self.cast(
+                    Type::unsigned(context.melior, solx_utils::BIT_LENGTH_ETH_ADDRESS),
+                    context,
+                );
+            }
+            return self.address_cast(target_type, context);
         }
         self.coerce(target_type, context)
     }

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -177,7 +177,7 @@ impl<'slice, T, const N: usize> IntoOds<&'slice [T]> for &'slice [T; N] {
 /// `self`, or a closed keyword. Keywords are call-shaped, so a bare identifier is always a parameter:
 /// result types `field()` / `address()` / `boolean()` / `memory()` / `calldata()` / `fixed_bytes(N)`
 /// / `ptr(pointee, stack)`; the receiver-derived `self` / `self_ty` / `gep_of(elem)`; attributes
-/// `int_attr` / `str_attr` / `symbol_attr` / `predicate_attr` / `ty_attr` / `count_attr`; variadic
+/// `int_attr` / `str_attr` / `bytes_attr` / `symbol_attr` / `predicate_attr` / `ty_attr` / `count_attr`; variadic
 /// operands `single` / `many` / `concat`; conditional setters `optional_str` / `optional_value`; the
 /// always-set unit flag `unit_flag`. The operation slot may be `checked(CheckedOp, UncheckedOp)`,
 /// which threads a `checked: bool` selector.
@@ -195,11 +195,12 @@ impl<'slice, T, const N: usize> IntoOds<&'slice [T]> for &'slice [T; N] {
 macro_rules! sol_ops {
     () => {};
 
-    (@ty value) => { $crate::Value<'context> };
-    (@ty ty) => { $crate::Type<'context> };
-    (@ty str) => { &str };
     (@ty i64) => { i64 };
+    (@ty str) => { &str };
+    (@ty bytes) => { &[u8] };
+    (@ty value) => { $crate::Value<'context> };
     (@ty values) => { &[$crate::Value<'context>] };
+    (@ty ty) => { $crate::Type<'context> };
     (@ty predicate) => { $crate::CmpPredicate };
     (@ty optional_str) => { ::core::option::Option<&str> };
     (@ty optional_value) => { ::core::option::Option<$crate::Value<'context>> };
@@ -238,6 +239,9 @@ macro_rules! sol_ops {
     };
     (@arg [$context:ident] [$receiver:tt] str_attr($text:ident)) => {
         ::melior::ir::attribute::StringAttribute::new($context.melior, $text)
+    };
+    (@arg [$context:ident] [$receiver:tt] bytes_attr($bytes:ident)) => {
+        ::melior::ir::attribute::StringAttribute::from_bytes($context.melior, $bytes)
     };
     (@arg [$context:ident] [$receiver:tt] symbol_attr($name:ident)) => {
         ::melior::ir::attribute::FlatSymbolRefAttribute::new($context.melior, $name)

--- a/solx-mlir/tests/lit/address_cast.sol
+++ b/solx-mlir/tests/lit/address_cast.sol
@@ -1,12 +1,57 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
+// CHECK: sol.func @{{.*identity.*}}
+// CHECK-NOT: address_cast
+
+// CHECK: sol.func @{{.*address_to_u160.*}}
+// CHECK:   sol.address_cast %{{.*}} : !sol.address to ui160
+
+// CHECK: sol.func @{{.*address_to_u256.*}}
+// CHECK:   sol.address_cast %{{.*}} : !sol.address to ui160
+// CHECK:   sol.cast %{{.*}} : ui160 to ui256
+
+// CHECK: sol.func @{{.*address_to_bytes20.*}}
+// CHECK:   sol.address_cast %{{.*}} : !sol.address to !sol.fixedbytes<20>
+
 // CHECK: sol.func @{{.*to_address.*}}
 // CHECK:   sol.cast %{{.*}} : ui256 to ui160
 // CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
 
+// CHECK: sol.func @{{.*u160_to_address.*}}
+// CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
+
+// CHECK: sol.func @{{.*literal_to_address.*}}
+// CHECK:   sol.constant 0 : ui8
+// CHECK:   sol.cast %{{.*}} : ui8 to ui160
+// CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
+
 contract C {
+    function identity(address a) public pure returns (address) {
+        return address(a);
+    }
+
+    function address_to_u160(address a) public pure returns (uint160) {
+        return uint160(a);
+    }
+
+    function address_to_u256(address a) public pure returns (uint256) {
+        return uint256(uint160(a));
+    }
+
+    function address_to_bytes20(address a) public pure returns (bytes20) {
+        return bytes20(a);
+    }
+
     function to_address(uint256 x) public pure returns (address) {
         return address(uint160(x));
+    }
+
+    function u160_to_address(uint160 u) public pure returns (address) {
+        return address(u);
+    }
+
+    function literal_to_address() public pure returns (address) {
+        return address(0);
     }
 }

--- a/solx-mlir/tests/lit/comparison.sol
+++ b/solx-mlir/tests/lit/comparison.sol
@@ -16,6 +16,11 @@
 // CHECK: sol.func @{{.*eq_address.*}}
 // CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : !sol.address
 
+// CHECK: sol.func @{{.*eq_string_literal.*}}
+// CHECK:   sol.constant 1633837924 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : !sol.fixedbytes<4>
+
 // CHECK: sol.func @{{.*ne.*}}
 // CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : ui256
 
@@ -86,6 +91,10 @@ contract C {
 
     function eq_address(address a, address b) public pure returns (bool) {
         return a == b;
+    }
+
+    function eq_string_literal(bytes4 x) public pure returns (bool) {
+        return x == "abcd";
     }
 
     function ne(uint256 a, uint256 b) public pure returns (bool) {

--- a/solx-mlir/tests/lit/conditional.sol
+++ b/solx-mlir/tests/lit/conditional.sol
@@ -1,7 +1,7 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*ternary.*}}(%{{.*}}: i1, %{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+// CHECK: sol.func @{{.*ternary_scalar.*}}(%{{.*}}: i1, %{{.*}}: ui256, %{{.*}}: ui256) -> ui256
 // CHECK:   sol.if %{{.*}} {
 // CHECK:     sol.store %{{.*}}, %[[SLOT:.*]] : ui256, !sol.ptr<ui256, Stack>
 // CHECK:   } else {
@@ -9,8 +9,20 @@
 // CHECK:   }
 // CHECK:   sol.load %[[SLOT]] : !sol.ptr<ui256, Stack>, ui256
 
+// CHECK: sol.func @{{.*ternary_string.*}}(%{{.*}}: i1) -> !sol.string<Memory>
+// CHECK:   %[[STR_SLOT:.*]] = sol.alloca : !sol.ptr<!sol.string<Memory>, Stack>
+// CHECK:   sol.if
+// CHECK:     %[[Y:.*]] = sol.string_lit "yes" -> !sol.string<Memory>
+// CHECK:     sol.store %[[Y]], %[[STR_SLOT]] : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
+// CHECK:     %[[N:.*]] = sol.string_lit "no" -> !sol.string<Memory>
+// CHECK:     sol.store %[[N]], %[[STR_SLOT]] : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
+
 contract C {
-    function ternary(bool c, uint256 a, uint256 b) public pure returns (uint256) {
+    function ternary_scalar(bool c, uint256 a, uint256 b) public pure returns (uint256) {
         return c ? a : b;
+    }
+
+    function ternary_string(bool c) public pure returns (string memory) {
+        return c ? "yes" : "no";
     }
 }

--- a/solx-mlir/tests/lit/fixed_point_state_var.sol
+++ b/solx-mlir/tests/lit/fixed_point_state_var.sol
@@ -1,0 +1,13 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// Fixed-point state variables: solc's print-init hits NYI and aborts (UNREACHABLE at SolidityToMLIR.cpp:747), so this is solx-only.
+
+// CHECK: sol.state_var {{.*}}: si128
+// CHECK: sol.state_var {{.*}}: ui128
+// CHECK: sol.state_var {{.*}}: si64
+
+contract C {
+    fixed128x18 a;
+    ufixed128x18 b;
+    fixed64x10 c;
+}

--- a/solx-mlir/tests/lit/function_calls.sol
+++ b/solx-mlir/tests/lit/function_calls.sol
@@ -11,6 +11,18 @@
 // CHECK:   sol.call @{{.*double.*}}
 // CHECK:   sol.call @{{.*add.*}}
 
+// CHECK: sol.func @{{.*literal_argument.*}}
+// CHECK:   sol.constant 1633837924 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK:   sol.call @{{.*literal_receiver.*}}
+
+// CHECK: sol.func @{{.*widening_argument.*}}
+// CHECK:   sol.load %{{.*}}
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.load %{{.*}}
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.call @{{.*add.*}}
+
 contract C {
     function add(uint256 a, uint256 b) public pure returns (uint256) {
         return a + b;
@@ -22,5 +34,15 @@ contract C {
 
     function chain(uint256 x) public pure returns (uint256) {
         return add(double(x), x);
+    }
+
+    function literal_receiver(bytes4 selector) internal pure {}
+
+    function literal_argument() public pure {
+        literal_receiver("abcd");
+    }
+
+    function widening_argument(uint8 a, uint8 b) public pure returns (uint256) {
+        return add(a, b);
     }
 }

--- a/solx-mlir/tests/lit/literal_string_to_byte.sol
+++ b/solx-mlir/tests/lit/literal_string_to_byte.sol
@@ -1,0 +1,18 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*f.*}}()
+// CHECK:   %[[BASE:.*]] = sol.addr_of @{{.*data.*}} : !sol.string<Storage>
+// CHECK:   %[[I:.*]] = sol.constant 0 : ui8
+// CHECK:   %[[P:.*]] = sol.gep %[[BASE]], %[[I]] : !sol.string<Storage>, ui8, !sol.ptr<!sol.byte, Storage>
+// CHECK:   %[[C:.*]] = sol.constant 120 : ui8
+// CHECK:   %[[B:.*]] = sol.bytes_cast %[[C]] : ui8 to !sol.byte
+// CHECK:   sol.store %[[B]], %[[P]] : !sol.byte, !sol.ptr<!sol.byte, Storage>
+
+contract C {
+    bytes data;
+
+    function f() public {
+        data[0] = "x";
+    }
+}

--- a/solx-mlir/tests/lit/literal_types.sol
+++ b/solx-mlir/tests/lit/literal_types.sol
@@ -18,6 +18,34 @@
 // CHECK: sol.func @{{.*scientific.*}}
 // CHECK:   sol.constant 1000000000000000000 : ui64
 
+// CHECK: sol.func @{{.*hex_to_bytes1.*}}
+// CHECK:   sol.constant 18 : ui8
+// CHECK:   sol.bytes_cast %{{.*}} : ui8 to !sol.fixedbytes<1>
+
+// CHECK: sol.func @{{.*hex_to_bytes32.*}}
+// CHECK:   sol.constant 0 : ui8
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+
+// CHECK: sol.func @{{.*hex_to_bytes4.*}}
+// CHECK:   sol.constant 2864434397 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+
+// CHECK: sol.func @{{.*string_to_bytes32.*}}
+// CHECK:   sol.constant 47219736118171679016481614208494153725245902603978864281390662590579859259392 : ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+
+// CHECK: sol.func @{{.*string_literal_to_bytes32.*}}
+// CHECK:   sol.constant 44048180597813453602326562734351324025098966208897425494240603688123167145984 : ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+
+// CHECK: sol.func @{{.*hex_string_to_bytes2.*}}
+// CHECK:   sol.constant 65281 : ui16
+// CHECK:   sol.bytes_cast %{{.*}} : ui16 to !sol.fixedbytes<2>
+
+// CHECK: sol.func @{{.*hex_string_to_bytes_memory.*}}
+// CHECK:   sol.string_lit "\FF\01" -> !sol.string<Memory>
+
 contract C {
     function address_literal() public pure returns (address) {
         return 0x00000000000000000000000000000000000000ff;
@@ -37,5 +65,34 @@ contract C {
 
     function scientific() public pure returns (uint256) {
         return 1e18;
+    }
+
+    function hex_to_bytes1() public pure returns (bytes1) {
+        return 0x12;
+    }
+
+    function hex_to_bytes32() public pure returns (bytes32) {
+        return 0x0;
+    }
+
+    function hex_to_bytes4() public pure returns (bytes4) {
+        return 0xaabbccdd;
+    }
+
+    function string_to_bytes32() public pure returns (bytes32) {
+        bytes32 x = "hello";
+        return x;
+    }
+
+    function string_literal_to_bytes32() public pure returns (bytes32) {
+        return "abc";
+    }
+
+    function hex_string_to_bytes2() public pure returns (bytes2) {
+        return hex"ff01";
+    }
+
+    function hex_string_to_bytes_memory() public pure returns (bytes memory) {
+        return hex"ff01";
     }
 }

--- a/solx-mlir/tests/lit/multi_return.sol
+++ b/solx-mlir/tests/lit/multi_return.sol
@@ -1,17 +1,44 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*pair.*}}
+// CHECK: sol.func @{{.*single_element_tuple.*}}
+// CHECK:   sol.constant 2004384122 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+
+// CHECK: sol.func @{{.*two_constants.*}}
 // CHECK: sol.return %{{.*}}, %{{.*}}
-// CHECK: sol.func @{{.*widen.*}}
+
+// CHECK: sol.func @{{.*widened_elements.*}}
 // CHECK: sol.return %{{.*}}, %{{.*}} : ui256, i1
 
+// CHECK: sol.func @{{.*string_and_constant.*}}
+// CHECK:   sol.constant 1633837924 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK:   sol.return %{{.*}}, %{{.*}} : !sol.fixedbytes<4>, ui256
+
+// CHECK: sol.func @{{.*string_and_variable.*}}
+// CHECK:   sol.constant 1633837924 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK:   sol.return %{{.*}}, %{{.*}} : !sol.fixedbytes<4>, ui256
+
 contract C {
-    function pair() public pure returns (uint256, uint256) {
+    function single_element_tuple() public pure returns (bytes4) {
+        return ("wxyz");
+    }
+
+    function two_constants() public pure returns (uint256, uint256) {
         return (3, 7);
     }
 
-    function widen(uint8 a, bool b) public pure returns (uint256, bool) {
+    function widened_elements(uint8 a, bool b) public pure returns (uint256, bool) {
         return (a, b);
+    }
+
+    function string_and_constant() public pure returns (bytes4, uint256) {
+        return ("abcd", 42);
+    }
+
+    function string_and_variable(uint256 x) public pure returns (bytes4, uint256) {
+        return ("abcd", x);
     }
 }

--- a/solx-mlir/tests/lit/type_casts.sol
+++ b/solx-mlir/tests/lit/type_casts.sol
@@ -10,8 +10,20 @@
 // CHECK: sol.func @{{.*int_to_uint.*}}
 // CHECK:   sol.cast %{{.*}} : si256 to ui256
 
-// CHECK: sol.func @{{.*uint_to_bool.*}}
-// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : ui256
+// CHECK: sol.func @{{.*bytes4_to_int.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : !sol.fixedbytes<4> to ui32
+
+// CHECK: sol.func @{{.*bytes_to_int.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : !sol.fixedbytes<32> to ui256
+
+// CHECK: sol.func @{{.*int_to_bytes.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+
+// CHECK: sol.func @{{.*widen_bytes.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : !sol.fixedbytes<1> to !sol.fixedbytes<4>
+
+// CHECK: sol.func @{{.*narrow_bytes.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : !sol.fixedbytes<32> to !sol.fixedbytes<16>
 
 contract C {
     function uint8_to_uint256(uint8 x) public pure returns (uint256) {
@@ -26,7 +38,23 @@ contract C {
         return uint256(x);
     }
 
-    function uint_to_bool(uint256 x) public pure returns (bool) {
-        return x != 0;
+    function bytes4_to_int(bytes4 x) public pure returns (uint32) {
+        return uint32(x);
+    }
+
+    function bytes_to_int(bytes32 x) public pure returns (uint256) {
+        return uint256(x);
+    }
+
+    function int_to_bytes(uint256 x) public pure returns (bytes32) {
+        return bytes32(x);
+    }
+
+    function widen_bytes(bytes1 x) public pure returns (bytes4) {
+        return bytes4(x);
+    }
+
+    function narrow_bytes(bytes32 x) public pure returns (bytes16) {
+        return bytes16(x);
     }
 }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -399,15 +399,14 @@ impl Call {
         arguments: &PositionalArguments,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
-        let argument_values = scope.positional_arguments(arguments);
         let signature = scope
             .contract
             .source_unit
             .function_signature(function_definition.node_id());
-        let coerced: Vec<Value<'context>> = argument_values
+        let coerced: Vec<Value<'context>> = arguments
             .iter()
             .zip(&signature.parameter_types)
-            .map(|(value, &parameter_type)| value.coerce(parameter_type, scope))
+            .map(|(argument, &parameter_type)| scope.coerced(&argument, parameter_type))
             .collect();
         Function::call(
             &signature.mlir_name,

--- a/solx-slang/src/contract/function/expression/literal.rs
+++ b/solx-slang/src/contract/function/expression/literal.rs
@@ -10,6 +10,11 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
+    /// The `true`/`false` keyword literals.
+    pub fn boolean_literal(&mut self, value: bool) -> Value<'context> {
+        Value::boolean(value, self)
+    }
+
     /// A decimal or hexadecimal integer literal, folded to a constant of the binder's type. The two
     /// literal kinds share this lowering; the enum is matched only to reach the concrete node whose
     /// `integer_value` and `get_type` read different terminals.
@@ -28,16 +33,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         )
     }
 
-    /// The `true`/`false` keyword literals.
-    pub fn boolean_literal(&mut self, value: bool) -> Value<'context> {
-        Value::boolean(value, self)
-    }
-
     /// A string literal, lowered to its Sol dialect string value.
     pub fn string_literal(&mut self, node: &StringExpression) -> Value<'context> {
-        Value::string_literal(
-            &String::from_utf8(node.value()).expect("slang validates string literals are UTF-8"),
-            self,
-        )
+        Value::string_literal(&node.value(), self)
     }
 }

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -118,22 +118,31 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// Emits an expression and coerces its value to `target_type`.
+    /// Emits an expression and coerces its value to `target_type`. A string literal reaching a
+    /// bytes-like target folds to that constant directly, since a materialized `sol.string_lit`
+    /// value cannot be reinterpreted.
     pub fn coerced(
         &mut self,
         expression: &Expression,
         target_type: MlirType<'context>,
     ) -> Value<'context> {
+        if let Expression::StringExpression(literal) = expression
+            && target_type.is_bytes_like()
+        {
+            return Value::left_aligned_bytes(literal.value(), target_type, self);
+        }
         self.expression(expression).coerce(target_type, self)
     }
 
-    /// Emits an expression and converts its value to `target_type` through an explicit `T(x)` cast,
-    /// the explicit sibling of `coerced`.
+    /// Emits an expression and converts its value to `target_type` through an explicit `T(x)` cast.
     pub fn converted(
         &mut self,
         expression: &Expression,
         target_type: MlirType<'context>,
     ) -> Value<'context> {
+        if let Expression::StringExpression(_) = expression {
+            return self.coerced(expression, target_type);
+        }
         self.expression(expression).convert(target_type, self)
     }
 

--- a/solx-slang/src/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/contract/function/statement/control_flow.rs
@@ -5,6 +5,7 @@
 use slang_solidity_v2::ast::BreakStatement;
 use slang_solidity_v2::ast::ContinueStatement;
 use slang_solidity_v2::ast::DoWhileStatement;
+use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::ForStatement;
 use slang_solidity_v2::ast::ForStatementCondition;
 use slang_solidity_v2::ast::ForStatementInitialization;
@@ -96,12 +97,26 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             self.current_block().r#return(&[], self);
             return;
         };
-        let values: Vec<_> = self
-            .expression_values(&expression)
-            .iter()
-            .zip(&self.return_types)
-            .map(|(value, &return_type)| value.coerce(return_type, self))
-            .collect();
+        let values = match &expression {
+            Expression::TupleExpression(tuple) => tuple
+                .items()
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    let element = item.expression().expect("slang validates tuple elements");
+                    self.coerced(&element, self.return_types[index])
+                })
+                .collect(),
+            _ => match self.return_types.as_slice() {
+                &[return_type] => vec![self.coerced(&expression, return_type)],
+                _ => self
+                    .expression_values(&expression)
+                    .iter()
+                    .zip(&self.return_types)
+                    .map(|(value, &return_type)| value.coerce(return_type, self))
+                    .collect(),
+            },
+        };
         self.current_block().r#return(&values, self);
     }
 }

--- a/solx-slang/src/type.rs
+++ b/solx-slang/src/type.rs
@@ -24,14 +24,16 @@ impl<'context> SourceUnitScope<'context> {
         inherited_location: Option<solx_utils::DataLocation>,
     ) -> MlirType<'context> {
         match node {
-            Type::Integer(integer_type) => {
-                let bits = integer_type.bits() as usize;
-                if integer_type.is_signed() {
-                    MlirType::signed(self.melior, bits)
-                } else {
-                    MlirType::unsigned(self.melior, bits)
-                }
-            }
+            Type::Integer(integer_type) => MlirType::integer(
+                self.melior,
+                integer_type.bits() as usize,
+                integer_type.is_signed(),
+            ),
+            Type::FixedPointNumber(fixed_point_type) => MlirType::integer(
+                self.melior,
+                fixed_point_type.bits() as usize,
+                fixed_point_type.is_signed(),
+            ),
             Type::Boolean(_) => MlirType::boolean(self.melior),
             Type::Address(_) => MlirType::address(self.melior, false),
             Type::Literal(literal_type) => match literal_type.kind() {
@@ -46,11 +48,7 @@ impl<'context> SourceUnitScope<'context> {
                         .expect("a literal's bit count fits the address width")
                         .next_multiple_of(solx_utils::BIT_LENGTH_BYTE)
                         .max(solx_utils::BIT_LENGTH_BYTE);
-                    if value.is_negative() {
-                        MlirType::signed(self.melior, bits)
-                    } else {
-                        MlirType::unsigned(self.melior, bits)
-                    }
+                    MlirType::integer(self.melior, bits, value.is_negative())
                 }
                 LiteralKind::HexInteger { bytes, .. } => {
                     let bits = bytes as usize * solx_utils::BIT_LENGTH_BYTE;


### PR DESCRIPTION
Completes literal and value-type conversions on the Slang frontend:

- String, hex-string, and number literals coerce to fixed-bytes targets by folding to a left-aligned constant, rather than materializing an unreinterpretable string.
- Explicit `T(x)` casts cover integer-to-bytes, bytes-to-integer, bytes-to-bytes, and address-to-integer.
- Fixed-point types resolve to their sized integer representation.
