### PR TITLE
feat(slang): complete lvalues and assignment

### DIFF
--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -141,4 +141,8 @@ uint32_t solxBytesLikeTypeWidth(MlirType ty) {
     return mlir::sol::getNumBytes(unwrap(ty));
 }
 
+bool solxIsScalarType(MlirType ty) {
+    return mlir::sol::isScalar(unwrap(ty));
+}
+
 } /* extern "C" */

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -164,6 +164,10 @@ unsafe extern "C" {
     /// Returns the byte width of a bytes-like type.
     pub fn solxBytesLikeTypeWidth(ty: mlir_sys::MlirType) -> u32;
 
+    /// Whether the type is a scalar value type: integer, enum, function reference,
+    /// address-like, or bytes-like.
+    pub fn solxIsScalarType(ty: mlir_sys::MlirType) -> bool;
+
     /// Returns the element type of a non-mapping reference type. For
     /// struct types, `struct_field_idx` selects the member.
     pub fn mlirSolGetEltType(ty: mlir_sys::MlirType, struct_field_idx: u64) -> mlir_sys::MlirType;

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -166,6 +166,9 @@ sol_ops! {
     Place::copy_from(self, value: value) {
         CopyOperation.src(value).dst(self)
     }
+    Place::delete(self) {
+        DeleteOperation.reference(self)
+    }
     Place::gep(self, index: value, element_type: ty) -> place {
         GepOperation.base_addr(self).idx(index).addr(gep_of(element_type))
     }

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -196,6 +196,12 @@ impl<'context> Type<'context> {
         unsafe { ffi::solxBytesLikeTypeWidth(self.inner.to_raw()) }
     }
 
+    /// Whether this is a scalar value type: integer, enum, function reference, address-like, or
+    /// bytes-like.
+    pub fn is_scalar(self) -> bool {
+        unsafe { ffi::solxIsScalarType(self.inner.to_raw()) }
+    }
+
     /// The integer attribute of `value` at this type, built via the arbitrary-width FFI constructor
     /// for values wider than `i64`.
     pub fn integer_attribute(self, value: &BigInt) -> Attribute<'context> {

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -5,6 +5,8 @@
 use melior::ir::Value as MlirValue;
 use melior::ir::ValueLike;
 use num::BigInt;
+use num::One;
+use num::Zero;
 use num::bigint::Sign;
 
 use crate::CmpPredicate;
@@ -23,8 +25,8 @@ pub struct Value<'context> {
 
 impl<'context> Value<'context> {
     /// Materialises a `sol.constant` from an arbitrary-width [`BigInt`] at the type a constant can be
-    /// emitted at — `ui160` for an address, the target type itself otherwise — and converts it to the
-    /// target.
+    /// emitted at, then converts it to the target: `ui160` for an address, the width-matched unsigned
+    /// integer for a bytes-like target, the target type itself otherwise.
     pub fn constant_from_bigint(
         value: &BigInt,
         result_type: Type<'context>,
@@ -32,6 +34,9 @@ impl<'context> Value<'context> {
     ) -> Self {
         let r#type = if result_type.is_address() {
             Type::unsigned(context.melior, solx_utils::BIT_LENGTH_ETH_ADDRESS)
+        } else if result_type.is_bytes_like() {
+            let bits = result_type.bytes_like_width() as usize * solx_utils::BIT_LENGTH_BYTE;
+            Type::unsigned(context.melior, bits)
         } else {
             result_type
         };
@@ -44,14 +49,14 @@ impl<'context> Value<'context> {
         .convert(result_type, context)
     }
 
-    /// Materialises the additive identity `0` of `result_type`.
+    /// Materialises the zero of `result_type`, the default value a Solidity value type carries.
     pub fn zero(result_type: Type<'context>, context: &Context<'context>) -> Self {
-        Self::constant(0, result_type, context)
+        Self::constant_from_bigint(&BigInt::zero(), result_type, context)
     }
 
     /// Materialises the multiplicative identity `1` of `result_type`.
     pub fn one(result_type: Type<'context>, context: &Context<'context>) -> Self {
-        Self::constant(1, result_type, context)
+        Self::constant_from_bigint(&BigInt::one(), result_type, context)
     }
 
     /// Materialises an `i1` boolean constant.

--- a/solx-mlir/tests/lit/conditional.sol
+++ b/solx-mlir/tests/lit/conditional.sol
@@ -17,6 +17,15 @@
 // CHECK:     %[[N:.*]] = sol.string_lit "no" -> !sol.string<Memory>
 // CHECK:     sol.store %[[N]], %[[STR_SLOT]] : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
 
+// CHECK: sol.func @{{.*ternary_statement.*}}
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.call @{{.*effect_a.*}}()
+// CHECK:     sol.yield
+// CHECK:   } else {
+// CHECK:     sol.call @{{.*effect_b.*}}()
+// CHECK:     sol.yield
+// CHECK:   }
+
 contract C {
     function ternary_scalar(bool c, uint256 a, uint256 b) public pure returns (uint256) {
         return c ? a : b;
@@ -24,5 +33,13 @@ contract C {
 
     function ternary_string(bool c) public pure returns (string memory) {
         return c ? "yes" : "no";
+    }
+
+    function effect_a() internal pure {}
+
+    function effect_b() internal pure {}
+
+    function ternary_statement(bool c) public pure {
+        c ? effect_a() : effect_b();
     }
 }

--- a/solx-mlir/tests/lit/delete.sol
+++ b/solx-mlir/tests/lit/delete.sol
@@ -1,0 +1,68 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*delete_array.*}}
+// CHECK:   sol.delete %{{.*}} : !sol.array<? x ui256, Storage>
+
+// CHECK: sol.func @{{.*delete_scalar.*}}
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*delete_bytes.*}}
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.fixedbytes<32>, !sol.ptr<!sol.fixedbytes<32>, Storage>
+
+// CHECK: sol.func @{{.*delete_map_entry.*}}
+// CHECK:   %[[ENTRY:.*]] = sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui8, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %[[ENTRY]] : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*delete_struct.*}}
+// CHECK:   sol.delete %{{.*}} : !sol.struct<(ui256, ui256), Storage>
+
+// CHECK: sol.func @{{.*delete_struct_field.*}}
+// CHECK:   %[[FIELD:.*]] = sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Storage>, ui64, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %[[FIELD]] : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*delete_local.*}}
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
+
+contract C {
+    uint256 scalar;
+    bytes32 word;
+    uint256[] array;
+    mapping(uint256 => uint256) map;
+
+    struct S {
+        uint256 a;
+        uint256 b;
+    }
+
+    S s;
+
+    function delete_array() public {
+        delete array;
+    }
+
+    function delete_scalar() public {
+        delete scalar;
+    }
+
+    function delete_bytes() public {
+        delete word;
+    }
+
+    function delete_map_entry() public {
+        delete map[3];
+    }
+
+    function delete_struct() public {
+        delete s;
+    }
+
+    function delete_struct_field() public {
+        delete s.a;
+    }
+
+    function delete_local(uint256 value) public pure returns (uint256) {
+        delete value;
+        return value;
+    }
+}

--- a/solx-mlir/tests/lit/function_calls.sol
+++ b/solx-mlir/tests/lit/function_calls.sol
@@ -23,6 +23,10 @@
 // CHECK:   sol.cast %{{.*}} : ui8 to ui256
 // CHECK:   sol.call @{{.*add.*}}
 
+// CHECK: sol.func @{{.*tuple_statement.*}}
+// CHECK:   sol.call @{{.*add.*}}
+// CHECK:   sol.call @{{.*double.*}}
+
 contract C {
     function add(uint256 a, uint256 b) public pure returns (uint256) {
         return a + b;
@@ -44,5 +48,9 @@ contract C {
 
     function widening_argument(uint8 a, uint8 b) public pure returns (uint256) {
         return add(a, b);
+    }
+
+    function tuple_statement(uint256 x) public pure {
+        (add(x, x), double(x));
     }
 }

--- a/solx-mlir/tests/lit/increment_decrement.sol
+++ b/solx-mlir/tests/lit/increment_decrement.sol
@@ -1,44 +1,98 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*prefix_inc.*}}
-// CHECK:   %[[OLD:.*]] = sol.load
-// CHECK:   %[[NEW:.*]] = sol.cadd %[[OLD]]
-// CHECK:   sol.store %[[NEW]]
+// CHECK: sol.func @{{.*prefix_increment.*}}
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
 // CHECK:   sol.return %[[NEW]]
 
-// CHECK: sol.func @{{.*postfix_inc.*}}
+// CHECK: sol.func @{{.*postfix_increment.*}}
 // CHECK:   %[[OLD:.*]] = sol.load
-// CHECK:   %[[NEW:.*]] = sol.cadd %[[OLD]]
-// CHECK:   sol.store %[[NEW]]
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
 // CHECK:   sol.return %[[OLD]]
 
-// CHECK: sol.func @{{.*prefix_dec.*}}
-// CHECK:   %[[OLD:.*]] = sol.load
-// CHECK:   %[[NEW:.*]] = sol.csub %[[OLD]]
-// CHECK:   sol.store %[[NEW]]
+// CHECK: sol.func @{{.*prefix_decrement.*}}
+// CHECK:   %[[NEW:.*]] = sol.csub
+// CHECK:   sol.store %[[NEW]], %{{.*}}
 // CHECK:   sol.return %[[NEW]]
 
-// CHECK: sol.func @{{.*postfix_dec.*}}
+// CHECK: sol.func @{{.*postfix_decrement.*}}
 // CHECK:   %[[OLD:.*]] = sol.load
-// CHECK:   %[[NEW:.*]] = sol.csub %[[OLD]]
-// CHECK:   sol.store %[[NEW]]
+// CHECK:   %[[NEW:.*]] = sol.csub
+// CHECK:   sol.store %[[NEW]], %{{.*}}
+// CHECK:   sol.return %[[OLD]]
+
+// CHECK: sol.func @{{.*prefix_field.*}}
+// CHECK:   %[[NEW:.*]] = sol.csub
+// CHECK:   sol.store %[[NEW]], %{{.*}}
+// CHECK:   sol.return %[[NEW]]
+
+// CHECK: sol.func @{{.*prefix_index.*}}
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
+// CHECK:   sol.return %[[NEW]]
+
+// CHECK: sol.func @{{.*postfix_field.*}}
+// CHECK:   %[[OLD:.*]] = sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
+// CHECK:   sol.return %[[OLD]]
+
+// CHECK: sol.func @{{.*postfix_index.*}}
+// CHECK:   %[[OLD:.*]] = sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
+// CHECK:   sol.return %[[OLD]]
+
+// CHECK: sol.func @{{.*parenthesized.*}}
+// CHECK:   %[[OLD:.*]] = sol.load
+// CHECK:   %[[NEW:.*]] = sol.cadd
+// CHECK:   sol.store %[[NEW]], %{{.*}}
 // CHECK:   sol.return %[[OLD]]
 
 contract C {
-    function prefix_inc(uint256 x) public pure returns (uint256) {
+    uint256[] array;
+
+    struct S {
+        uint256 a;
+    }
+
+    S s;
+
+    function prefix_increment(uint256 x) public pure returns (uint256) {
         return ++x;
     }
 
-    function postfix_inc(uint256 x) public pure returns (uint256) {
+    function postfix_increment(uint256 x) public pure returns (uint256) {
         return x++;
     }
 
-    function prefix_dec(uint256 x) public pure returns (uint256) {
+    function prefix_decrement(uint256 x) public pure returns (uint256) {
         return --x;
     }
 
-    function postfix_dec(uint256 x) public pure returns (uint256) {
+    function postfix_decrement(uint256 x) public pure returns (uint256) {
         return x--;
+    }
+
+    function prefix_field() public returns (uint256) {
+        return --s.a;
+    }
+
+    function prefix_index() public returns (uint256) {
+        return ++array[0];
+    }
+
+    function postfix_field() public returns (uint256) {
+        return s.a++;
+    }
+
+    function postfix_index() public returns (uint256) {
+        return array[0]++;
+    }
+
+    function parenthesized(uint256 x) public pure returns (uint256) {
+        return (x)++;
     }
 }

--- a/solx-mlir/tests/lit/local_variables.sol
+++ b/solx-mlir/tests/lit/local_variables.sol
@@ -1,36 +1,47 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*default_init.*}}
-// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
-// CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui256
-// CHECK:   sol.store %[[ZERO]], %[[PTR]] : ui256, !sol.ptr<ui256, Stack>
-// CHECK:   %[[VAL:.*]] = sol.load %[[PTR]] : !sol.ptr<ui256, Stack>, ui256
-// CHECK:   sol.return %[[VAL]] : ui256
+// CHECK: sol.func @{{.*default_uint.*}}
+// CHECK:   sol.constant 0 : ui256
 
-// CHECK: sol.func @{{.*explicit_init.*}}
-// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
-// CHECK:   sol.store %{{.*}}, %[[PTR]] : ui256, !sol.ptr<ui256, Stack>
-// CHECK:   %[[VAL:.*]] = sol.load %[[PTR]] : !sol.ptr<ui256, Stack>, ui256
-// CHECK:   sol.return %[[VAL]] : ui256
+// CHECK: sol.func @{{.*default_address.*}}
+// CHECK:   sol.address_cast %{{.*}} : ui160 to !sol.address
+
+// CHECK: sol.func @{{.*default_bytes.*}}
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+
+// CHECK: sol.func @{{.*default_bool.*}}
+// CHECK:   sol.constant false
+
+// CHECK: sol.func @{{.*explicit_initialize.*}}
+// CHECK:   sol.constant 42
 
 // CHECK: sol.func @{{.*reassign.*}}
-// CHECK:   %[[PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
-// CHECK:   sol.store %arg0, %[[PTR]]
-// CHECK:   %[[V1:.*]] = sol.load %[[PTR]]
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
-// CHECK:   %[[V2:.*]] = sol.load %[[PTR]]
-// CHECK:   sol.store %{{.*}}, %[[PTR]]
-// CHECK:   %[[RET:.*]] = sol.load %[[PTR]]
-// CHECK:   sol.return %[[RET]]
+// CHECK:   sol.cadd
+// CHECK:   sol.cmul
 
 contract C {
-    function default_init() public pure returns (uint256) {
+    function default_uint() public pure returns (uint256) {
         uint256 x;
         return x;
     }
 
-    function explicit_init() public pure returns (uint256) {
+    function default_address() public pure returns (address) {
+        address a;
+        return a;
+    }
+
+    function default_bytes() public pure returns (bytes32) {
+        bytes32 b;
+        return b;
+    }
+
+    function default_bool() public pure returns (bool) {
+        bool f;
+        return f;
+    }
+
+    function explicit_initialize() public pure returns (uint256) {
         uint256 x = 42;
         return x;
     }

--- a/solx-mlir/tests/lit/multi_return.sol
+++ b/solx-mlir/tests/lit/multi_return.sol
@@ -21,6 +21,22 @@
 // CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
 // CHECK:   sol.return %{{.*}}, %{{.*}} : !sol.fixedbytes<4>, ui256
 
+// CHECK: sol.func @{{.*via_call.*}}
+// CHECK: %[[R:[0-9]+]]:2 = sol.call @{{.*two_constants.*}}() : () -> (ui256, ui256)
+// CHECK: sol.return %[[R]]#0, %[[R]]#1 : ui256, ui256
+
+// CHECK: sol.func @{{.*via_conditional.*}}
+// CHECK: sol.if
+// CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
+
+// CHECK: sol.func @{{.*via_conditional_call.*}}
+// CHECK: sol.if
+// CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
+
+// CHECK: sol.func @{{.*via_nested_conditional.*}}
+// CHECK: sol.if
+// CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
+
 contract C {
     function single_element_tuple() public pure returns (bytes4) {
         return ("wxyz");
@@ -40,5 +56,21 @@ contract C {
 
     function string_and_variable(uint256 x) public pure returns (bytes4, uint256) {
         return ("abcd", x);
+    }
+
+    function via_call() public pure returns (uint256, uint256) {
+        return two_constants();
+    }
+
+    function via_conditional(bool c) public pure returns (uint256, uint256) {
+        return c ? (1, 2) : (3, 4);
+    }
+
+    function via_conditional_call(bool c) public pure returns (uint256, uint256) {
+        return c ? two_constants() : two_constants();
+    }
+
+    function via_nested_conditional(bool a, bool b) public pure returns (uint256, uint256) {
+        return a ? (1, 2) : b ? (3, 4) : (5, 6);
     }
 }

--- a/solx-mlir/tests/lit/named_returns.sol
+++ b/solx-mlir/tests/lit/named_returns.sol
@@ -2,19 +2,19 @@
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func @{{.*identity.*}}
-// CHECK:   %[[IN:.*]] = sol.alloca : !sol.ptr<i1, Stack>
-// CHECK:   sol.store %{{.*}}, %[[IN]]
 // CHECK:   %[[OUT:.*]] = sol.alloca : !sol.ptr<i1, Stack>
-// CHECK:   sol.store %{{.*}}, %[[OUT]]
-// CHECK:   sol.load %[[IN]]
 // CHECK:   sol.store %{{.*}}, %[[OUT]]
 // CHECK:   sol.load %[[OUT]]
 // CHECK:   sol.return
 
-// CHECK-LABEL: sol.func @{{.*plus_one.*}}
+// CHECK: sol.func @{{.*plus_one.*}}
 // CHECK:   sol.alloca : !sol.ptr<ui256, Stack>
 // CHECK-NOT: sol.alloca
-// CHECK: sol.return
+// CHECK:   sol.return
+
+// CHECK: sol.func @{{.*named_bytes.*}}
+// CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui32
+// CHECK:   sol.bytes_cast %[[ZERO]] : ui32 to !sol.fixedbytes<4>
 
 contract C {
     function identity(bool _in) public pure returns (bool _out) {
@@ -24,4 +24,6 @@ contract C {
     function plus_one(uint256 x) public pure returns (uint256) {
         return x + 1;
     }
+
+    function named_bytes() public pure returns (bytes4 result) {}
 }

--- a/solx-mlir/tests/lit/reference_assignment.sol
+++ b/solx-mlir/tests/lit/reference_assignment.sol
@@ -1,0 +1,51 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*assign_fixed.*}}
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui256, Memory>, !sol.array<3 x ui256, Storage>
+
+// CHECK: sol.func @{{.*assign_dynamic.*}}
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui8, Memory>, !sol.array<? x ui256, Storage>
+
+// CHECK: sol.func @{{.*assign_string.*}}
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.string<Storage>
+
+// CHECK: sol.func @{{.*assign_struct.*}}
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, !sol.struct<(ui256, ui256), Storage>
+
+// CHECK: sol.func @{{.*rebind.*}}
+// CHECK:   sol.length %{{.*}} : !sol.array<? x ui256, Storage>
+
+contract C {
+    uint256[3] fixed_array;
+    uint256[] dynamic_array;
+    string text;
+
+    struct S {
+        uint256 a;
+        uint256 b;
+    }
+
+    S s;
+
+    function assign_fixed(uint256 value) public {
+        fixed_array = [value, 2, 3];
+    }
+
+    function assign_dynamic() public {
+        dynamic_array = [1, 2, 3];
+    }
+
+    function assign_string() public {
+        text = "abc";
+    }
+
+    function assign_struct(uint256 value) public {
+        s = S(value, 2);
+    }
+
+    function rebind() public view returns (uint256) {
+        uint256[] storage pointer = dynamic_array;
+        return pointer.length;
+    }
+}

--- a/solx-mlir/tests/lit/tuple_assignment.sol
+++ b/solx-mlir/tests/lit/tuple_assignment.sol
@@ -1,0 +1,62 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*assign_from_call.*}}
+// CHECK:   %[[R:.*]]:2 = sol.call @{{.*two.*}}()
+// CHECK:   sol.store %[[R]]#0, %{{.*}}
+// CHECK:   sol.store %[[R]]#1, %{{.*}}
+
+// CHECK: sol.func @{{.*swap.*}}
+// CHECK:   %[[V0:.*]] = sol.load
+// CHECK:   %[[V1:.*]] = sol.load
+// CHECK:   sol.store %[[V0]], %{{.*}}
+// CHECK:   sol.store %[[V1]], %{{.*}}
+
+// CHECK: sol.func @{{.*conditional_right.*}}
+// CHECK:   sol.if
+// CHECK:   sol.store %{{.*}}, %[[A:.*]] : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   sol.store %{{.*}}, %[[B:.*]] : ui256, !sol.ptr<ui256, Stack>
+
+// CHECK: sol.func @{{.*parenthesized.*}}
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
+
+// CHECK: sol.func @{{.*reference_element.*}}
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui256, Memory>, !sol.array<? x ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
+
+contract C {
+    uint256[] array;
+
+    function two() internal pure returns (uint256, uint256) {
+        return (1, 2);
+    }
+
+    function assign_from_call() public pure returns (uint256) {
+        uint256 a;
+        uint256 b;
+        (a, b) = two();
+        return a + b;
+    }
+
+    function swap(uint256 x, uint256 y) public pure returns (uint256, uint256) {
+        (x, y) = (y, x);
+        return (x, y);
+    }
+
+    function conditional_right(bool f) public pure returns (uint256, uint256) {
+        uint256 a;
+        uint256 b;
+        (a, b) = f ? (1, 2) : (3, 4);
+        return (a, b);
+    }
+
+    function parenthesized(uint256 x) public pure returns (uint256) {
+        (x) = 7;
+        return x;
+    }
+
+    function reference_element() public {
+        uint256 x;
+        (array, x) = ([uint256(1), 2, 3], 5);
+    }
+}

--- a/solx-mlir/tests/lit/tuple_assignment_blank.sol
+++ b/solx-mlir/tests/lit/tuple_assignment_blank.sol
@@ -1,0 +1,15 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// solc emits nothing for a file containing a blank tuple target, so this case is checked for solx
+// only. TODO: fold into tuple_assignment.sol once solc's MLIR backend compiles blank targets.
+
+// CHECK: sol.func @{{.*blank.*}}
+// CHECK: sol.cast %c7_ui8
+
+contract C {
+    function blank() public pure returns (uint256) {
+        uint256 a;
+        (a, ) = (7, 8);
+        return a;
+    }
+}

--- a/solx-mlir/tests/lit/tuple_assignment_nested.sol
+++ b/solx-mlir/tests/lit/tuple_assignment_nested.sol
@@ -1,0 +1,30 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// solc drops an inner element of a parenthesized or nested tuple assignment target, so these cases
+// are checked for solx only. TODO: add solc's RUN line once its MLIR backend stops dropping them.
+
+// CHECK: sol.func @{{.*parenthesized_swap.*}}
+// CHECK:   %[[B:.*]] = sol.load
+// CHECK:   %[[A:.*]] = sol.load
+// CHECK:   sol.store %[[B]], %{{.*}}
+// CHECK:   sol.store %[[A]], %{{.*}}
+
+// CHECK: sol.func @{{.*nested.*}}
+// CHECK:   sol.cast %c1_ui8
+// CHECK:   sol.cast %c2_ui8
+// CHECK:   sol.cast %c3_ui8
+
+contract C {
+    function parenthesized_swap(uint256 a, uint256 b) public pure returns (uint256, uint256) {
+        ((a, b)) = (b, a);
+        return (a, b);
+    }
+
+    function nested() public pure returns (uint256, uint256, uint256) {
+        uint256 a;
+        uint256 b;
+        uint256 c;
+        ((a, b), c) = ((1, 2), 3);
+        return (a, b, c);
+    }
+}

--- a/solx-mlir/tests/lit/tuple_destructuring.sol
+++ b/solx-mlir/tests/lit/tuple_destructuring.sol
@@ -15,9 +15,19 @@
 // CHECK: sol.alloca
 // CHECK-NEXT: sol.store %{{[0-9]+}}
 
+// CHECK: sol.func @{{.*literal_fold.*}}
+// CHECK: sol.constant 1633837924
+// CHECK: sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+// CHECK: sol.cast %{{.*}} : ui8 to ui256
+
 contract C {
     function sum(uint256 x, uint256 y, uint256 z) public pure returns (uint256) {
         (uint256 a, uint256 b, uint256 c) = (x, y, z);
         return a + b + c;
+    }
+
+    function literal_fold() public pure returns (bytes4, uint256) {
+        (bytes4 p, uint256 q) = ("abcd", 42);
+        return (p, q);
     }
 }

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -18,7 +18,16 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     pub fn assignment(&mut self, node: &AssignmentExpression) -> Option<Value<'context>> {
         let places = self.expression_places(&node.left_operand());
         if places.len() > 1 {
-            let values = self.expression_values(&node.right_operand());
+            let targets: Vec<_> = places
+                .iter()
+                .map(|&element| {
+                    let Some((place, element_type)) = element else {
+                        return None;
+                    };
+                    (place.r#type() != element_type).then_some(element_type)
+                })
+                .collect();
+            let values = self.coerced_values(&node.right_operand(), &targets);
             for (place, value) in places.into_iter().zip(values) {
                 let Some((place, element_type)) = place else {
                     continue;
@@ -26,7 +35,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 if place.r#type() == element_type {
                     place.copy_from(value, self);
                 } else {
-                    place.store(value.coerce(element_type, self), self);
+                    place.store(value, self);
                 }
             }
             return None;

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -10,17 +10,46 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// Plain `=` and the compound `op=` forms, lowered through the left operand's place. The right
-    /// operand is evaluated before the place's old value is read; `=` coerces and stores it without
-    /// the read-modify load, a shift compound keeps it at its own type, and every other compound
-    /// coerces it to the place's type.
-    pub fn assignment(&mut self, node: &AssignmentExpression) -> Value<'context> {
-        let (place, element_type) = self.expression_place(&node.left_operand());
-        if place.r#type() == element_type {
-            unimplemented!(
-                "assignment through a reference-typed place in storage or calldata is not yet supported"
-            );
+    /// `lhs = rhs` and the compound `lhs op= rhs`. A multi-element tuple left operand destructures and
+    /// yields nothing, tuple assignment being value-less; every other form yields the stored value. A
+    /// reference-typed place is its own address and takes a `sol.copy` of the right operand, which
+    /// bridges both its type and its data location. A shift compound keeps its right operand at its
+    /// own type, every other form coerces it to the place's type.
+    pub fn assignment(&mut self, node: &AssignmentExpression) -> Option<Value<'context>> {
+        let places = self.expression_places(&node.left_operand());
+        if places.len() > 1 {
+            let values = self.expression_values(&node.right_operand());
+            for (place, value) in places.into_iter().zip(values) {
+                let Some((place, element_type)) = place else {
+                    continue;
+                };
+                if place.r#type() == element_type {
+                    place.copy_from(value, self);
+                } else {
+                    place.store(value.coerce(element_type, self), self);
+                }
+            }
+            return None;
         }
+
+        let (place, element_type) = places
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("an assignment target denotes a place");
+
+        if place.r#type() == element_type {
+            let source = self.expression(&node.right_operand());
+            place.copy_from(source, self);
+            return Some(Value::from(place));
+        }
+
+        if let AssignmentExpressionOperator::Equal(_) = node.operator() {
+            let value = self.coerced(&node.right_operand(), element_type);
+            place.store(value, self);
+            return Some(value);
+        }
+
         let rhs = match node.operator() {
             AssignmentExpressionOperator::LessThanLessThanEqual(_)
             | AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => {
@@ -28,44 +57,28 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             }
             _ => self.coerced(&node.right_operand(), element_type),
         };
-        let stored =
-            match node.operator() {
-                AssignmentExpressionOperator::Equal(_) => rhs,
-                AssignmentExpressionOperator::PlusEqual(_) => {
-                    place.load(element_type, self).add(rhs, self.checked, self)
-                }
-                AssignmentExpressionOperator::MinusEqual(_) => place
-                    .load(element_type, self)
-                    .subtract(rhs, self.checked, self),
-                AssignmentExpressionOperator::AsteriskEqual(_) => place
-                    .load(element_type, self)
-                    .multiply(rhs, self.checked, self),
-                AssignmentExpressionOperator::SlashEqual(_) => place
-                    .load(element_type, self)
-                    .divide(rhs, self.checked, self),
-                AssignmentExpressionOperator::PercentEqual(_) => {
-                    place.load(element_type, self).remainder(rhs, self)
-                }
-                AssignmentExpressionOperator::AmpersandEqual(_) => {
-                    place.load(element_type, self).bitand(rhs, self)
-                }
-                AssignmentExpressionOperator::BarEqual(_) => {
-                    place.load(element_type, self).bitor(rhs, self)
-                }
-                AssignmentExpressionOperator::CaretEqual(_) => {
-                    place.load(element_type, self).bitxor(rhs, self)
-                }
-                AssignmentExpressionOperator::LessThanLessThanEqual(_) => {
-                    place.load(element_type, self).shl(rhs, self)
-                }
-                AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => {
-                    place.load(element_type, self).shr(rhs, self)
-                }
-                AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(_) => {
-                    unreachable!("Solidity has no >>> operator")
-                }
-            };
-        place.store(stored, self);
-        stored
+        let current = place.load(element_type, self);
+        let assigned = match node.operator() {
+            AssignmentExpressionOperator::PlusEqual(_) => current.add(rhs, self.checked, self),
+            AssignmentExpressionOperator::MinusEqual(_) => {
+                current.subtract(rhs, self.checked, self)
+            }
+            AssignmentExpressionOperator::AsteriskEqual(_) => {
+                current.multiply(rhs, self.checked, self)
+            }
+            AssignmentExpressionOperator::SlashEqual(_) => current.divide(rhs, self.checked, self),
+            AssignmentExpressionOperator::PercentEqual(_) => current.remainder(rhs, self),
+            AssignmentExpressionOperator::AmpersandEqual(_) => current.bitand(rhs, self),
+            AssignmentExpressionOperator::BarEqual(_) => current.bitor(rhs, self),
+            AssignmentExpressionOperator::CaretEqual(_) => current.bitxor(rhs, self),
+            AssignmentExpressionOperator::LessThanLessThanEqual(_) => current.shl(rhs, self),
+            AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => current.shr(rhs, self),
+            AssignmentExpressionOperator::Equal(_)
+            | AssignmentExpressionOperator::GreaterThanGreaterThanGreaterThanEqual(_) => {
+                unreachable!("`=` is handled above and Solidity has no `>>>`")
+            }
+        };
+        place.store(assigned, self);
+        Some(assigned)
     }
 }

--- a/solx-slang/src/contract/function/expression/conditional.rs
+++ b/solx-slang/src/contract/function/expression/conditional.rs
@@ -3,23 +3,77 @@
 //!
 
 use slang_solidity_v2::ast::ConditionalExpression;
+use slang_solidity_v2::ast::Type as SlangType;
 
+use solx_mlir::Place;
+use solx_mlir::Type;
 use solx_mlir::Value;
 
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// The ternary conditional operator: neither operand short-circuits, so there is no initializer
-    /// and both arms store their evaluated operand.
-    pub fn conditional(&mut self, node: &ConditionalExpression) -> Value<'context> {
-        let result_type = self.typing(node.get_type());
+    /// The ternary conditional operator, lowered to a branch on the condition so only the selected
+    /// arm runs. Each arm stores its element values into per-element stack slots, one for a scalar
+    /// result and one per element for a tuple, loaded after the merge.
+    pub fn conditional_values(&mut self, node: &ConditionalExpression) -> Vec<Value<'context>> {
+        let element_types: Vec<Type<'context>> = match node.get_type() {
+            Some(SlangType::Tuple(tuple_type)) => tuple_type
+                .types()
+                .iter()
+                .map(|element_type| self.typing(Some(element_type.clone())))
+                .collect(),
+            Some(scalar) => vec![self.typing(Some(scalar))],
+            // TODO: Slang does not resolve the type of a conditional whose arms differ in shape,
+            // such as a call versus a tuple literal, though the common type is well-defined; remove
+            // this arm once Slang v2 types such conditionals.
+            None => unimplemented!(
+                "conditional with heterogeneously-shaped arms: Slang does not resolve its type"
+            ),
+        };
         let condition = self.expression(&node.operand()).is_nonzero(self);
-        self.branch_value(
-            condition,
-            result_type,
-            |_scope| None,
-            |scope| Some(scope.expression(&node.true_expression())),
-            |scope| Some(scope.expression(&node.false_expression())),
-        )
+        let slots: Vec<Place<'context>> = element_types
+            .iter()
+            .map(|&element_type| Place::stack(element_type, self))
+            .collect();
+        let (then_block, else_block) = self.current_block().branch_with_else(condition, self);
+        for (block, branch) in [
+            (then_block, node.true_expression()),
+            (else_block, node.false_expression()),
+        ] {
+            self.region(block, |scope| {
+                for ((slot, &element_type), value) in slots
+                    .iter()
+                    .zip(&element_types)
+                    .zip(scope.expression_values(&branch))
+                {
+                    slot.store(value.coerce(element_type, scope), scope);
+                }
+            });
+        }
+        slots
+            .iter()
+            .zip(&element_types)
+            .map(|(slot, &element_type)| slot.load(element_type, self))
+            .collect()
+    }
+
+    /// The ternary in single-value position: its sole value.
+    pub fn conditional(&mut self, node: &ConditionalExpression) -> Value<'context> {
+        self.conditional_values(node)
+            .pop()
+            .expect("a conditional yields at least one value")
+    }
+
+    /// The ternary in statement position, its selected arm run for side effects. Void arms carry no
+    /// result type, so this cannot go through `conditional_values`.
+    pub fn conditional_effect(&mut self, node: &ConditionalExpression) {
+        let condition = self.expression(&node.operand()).is_nonzero(self);
+        let (then_block, else_block) = self.current_block().branch_with_else(condition, self);
+        self.region(then_block, |scope| {
+            scope.expression_effect(&node.true_expression())
+        });
+        self.region(else_block, |scope| {
+            scope.expression_effect(&node.false_expression())
+        });
     }
 }

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -53,9 +53,13 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             Expression::InequalityExpression(inner) => self.inequality(inner),
             Expression::AndExpression(inner) => self.and(inner),
             Expression::OrExpression(inner) => self.or(inner),
-            Expression::PrefixExpression(inner) => self.prefix(inner),
+            Expression::PrefixExpression(inner) => self
+                .prefix(inner)
+                .expect("a prefix expression in value position yields a value"),
             Expression::PostfixExpression(inner) => self.postfix(inner),
-            Expression::AssignmentExpression(inner) => self.assignment(inner),
+            Expression::AssignmentExpression(inner) => self
+                .assignment(inner)
+                .expect("an assignment in value position yields its assigned value"),
             Expression::ConditionalExpression(inner) => self.conditional(inner),
             Expression::TupleExpression(inner) => self.tuple(inner),
             Expression::ArrayExpression(inner) => self.array(inner),
@@ -88,21 +92,46 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         match node {
             Expression::TupleExpression(inner) => self.tuple_values(inner),
             Expression::FunctionCallExpression(inner) => Call::emit(inner, self),
+            Expression::ConditionalExpression(inner) => self.conditional_values(inner),
             _ => vec![self.expression(node)],
         }
     }
 
