### PR TITLE
ci: align Windows eol config so solc builds lose the ".mod" version stamp

### DIFF
--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -90,15 +90,21 @@ runs:
         verbose: 2
         save: ${{ github.event_name != 'pull_request' }}
 
-    # commit_hash.txt must sit in the solx-solidity root (not the checkout root):
-    # it is buildinfo.cmake's escape hatch that skips the dirty-tree check, which
-    # on Windows stamps the version `.mod` (autocrlf keeps two CRLF fixtures
-    # perpetually "modified").
-    - name: Pin solc commit hash
-      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+    # The Windows checkout is smudged to CRLF by Git for Windows (system
+    # core.autocrlf=true), but buildinfo.cmake's dirty-tree check runs under
+    # MSYS2's git (autocrlf unset), which would see every text file as
+    # modified and stamp the solc version `.mod`. Both gits read the
+    # submodule's repo-local config, so aligning it lets the check run and
+    # pass honestly — a genuinely patched tree still gets stamped. The nested
+    # deps submodules need the same setting or they surface as modified
+    # content in the parent diff.
+    - name: Align solc eol config with the checkout (Windows)
+      if: runner.os == 'Windows' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      shell: bash
       working-directory: ${{ inputs.working-dir }}
-      run: git rev-parse HEAD > commit_hash.txt
+      run: |
+        git config core.autocrlf true
+        git submodule foreach --recursive git config core.autocrlf true
 
     - name: Build solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         SHA=$(git -C solx-solidity rev-parse HEAD)
         SCRIPT_HASH=$(find solx-dev/src/solc -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1)
-        KEY="v1-solc-${{ runner.os }}-${{ runner.arch }}"
+        KEY="v2-solc-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.cmake-build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.cmake-build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         KEY="${KEY}-boost${{ inputs.boost-version }}-${SHA}-script${SCRIPT_HASH:0:8}"
@@ -89,6 +89,16 @@ runs:
         max-size: "10G"
         verbose: 2
         save: ${{ github.event_name != 'pull_request' }}
+
+    # commit_hash.txt must sit in the solx-solidity root (not the checkout root):
+    # it is buildinfo.cmake's escape hatch that skips the dirty-tree check, which
+    # on Windows stamps the version `.mod` (autocrlf keeps two CRLF fixtures
+    # perpetually "modified").
+    - name: Pin solc commit hash
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      working-directory: ${{ inputs.working-dir }}
+      run: git rev-parse HEAD > commit_hash.txt
 
     - name: Build solc
       if: steps.solc-artifact-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Windows auto CLRF handling from files from solc causes the files to be modified, creating .mod files for solc builds and releases. 

## Claude Summary

Every Windows build of the solc fork is version-stamped `0.8.34+commit.79519a9b.mod` while Linux/macOS builds report `0.8.34+commit.79519a9b` — including the released binaries: the 0.1.5 `ci:release` Windows artifact embeds `79519a9b.mod.Windows.clang` (the Linux one, a clean `79519a9b.Linux.clang`). Since solc embeds its full version in contract metadata, and the metadata's ipfs digest is written into the bytecode's CBOR trailer, Windows-built solx emits **different metadata and different bytecode trailer bytes than every other platform for identical input** — breaking cross-platform reproducibility and source verification against Windows-compiled contracts.

## Root cause

