### PR TITLE
ci(coverage): move to hosted ubuntu-24.04 runner, drop ci:coverage label gating

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,7 +33,7 @@ jobs:
   coverage:
     # Fork PRs get a read-only GITHUB_TOKEN, which would fail the PR coverage
     # summary comment step.
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -38,13 +38,23 @@ jobs:
 
   coverage:
     needs: [label-check, cooldown-check]
-    runs-on: solx-linux-amd64-self-hosted
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
       packages: read
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
+      # Host tooling bind-mounts for the free-disk-space-linux action, needed
+      # when a solx-llvm bump forces a cold LLVM build before cache-warmup has
+      # run for that SHA. Keep in sync with the matching lists in test.yaml
+      # and cache-warmup.yaml.
+      volumes:
+        - /usr/share/dotnet:/mnt/free-disk-space/dotnet
+        - /usr/local/lib/android:/mnt/free-disk-space/android
+        - /opt/ghc:/mnt/free-disk-space/ghc
+        - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
+        - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     env:
       BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
       SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
@@ -57,6 +67,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+
+      - name: Free disk space (Linux)
+        uses: ./.github/actions/free-disk-space-linux
 
       - name: Checkout submodules
         uses: ./.github/actions/checkout-submodules

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,7 +2,6 @@ name: Code coverage
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
@@ -17,19 +16,9 @@ permissions:
 
 jobs:
 
-  label-check:
-    if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ci:coverage'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:coverage'))
-      && !github.event.pull_request.head.repo.fork
-    runs-on: ubuntu-24.04
-    steps:
-      - run: 'true'
-
   cooldown-check:
     name: Cargo cooldown check
     runs-on: ubuntu-24.04
-    needs: label-check
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -37,7 +26,10 @@ jobs:
       - uses: ./.github/actions/cooldown-check
 
   coverage:
-    needs: [label-check, cooldown-check]
+    # Fork PRs get a read-only GITHUB_TOKEN, which would fail the PR coverage
+    # summary comment step.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    needs: cooldown-check
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,6 +2,11 @@ name: Code coverage
 
 on:
   pull_request:
+  # Main runs upload the Codecov base for PR deltas and save the cargo cache
+  # that PR runs restore (rust-cache save-if only fires on refs/heads/main).
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
@@ -70,6 +75,13 @@ jobs:
         uses: ./.github/actions/setup-sfw
         with:
           optional: 'true'
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: coverage-v1
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build LLVM
         uses: ./.github/actions/build-llvm
@@ -253,6 +265,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Post PR coverage summary
+        if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12
         with:
           message-id: 'coverage-summary'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,7 +34,6 @@ jobs:
     # Fork PRs get a read-only GITHUB_TOKEN, which would fail the PR coverage
     # summary comment step.
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    needs: cooldown-check
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -140,7 +140,10 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
           RUSTFLAGS: '-C target-feature=+crt-static -C instrument-coverage -C link-arg=-fuse-ld=lld'
-          LLVM_PROFILE_FILE: 'unit-tests-%p-%m.profraw'
+          # %Nm without %p: the profile runtime merges profiles online into a
+          # pool of 4 files instead of leaving one profraw per process (CLI
+          # tests spawn thousands of short-lived solx subprocesses).
+          LLVM_PROFILE_FILE: 'unit-tests-%4m.profraw'
         run: ${SFW_PREFIX:-} cargo fetch --locked && ${SFW_PREFIX:-} cargo test --frozen --release --target x86_64-unknown-linux-gnu
 
       # Inkwell feature poisoning: solc path builds inkwell with LLVM linking,
@@ -152,7 +155,7 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
           RUSTFLAGS: '-C instrument-coverage -C link-arg=-fuse-ld=lld'
-          LLVM_PROFILE_FILE: 'slang-tests-%p-%m.profraw'
+          LLVM_PROFILE_FILE: 'slang-tests-%4m.profraw'
           CARGO_TARGET_DIR: target-slang
         run: ${SFW_PREFIX:-} cargo test-slang --frozen --release --target x86_64-unknown-linux-gnu
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -57,7 +57,9 @@ jobs:
       PROFDATA_FILE: solx.profdata
       LCOV_FILE: codecov.lcov
       OUTPUT_HTML_DIR: COVERAGE
-      COVERAGE_IGNORE_REGEX: '/(solx-llvm|target-llvm|solx-solidity|\.cargo|cargo/registry)/'
+      # ^/rustc/ = std sources monomorphized into our binaries; the remapped
+      # path exists on no runner, so llvm-cov show errors trying to render it.
+      COVERAGE_IGNORE_REGEX: '/(solx-llvm|target-llvm|solx-solidity|\.cargo|cargo/registry)/|^/rustc/'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,6 @@ Tests live in `tests/solidity/`, `tests/yul/`, `tests/llvm-ir/`.
 - `ci:slang` — enable Slang tests
 - `ci:sanitizer` — enable address sanitizer tests
 - `ci:integration` — enable integration tests
-- `ci:coverage` — enable code coverage
 
 ## Renovate Config
 


### PR DESCRIPTION
I noticed the coverage run did not take as much time now that the warmup caching is working well. 

This pr does the following:
* Switches back the runner to a free ubuntu-24.04 runner, and drop the label
* Enables code coverage on main pushes
* Adds Rust caching for coverage. Note that this will start working properly when caches get pushed on main merges
* Optimises coverage workflow by optimising llvm-cov flags and making the cooldown-check run in parallel (similar to other workflows)
  * Reduced the running time to ~12 minute compared to ~25 minutes unoptimised which is now faster than macOS x86 Tests. (self-hosted was ~3 minutes)