-    /// Resolves an assignable expression to the place it denotes together with its element MLIR
-    /// type, serving both the read path and the assignment lvalue path.
+    /// Resolves an assignable expression, its parentheses peeled, to the place it denotes together
+    /// with its element MLIR type, serving both the read path and the assignment lvalue path. A
+    /// parenthesized place is a single-element tuple, peeled here; a multi-element tuple denotes
+    /// several places, resolved by `expression_places`.
     pub fn expression_place(&mut self, node: &Expression) -> (Place<'context>, MlirType<'context>) {
         match node {
             Expression::Identifier(inner) => self.identifier_place(inner),
             Expression::MemberAccessExpression(inner) => self.member_access_place(inner),
             Expression::IndexAccessExpression(inner) => self.index_access_place(inner),
+            Expression::TupleExpression(inner) if inner.items().len() == 1 => {
+                let operand = inner
+                    .items()
+                    .iter()
+                    .next()
+                    .and_then(|item| item.expression())
+                    .expect("a parenthesized place wraps a single operand");
+                self.expression_place(&operand)
+            }
             _ => unimplemented!(
                 "expression is not an assignable place: {:?}",
                 std::mem::discriminant(node)
             ),
+        }
+    }
+
+    /// Resolves an expression in multi-place position: a tuple yields its elements' places, nested
+    /// and parenthesized tuples flattening in and a blank element denoting none; any other
+    /// expression its single place. The place-side sibling of `expression_values`.
+    pub fn expression_places(
+        &mut self,
+        node: &Expression,
+    ) -> Vec<Option<(Place<'context>, MlirType<'context>)>> {
+        match node {
+            Expression::TupleExpression(inner) => self.tuple_places(inner),
+            _ => vec![Some(self.expression_place(node))],
         }
     }
 
