### PR TITLE
ci: extend cargo caching to containerized jobs, fix dead slang cache

### DIFF
--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -138,12 +138,15 @@ jobs:
           echo "After cleanup:" && df -h .
 
       - name: Cache cargo artifacts
-        if: ${{ !matrix.image }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: slang-tests-v2
+          # `cargo test-slang` writes to target-slang, not target (.cargo/config.toml alias)
+          workspaces: ". -> target-slang"
           cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Label-gated workflow that never runs on main: branch-scoped saves
+          # are the only way this cache can populate.
+          save-if: 'true'
 
       - name: Run slang tests
         uses: ./.github/actions/rust-unit-tests

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   merge_group:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -18,9 +21,10 @@ jobs:
 
   label-check:
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ci:slang'
+      github.event_name == 'push'
+      || ((github.event.action == 'labeled' && github.event.label.name == 'ci:slang'
       || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:slang'))
-      && !github.event.pull_request.head.repo.fork
+      && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-24.04
     steps:
       - run: 'true'
@@ -144,9 +148,7 @@ jobs:
           # `cargo test-slang` writes to target-slang, not target (.cargo/config.toml alias)
           workspaces: ". -> target-slang"
           cache-on-failure: true
-          # Label-gated workflow that never runs on main: branch-scoped saves
-          # are the only way this cache can populate.
-          save-if: 'true'
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run slang tests
         uses: ./.github/actions/rust-unit-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,6 +122,13 @@ jobs:
       - name: Setup SFW
         uses: ./.github/actions/setup-sfw
 
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: cargo-checks-v1
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Build LLVM
         uses: ./.github/actions/build-llvm
         with:
@@ -244,7 +251,6 @@ jobs:
         uses: ./.github/actions/free-disk-space-macos
 
       - name: Cache cargo artifacts
-        if: ${{ !matrix.image }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: build-and-test-v2


### PR DESCRIPTION
Noticed some of the Rust caching didn't seem to be working any more, and had a proper look at the Rust cache to fix any issues. I've done the following:

* Fixed Rust caching for Linux runners (see Why section)
* **Enabled Slang tests to run when merging to main** for a few reasons:. 
  * We probably want this at this point anyway
  * The Rust cache and solc cache will start to actually be populated (as they only get populated during main pushes
* Add Rust cache to cargo-checks
* (Fixed the Slang cache target directory which would have caused it to still not work even after having added main merges.)

I tested both normal and Slang workflows by enabling caching in PR for a cold run, and then doing another run warm. I've recorded the times below.

# Claude summary

## Why

Rust caching in CI is half-built: `rust-cache` was added in #262 with an `if: ${{ !matrix.image }}` guard, correct at the time because the containerized Linux legs ran on self-hosted runners whose persistent work directory already preserved `target/`. Those legs have since moved to hosted `ubuntu-24.04`/`-arm` runners, so today the guard denies caching to exactly the jobs that need it — the Linux legs (~10 and ~8 min on every code PR) and `cargo-checks` (~12 min, never had a cache step at all) rebuild all dependencies from scratch on every run, while the macOS/Windows legs enjoy warm caches.

slang-tests' cache config turns out to be dead twice over:

1. `save-if: github.ref == 'refs/heads/main'` can never fire — the workflow only triggers on `pull_request`/`merge_group`. The repo has zero `slang-tests-*` cache entries.
2. It caches `./target`, but `cargo test-slang` writes to `target-slang/` (see the alias in `.cargo/config.toml`), so even a saved cache would have been empty of the artifacts that matter.

## What

- **test.yaml `build-and-test`**: drop the `!matrix.image` guard. `CARGO_HOME=/usr/local/cargo` is image ENV, which rust-cache picks up inside the container.
- **test.yaml `cargo-checks`**: add rust-cache with its own prefix key (`cargo-checks-v1`), saving from main pushes like build-and-test.
- **slang-tests.yaml**: drop the guard and point the cache at the right target dir (`workspaces: ". -> target-slang"`).
- **slang-tests.yaml**: also run on pushes to main. PR runs stay opt-in via the `ci:slang` label, but nothing previously tested the slang pipeline post-merge, so an unlabeled PR could break it silently. With main runs existing, the cargo cache saves from main like the other workflows (main saves, labeled PR runs restore). The pr-checks aggregate needs no change: on push, label-check succeeds, so alls-green's allowed-skips list is empty and "PR Checks (Slang)" turns red on main when the suite fails.

Distinct prefix keys per job keep RUSTFLAGS/feature variants from colliding; rust-cache additionally hashes rustc version, lockfiles, and job-level env into the key.

Main runs also unblock **solc caching** for the slang suite: `build-solc`'s cache saves (artifact cache and ccache) are gated on non-PR events, and since slang-tests only ever ran on labeled PRs, its Release+mlir solc variant was never saved — every labeled run rebuilt boost + solc from scratch (~10–42 min per leg, visible in the timings below). The first merge to main populates the cache; labeled PR runs then restore it for as long as solx-solidity main (which the job syncs to) hasn't moved, and the main-saved ccache cushions rebuilds when it has.

## Notes

- Cache budget is not a concern: the repo holds ~149 GB of active caches (LLVM artifacts + ccache), so the org limit is clearly raised well past the 10 GB default; these cargo caches add ~1–2 GB per variant.
- PR runs restore but don't save (by design), so the roundtrips wouldn't normally prove out until the first main push after merge. Both were demonstrated on this PR with temporary `save-if: 'true'` commits, since removed — timings in Verification below.
- Follow-up: draft #564 adds the same treatment to coverage.yaml (plus a `push: main` trigger so its cache can save and Codecov gets a main base upload).

## Verification

- `actionlint` clean on both workflows (no non-shellcheck findings; shellcheck infos are pre-existing in untouched `run:` scripts).
- Confirmed zero existing `slang-tests-*`/`cargo-checks-*` cache keys via `gh api repos/NomicFoundation/solx/actions/caches`, so no stale-namespace collisions.
- test.yaml save/restore roundtrip demonstrated on this PR (cold run [29612999959](https://github.com/NomicFoundation/solx/actions/runs/29612999959) logged `No cache found` and saved; warm re-run [29613941923](https://github.com/NomicFoundation/solx/actions/runs/29613941923) restored with a full key match). Cold vs warm, same lockfile:

  | Job | Total cold → warm | Cargo step cold → warm |
  |---|---|---|
  | cargo-checks | 12m46s → 5m44s | 8m41s → 2m00s |
  | Linux x86 gnu | 10m44s → 7m25s | 6m43s → 4m04s |
  | Linux ARM64 gnu | 8m33s → 7m07s | 5m00s → 3m12s |

  The residual warm time is workspace-crate compilation plus running the tests, which a dependency cache can't remove; cache restore itself costs ~30–40s (~1 GB at ~240 MB/s). Job totals are diluted by ~5 min of fixed preamble on the container legs (container init, checkout, disk cleanup, LLVM/solc cache restores).
- slang-tests roundtrip likewise demonstrated (cold [attempt 1](https://github.com/NomicFoundation/solx/actions/runs/29651670313/attempts/1), warm [re-run](https://github.com/NomicFoundation/solx/actions/runs/29651670313)). The cargo cache's signal is the "Run slang tests" step; job totals are dominated by the solc build, which is uncached on PR runs (see above) and jitters with runner load — warm Linux x86 drew an 18m33s solc build vs 11m40s cold, hence its higher total:

  | Leg | Total cold → warm | Run slang tests cold → warm |
  |---|---|---|
  | MacOS x86 | 73m34s → 43m33s | 19m49s → 3m24s |
  | Windows | 49m35s → 38m07s | 9m27s → 2m55s |
  | MacOS arm64 | 18m52s → 13m46s | 4m57s → 1m09s |
  | Linux x86 gnu | 17m19s → 22m13s | 3m20s → 1m10s |
  | Linux ARM64 gnu | 17m02s → 13m46s | 3m21s → 1m08s |

  Once main runs populate the solc cache, the Build solc step drops to a restore (~10–30s) on labeled PR runs, making the totals reflect the slang tests themselves.