Notes: 
* This should also fix code cov diffs missing for HEAD as codecov stats will now be seeded on main push.
* The one time a coverage run will be longer, will be a solx-llvm bump, but that's the same time the normal tests are longer, so it should not make the overall testing time for a PR much longer.



# Claude Summary

## Why

The coverage job doesn't need the self-hosted box. Its only expensive dependency — the coverage-variant LLVM build (`RelWithDebInfo` + MLIR + coverage, no assertions) — is already built nightly on `ubuntu-24.04` by `cache-warmup.yaml`'s "LLVM · Coverage" job. The artifact-cache key is derived from `runner.os`/`runner.arch`, which is `Linux`/`X64` on both hosted and self-hosted, so a hosted coverage job restores exactly the caches the warmup saves. Same for solc, and the `solx-ci-runner` container runs fine on hosted Linux.

What remains per run — building solx, unit tests, two build-only solx-tester invocations, and the profdata merge — fits in a hosted runner's 4 cores / 16 GB.

And with the job off self-hosted, the `ci:coverage` label loses its purpose (it existed to protect self-hosted capacity), so it goes too: every PR now gets the coverage summary comment and Codecov delta.

## What

- `runs-on: solx-linux-amd64-self-hosted` → `ubuntu-24.04`.
- Copy test.yaml's `free-disk-space-linux` bind-mount pattern (volumes + step), so a cold LLVM build (a `solx-llvm` bump before cache-warmup has run for that SHA) doesn't exhaust the hosted runner's disk.
- Remove the `label-check` job and the `labeled` trigger type. The fork exclusion it carried moves to a job-level `if` on `coverage` (fork PRs get a read-only `GITHUB_TOKEN`, which would fail the summary comment step). `cooldown-check` now runs on fork PRs too, where a supply-chain check is most useful.
- Add `Swatinem/rust-cache` (prefix `coverage-v1`, saved on `main` only) and a `push: main` trigger, which also seeds the Codecov base for PR deltas.
- `LLVM_PROFILE_FILE`: `unit-tests-%p-%m.profraw` → `unit-tests-%4m.profraw` (same for the slang pattern). With `%p` every process wrote its own profraw, and the CLI tests spawn thousands of short-lived solx subprocesses — `llvm-profdata merge` ground through them for ~10 min. `%Nm` alone lets the profile runtime flock-merge into a pool of 4 files per binary signature as processes exit.
- Drop `needs: cooldown-check` from the coverage job — test.yaml starts its matrix alongside cooldown-check; the `needs:` serialized ~80 s for no extra safety.
- Add `|^/rustc/` to `COVERAGE_IGNORE_REGEX`: std generics monomorphized into our binaries carry mappings with the rustc-remapped virtual path `/rustc/<hash>/library/...`, which exists on no runner — `llvm-cov show` errored trying to render it, and the lcov shipped std entries to Codecov that wobble with toolchain bumps. Same category as the existing `cargo/registry` exclusion; matches cargo-llvm-cov's default filter.
- Make the fork-exclusion `if` spell out the push case (`github.event_name == 'push' || …`), matching the explicit compound shape of every other fork check in the repo (Copilot review suggestion; the bare form was functionally correct via null-propagation).
- Drop `ci:coverage` from CLAUDE.md's label list.

## Measured

Warm path (all caches hit), coverage job wall clock: **24 min → ~12 min** (runs [29728249951](https://github.com/NomicFoundation/solx/actions/runs/29728249951) before → [29755207762](https://github.com/NomicFoundation/solx/actions/runs/29755207762) after). Where it went:

| Step | Before | After |
|---|---|---|
| Merge unit test profraw | 9m58s | <30s |
| Run unit tests | 4m06s | 1m45s (less profraw write I/O) |
| Workflow start → job start | ~80s | ~5s (cooldown-check in parallel) |

The remaining ~12 min floor: solx build ~3m45s (workspace crates + linking three binaries; rust-cache covers dependencies only), unit tests, ~2 min container/checkout overhead, ~1m25s Codecov upload.

## Trade-offs

- **Warm path vs self-hosted: ~3 min → ~12 min.** The self-hosted runner implicitly reused `target/` across runs via its persistent `_work` dir; rust-cache recovers the dependency half of that, and the workspace rebuild + linking is the irreducible remainder.
- **Every-PR cost:** free on hosted runners for a public repo; `cancel-in-progress` concurrency already collapses rapid pushes. On `solx-llvm` bump PRs the job does a cold LLVM build per push (PR runs don't save artifact/ccache), but the 5-platform test matrix already behaves the same way on those PRs, and ccache restore-keys keep it link-dominated.
- **Wins:** coverage signal on every PR instead of opt-in; the job stops competing with integration/benchmark runs for self-hosted capacity; hosted runners hard-cap jobs at 6 h so a hung build can no longer squat a runner indefinitely.

## Verification

- Full run on the final head ([29755207762](https://github.com/NomicFoundation/solx/actions/runs/29755207762)) green in ~12 min; the `/rustc/... No such file or directory` error from earlier runs is gone from the `llvm-cov show` output, and the summary comment + Codecov upload work end-to-end.
- The `find . -name 'unit-tests-*.profraw'` globs in the merge steps still match the `%4m` pool files, so no other script changes were needed.
- `actionlint` on the edited workflow: the change removes the one pre-existing error (unknown self-hosted runner label); the remaining 7 shellcheck infos are pre-existing on `main` in `run:` scripts this PR doesn't touch.
- Cache-key equivalence checked against `.github/actions/build-llvm/action.yml` (key = os/arch/build-type/mlir/coverage/assertions/dev-hash/submodule-SHA — no runner-specific input).
- `label-check` from coverage.yaml is not a required status check on `main` (required: the "PR Checks" trio from test/sanitizer/slang-tests), so removing it can't hang the merge queue.