@@ -112,6 +141,16 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             Expression::FunctionCallExpression(call) => {
                 Call::emit(call, self);
             }
+            Expression::PrefixExpression(inner) => {
+                self.prefix(inner);
+            }
+            Expression::AssignmentExpression(inner) => {
+                self.assignment(inner);
+            }
+            Expression::ConditionalExpression(inner) => {
+                self.conditional_effect(inner);
+            }
+            Expression::TupleExpression(inner) => self.tuple_effect(inner),
             _ => {
                 self.expression(node);
             }
@@ -158,5 +197,43 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             self.coerced(left, result_type),
             self.coerced(right, result_type),
         )
+    }
+
+    /// Lowers a multi-value expression to values coerced to `targets`, folding a string-literal tuple
+    /// element to its bytes-like constant the way `coerced` does for a scalar. A tuple coerces each
+    /// element expression; a lone target folds the whole expression; any other expression
+    /// materialises its results and coerces them. A `None` target passes its value through, for a
+    /// blank destructuring slot.
+    pub fn coerced_values(
+        &mut self,
+        node: &Expression,
+        targets: &[Option<MlirType<'context>>],
+    ) -> Vec<Value<'context>> {
+        match node {
+            Expression::TupleExpression(tuple) => tuple
+                .items()
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    let element = item.expression().expect("slang validates tuple elements");
+                    match targets[index] {
+                        Some(target) => self.coerced(&element, target),
+                        None => self.expression(&element),
+                    }
+                })
+                .collect(),
+            _ => match targets {
+                [Some(target)] => vec![self.coerced(node, *target)],
+                _ => self
+                    .expression_values(node)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, value)| match targets[index] {
+                        Some(target) => value.coerce(target, self),
+                        None => value,
+                    })
+                    .collect(),
+            },
+        }
     }
 }

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -199,40 +199,36 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         )
     }
 