`solx-solidity/cmake/scripts/buildinfo.cmake` appends `.mod` ("built from modified sources") when `git diff HEAD --shortstat` is non-empty at CMake-configure time. On the Windows runners that check is answered by a **different git than the one that made the checkout**, and the two disagree about line endings. Confirmed with a throwaway probe running the exact buildinfo check from both gits on `windows-2025` ([run 29844457133](https://github.com/NomicFoundation/solx/actions/runs/29844457133/job/88681355195)):

| | checkout git (Git for Windows — `shell: bash` steps, actions/checkout) | configure git (MSYS2 — `msys2 {0}` steps, what CMake finds) |
|---|---|---|
| binary | `C:\Program Files\Git` git 2.55.0.windows.2 | `/usr/bin/git` 2.54.0 |
| `core.autocrlf` | `true` (from `C:/Program Files/Git/etc/gitconfig`) | unset → false |
| `git diff HEAD --shortstat` in `solx-solidity` | clean | **11,357 files changed** |

actions/checkout smudges all ~11k text files to CRLF on disk (11,359 `w/crlf` per `git ls-files --eol`). Git for Windows considers that clean — its clean filter converts CRLF back to LF before comparing. MSYS2's git has no autocrlf anywhere in its config chain and a stat cache it can't trust (the index was written by the other git's stat emulation), so it re-reads content raw and sees the entire tree as modified. Non-empty shortstat → `.mod`, deterministically, on every Windows build.

An earlier revision of this PR blamed the two deliberately-CRLF-committed test fixtures (`license_crlf_endings.sol`, `smt_contract_with_crlf_newlines.sol`). That diagnosis was wrong: git ≥2.8 exempts CRLF-in-index files from autocrlf conversion, so they never dirty a single-git checkout — the probe shows they are in fact the only two **clean** files in MSYS2 git's view (11,359 CRLF worktree files, 11,357 dirty: the delta is exactly those two). NomicFoundation/solx-solidity#160 marked them `-text`; that stands as fixture hygiene but is not the `.mod` fix.

Linux/macOS run a single git with no eol conversion → clean tree → no `.mod`.

## Fix

`build-solc` now aligns the configure-time git with the checkout, Windows-only, before building (on cache miss): repo-local `core.autocrlf=true` in `solx-solidity` plus `git submodule foreach --recursive` for the nested deps. Both gits read the submodule's own config file (`.git/modules/solidity/config`), so MSYS2's git then cleans CRLF back to LF when diffing exactly as Git for Windows does, and buildinfo's dirty check runs and passes because the tree is **genuinely clean by both gits' judgment** — a really patched tree would still stamp `.mod`, which is the property the check exists for. The `foreach --recursive` is load-bearing, not defensive: the deps submodules (fmtlib, nlohmann-json, range-v3) otherwise surface as modified content, +3 entries in the parent diff. The action is shared by all eight workflows that build solc (test, release, integration, coverage, sanitizer, slang, compile-benchmark, cache-warmup), so test and release legs are fixed together.

An earlier revision of this PR instead wrote `commit_hash.txt` into `solx-solidity` — buildinfo's built-in escape hatch that skips the dirty check entirely (upstream uses it for release tarballs, where no git exists and the check cannot run). That also removes the `.mod` stamp (validated on the `ci:release` dry-run [run 29662095386](https://github.com/NomicFoundation/solx/actions/runs/29662095386)), but by silencing the modified-sources check rather than making the tree clean: a genuinely patched tree would ship claiming pristine. The alignment fix keeps the check honest for the same line count.

The solc artifact-cache key is bumped `v1-solc` → `v2-solc`: existing v1 Windows artifacts carry the bad stamp baked in and would keep serving it from cache at the same submodule pin. (One-time solc rebuild per platform; ccache softens it — and main's pin bump to `ebeac7c2` forces fresh keys anyway.)

## Validation

The mechanism is validated in isolation on `windows-2025` ([run 29848797409](https://github.com/NomicFoundation/solx/actions/runs/29848797409), throwaway probe workflow, real checkout topology including recursive deps): the exact buildinfo check (`git diff HEAD --shortstat`) run by MSYS2's git reports 11,360 files modified before the two config lines and is clean after them; Git for Windows is clean throughout.

End-to-end artifact check on this revision ([run 29858498912](https://github.com/NomicFoundation/solx/actions/runs/29858498912), head ae39f65c): main had bumped the submodule pin to `ebeac7c2`, so the merge-ref build was a genuine `v2-solc` cache miss — the Windows job log shows the alignment step executing immediately before `solx-dev solc build`. Grepping the downloaded artifacts for the embedded buildinfo fragment shows

| Artifact | Embedded stamp |
|---|---|
| `solx-windows-amd64-gnu-notag.exe` | `commit.ebeac7c2.Windows.clang` |
| `solx-linux-amd64-gnu-notag` | `commit.ebeac7c2.Linux.clang` |

with zero occurrences of `.mod` in the Windows binary — versus the 0.1.5 Windows release, which embeds `79519a9b.mod.Windows.clang`. The earlier `commit_hash.txt` revision had equally clean artifacts ([run 29662095386](https://github.com/NomicFoundation/solx/actions/runs/29662095386), pin `79519a9b`). (When replicating: grep for `commit\.[0-9a-f]{8}`, not the full `0.8.34+commit.…` string — solc stores only the fragment and assembles the `0.8.34+` prefix at runtime.)

## Relation and follow-ups

- Found via #562 (docs-examples verification), whose Windows leg had to wildcard the version string and two metadata-digest regions; those three wildcards can be tightened back to exact bytes once this lands. (#562's fourth Windows wildcard — LLVM printing `.file "Simple"` because it parses `Simple.sol:Simple` as a drive-prefixed path — is unrelated and stays.)
- Same theme as #550: the Windows leg diverging from other platforms through incidental setup (MSYS2 package drift, bundled static libstdc++, and now a second git with divergent eol config). Candidate for the same unification effort.
- Local Windows dev builds hit the same two-git split whenever the clone is made by Git for Windows and `solx-dev solc build` runs from an MSYS2 shell — this PR fixes CI only. The structural fix is fork-side: `* -text` in `solx-solidity`'s `.gitattributes` (generalizing NomicFoundation/solx-solidity#160 from two files to the tree) removes eol conversion for every git, CI and local, and makes Windows checkouts byte-identical to Linux/macOS. Needs a fork commit on the 0.8.34 branch plus a submodule bump, so it's follow-up material.