-    /// Lowers a multi-value expression to values coerced to `targets`, folding a string-literal tuple
-    /// element to its bytes-like constant the way `coerced` does for a scalar. A tuple coerces each
-    /// element expression; a lone target folds the whole expression; any other expression
-    /// materialises its results and coerces them. A `None` target passes its value through, for a
-    /// blank destructuring slot.
+    /// Lowers a multi-value expression to values coerced to `targets`, a nested tuple flattening into
+    /// the same list as `tuple_values` and a string-literal element folding to its bytes-like constant
+    /// as `coerced` does. A call or conditional coerces each result it yields; a `None` target passes
+    /// its value through, for a blank destructuring slot.
     pub fn coerced_values(
         &mut self,
         node: &Expression,
         targets: &[Option<MlirType<'context>>],
     ) -> Vec<Value<'context>> {
         match node {
-            Expression::TupleExpression(tuple) => tuple
-                .items()
-                .iter()
-                .enumerate()
-                .map(|(index, item)| {
+            Expression::TupleExpression(tuple) => {
+                let mut values = Vec::with_capacity(targets.len());
+                for item in tuple.items().iter() {
                     let element = item.expression().expect("slang validates tuple elements");
-                    match targets[index] {
-                        Some(target) => self.coerced(&element, target),
-                        None => self.expression(&element),
-                    }
+                    values.extend(self.coerced_values(&element, &targets[values.len()..]));
+                }
+                values
+            }
+            Expression::FunctionCallExpression(_) | Expression::ConditionalExpression(_) => self
+                .expression_values(node)
+                .into_iter()
+                .zip(targets)
+                .map(|(value, target)| match target {
+                    Some(target) => value.coerce(*target, self),
+                    None => value,
                 })
                 .collect(),
-            _ => match targets {
-                [Some(target)] => vec![self.coerced(node, *target)],
-                _ => self
-                    .expression_values(node)
-                    .into_iter()
-                    .enumerate()
-                    .map(|(index, value)| match targets[index] {
-                        Some(target) => value.coerce(target, self),
-                        None => value,
-                    })
-                    .collect(),
+            _ => match targets[0] {
+                Some(target) => vec![self.coerced(node, target)],
+                None => vec![self.expression(node)],
             },
         }
     }

--- a/solx-slang/src/contract/function/expression/tuple.rs
+++ b/solx-slang/src/contract/function/expression/tuple.rs
@@ -4,27 +4,53 @@
 
 use slang_solidity_v2::ast::TupleExpression;
 
+use solx_mlir::Place;
+use solx_mlir::Type;
 use solx_mlir::Value;
 
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// A parenthesized expression; the multi-element form only yields values in multi-value
-    /// positions.
+    /// A parenthesized value: the single value it wraps. A multi-element tuple is a value only in
+    /// multi-value positions, never here.
     pub fn tuple(&mut self, node: &TupleExpression) -> Value<'context> {
-        if node.items().len() != 1 {
-            unimplemented!("a multi-element tuple in single-value position is not yet supported");
-        }
-        self.tuple_values(node).pop().expect("length checked")
+        self.tuple_values(node)
+            .into_iter()
+            .next()
+            .expect("a parenthesized value wraps an operand")
     }
 
-    /// A tuple's elements in declaration order.
+    /// A tuple's elements in declaration order, each contributing every value it yields, so a nested
+    /// tuple flattens into the same list.
     pub fn tuple_values(&mut self, node: &TupleExpression) -> Vec<Value<'context>> {
         node.items()
             .iter()
-            .map(|item| {
-                self.expression(&item.expression().expect("slang validates tuple elements"))
+            .flat_map(|item| {
+                self.expression_values(&item.expression().expect("slang validates tuple elements"))
             })
             .collect()
+    }
+
+    /// A tuple's assignment targets in declaration order, each contributing every place it denotes, so
+    /// a nested tuple flattens into the same list; a blank element denotes no place and discards the
+    /// value paired with it.
+    pub fn tuple_places(
+        &mut self,
+        node: &TupleExpression,
+    ) -> Vec<Option<(Place<'context>, Type<'context>)>> {
+        node.items()
+            .iter()
+            .flat_map(|item| match item.expression() {
+                Some(target) => self.expression_places(&target),
+                None => vec![None],
+            })
+            .collect()
+    }
+
+    /// A tuple in statement position: each element is evaluated for its side effects.
+    pub fn tuple_effect(&mut self, node: &TupleExpression) {
+        for item in node.items().iter() {
+            self.expression_effect(&item.expression().expect("slang validates tuple elements"));
+        }
     }
 }

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -15,20 +15,21 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// The prefix `++`, `--`, `~`, `!`, and `-` operators.
-    pub fn prefix(&mut self, node: &PrefixExpression) -> Value<'context> {
+    /// The prefix `++`, `--`, `~`, `!`, and `-` operators, each yielding a value; and `delete`, which
+    /// resets its operand and yields nothing, `delete` being value-less in Solidity.
+    pub fn prefix(&mut self, node: &PrefixExpression) -> Option<Value<'context>> {
         match node.operator() {
-            PrefixExpressionOperator::PlusPlus(_) => self.step(&node.operand(), Value::add).1,
+            PrefixExpressionOperator::PlusPlus(_) => Some(self.step(&node.operand(), Value::add).1),
             PrefixExpressionOperator::MinusMinus(_) => {
-                self.step(&node.operand(), Value::subtract).1
+                Some(self.step(&node.operand(), Value::subtract).1)
             }
             PrefixExpressionOperator::Tilde(_) => {
                 let result_type = self.typing(node.get_type());
-                self.coerced(&node.operand(), result_type).not(self)
+                Some(self.coerced(&node.operand(), result_type).not(self))
             }
             PrefixExpressionOperator::Bang(_) => {
                 let value = self.expression(&node.operand());
-                value.compare(Value::zero(value.r#type(), self), CmpPredicate::Eq, self)
+                Some(value.compare(Value::zero(value.r#type(), self), CmpPredicate::Eq, self))
             }
             PrefixExpressionOperator::Minus(_) => {
                 let result_type = self.typing(node.get_type());
@@ -37,16 +38,17 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                     Expression::HexNumberExpression(number) => number.integer_value(),
                     _ => None,
                 };
-                match magnitude {
+                Some(match magnitude {
                     Some(magnitude) => Value::constant_from_bigint(&-magnitude, result_type, self),
                     None => {
                         let value = self.coerced(&node.operand(), result_type);
                         Value::zero(result_type, self).subtract(value, self.checked, self)
                     }
-                }
+                })
             }
             PrefixExpressionOperator::DeleteKeyword(_) => {
-                unimplemented!("delete expression is not yet supported")
+                self.delete(&node.operand());
+                None
             }
         }
     }
@@ -80,5 +82,17 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let new = operator(old, Value::one(element_type, self), self.checked, self);
         place.store(new, self);
         (old, new)
+    }
+
+    /// Emits `delete <lvalue>`, a value-less reset. A reference-typed storage aggregate, which is its
+    /// own address, recursively clears through `sol.delete`; every other place, a scalar slot, struct
+    /// field, mapping entry, or local, stores its element type's zero, which is `delete` for a scalar.
+    fn delete(&mut self, operand: &Expression) {
+        let (place, element_type) = self.expression_place(operand);
+        if place.r#type() == element_type {
+            place.delete(self);
+        } else {
+            place.store(Value::zero(element_type, self), self);
+        }
     }
 }

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -70,9 +70,9 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                         .map(|(index, parameter)| {
                             let identifier = parameter.name()?;
                             let return_type = scope.return_types[index];
-                            if !return_type.is_integer() {
+                            if !return_type.is_scalar() {
                                 unimplemented!(
-                                    "zero-initialization for non-integer named return: {return_type}"
+                                    "default-initialization for non-scalar named return: {return_type}"
                                 );
                             }
                             Some(scope.define_local(identifier.name(), return_type, |scope| {

--- a/solx-slang/src/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/contract/function/statement/control_flow.rs
@@ -5,7 +5,6 @@
 use slang_solidity_v2::ast::BreakStatement;
 use slang_solidity_v2::ast::ContinueStatement;
 use slang_solidity_v2::ast::DoWhileStatement;
-use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::ForStatement;
 use slang_solidity_v2::ast::ForStatementCondition;
 use slang_solidity_v2::ast::ForStatementInitialization;
@@ -97,26 +96,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             self.current_block().r#return(&[], self);
             return;
         };
-        let values = match &expression {
-            Expression::TupleExpression(tuple) => tuple
-                .items()
-                .iter()
-                .enumerate()
-                .map(|(index, item)| {
-                    let element = item.expression().expect("slang validates tuple elements");
-                    self.coerced(&element, self.return_types[index])
-                })
-                .collect(),
-            _ => match self.return_types.as_slice() {
-                &[return_type] => vec![self.coerced(&expression, return_type)],
-                _ => self
-                    .expression_values(&expression)
-                    .iter()
-                    .zip(&self.return_types)
-                    .map(|(value, &return_type)| value.coerce(return_type, self))
-                    .collect(),
-            },
-        };
+        let targets: Vec<_> = self.return_types.iter().copied().map(Some).collect();
+        let values = self.coerced_values(&expression, &targets);
         self.current_block().r#return(&values, self);
     }
 }

--- a/solx-slang/src/contract/function/statement/variable_declaration.rs
+++ b/solx-slang/src/contract/function/statement/variable_declaration.rs
@@ -1,5 +1,5 @@
 //!
-//! Variable declaration statements, single and tuple-deconstructing.
+//! Variable declaration statements, single and tuple-destructuring.
 //!
 
 use slang_solidity_v2::ast::MultiTypedDeclaration;
@@ -17,7 +17,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         self.variable_declaration_target(&node.target());
     }
 
-    /// A variable declaration target, single or tuple-deconstructing.
+    /// A variable declaration target, single or tuple-destructuring.
     pub fn variable_declaration_target(&mut self, node: &VariableDeclarationTarget) {
         match node {
             VariableDeclarationTarget::SingleTypedDeclaration(inner) => {
@@ -31,7 +31,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// A single-typed variable declaration. An explicit initializer is evaluated before the slot is
     /// allocated, matching solc's order; an absent one default-initializes the freshly allocated
-    /// slot, which integers zero-fill.
+    /// slot, which every scalar value type zero-fills.
     pub fn single_typed_declaration(&mut self, node: &SingleTypedDeclaration) {
         let declared_type = self.typing(node.declaration().get_type());
         match node.value() {
@@ -41,26 +41,34 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                     value
                 });
             }
-            None if declared_type.is_integer() => {
+            None if declared_type.is_scalar() => {
                 self.define_local(node.declaration().name().name(), declared_type, |scope| {
                     Value::zero(declared_type, scope)
                 });
             }
-            None => unimplemented!("zero-initialization for non-integer type {declared_type}"),
+            None => unimplemented!("default-initialization for non-scalar type {declared_type}"),
         }
     }
 
-    /// A multi-typed variable declaration, deconstructing a tuple or call.
+    /// A multi-typed variable declaration, destructuring a tuple or a call through `coerced_values`,
+    /// so a string-literal tuple element folds to its bytes-like constant. A blank slot evaluates its
+    /// operand but binds nothing.
     pub fn multi_typed_declaration(&mut self, node: &MultiTypedDeclaration) {
-        let values = self.expression_values(&node.value());
-        for (member, value) in node.elements().iter().zip(values) {
-            let Some(declaration) = member.member() else {
-                continue;
-            };
-            let declared_type = self.typing(declaration.get_type());
-            self.define_local(declaration.name().name(), declared_type, |scope| {
-                value.coerce(declared_type, scope)
-            });
+        let elements = node.elements();
+        let targets: Vec<_> = elements
+            .iter()
+            .map(|member| {
+                member
+                    .member()
+                    .map(|declaration| self.typing(declaration.get_type()))
+            })
+            .collect();
+        let values = self.coerced_values(&node.value(), &targets);
+        for ((member, target), value) in elements.iter().zip(targets).zip(values) {
+            if let Some(declaration) = member.member() {
+                let target = target.expect("a bound slot has a declared type");
+                self.define_local(declaration.name().name(), target, |_scope| value);
+            }
         }
     }
 }


### PR DESCRIPTION
Completes lvalues and assignment on the Slang frontend:

- A destructuring assignment flattens its left targets against the right operand's values and stores them pairwise, every value evaluated before any target is written so `(a, b) = (b, a)` swaps; a nested tuple flattens into the same list, and a blank target discards its paired value.
- A plain assignment through a place that is its own address — a storage or calldata reference — emits `sol.copy`, which bridges both the element type and the data location of its right operand.
- The ternary conditional yields a tuple by storing each arm into per-element stack slots, loaded after the merge.
- Prefix and postfix `++`/`--` step through any computed place.
- An uninitialized scalar declaration or named return zero-fills by folding to a typed constant.
- `delete` resets its operand in place, clearing a storage aggregate through `sol.delete` and storing the element type's zero into every other place.
