### PR TITLE
feat(slang): complete memory data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1168,7 +1168,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1649,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3824,7 +3824,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4288,7 +4288,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint 0.4.6",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4332,12 +4332,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=5dcb93f6fb52370d990ded14de94c082a7f6ba2c#5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
@@ -4811,7 +4811,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4820,7 +4820,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5419,7 +5419,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "5dcb93f6fb52370d990ded14de94c082a7f6ba2c"
+rev = "e04e567421393be60bfbbd73e280ed2558df29c6"

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -93,6 +93,10 @@ MlirType solxCreateStringType(MlirContext ctx, uint32_t dataLocation) {
     return wrap(mlir::sol::StringType::get(context, location));
 }
 
+MlirType solxCreateByteType(MlirContext ctx) {
+    return wrap(mlir::sol::ByteType::get(unwrap(ctx)));
+}
+
 MlirType solxCreateFixedBytesType(MlirContext ctx, uint32_t size) {
     auto *context = unwrap(ctx);
     return wrap(mlir::sol::FixedBytesType::get(context, size));
@@ -133,6 +137,10 @@ bool solxIsAddressType(MlirType ty) {
     return mlir::isa<mlir::sol::AddressType>(unwrap(ty));
 }
 
+bool solxIsStringType(MlirType ty) {
+    return mlir::isa<mlir::sol::StringType>(unwrap(ty));
+}
+
 bool solxIsBytesLikeType(MlirType ty) {
     return mlir::sol::isBytesLikeType(unwrap(ty));
 }
@@ -143,6 +151,10 @@ uint32_t solxBytesLikeTypeWidth(MlirType ty) {
 
 bool solxIsScalarType(MlirType ty) {
     return mlir::sol::isScalar(unwrap(ty));
+}
+
+uint32_t solxTypeDataLocation(MlirType ty) {
+    return static_cast<uint32_t>(mlir::sol::getDataLocation(unwrap(ty)));
 }
 
 } /* extern "C" */

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -122,6 +122,10 @@ unsafe extern "C" {
     /// 2=Memory, 3=Stack, 4=Immutable, 5=Transient).
     pub fn solxCreateStringType(context: MlirContext, data_location: u32) -> mlir_sys::MlirType;
 
+    /// Creates the `sol::ByteType` singleton (`!sol.byte`), the element a dynamic `bytes`
+    /// push yields.
+    pub fn solxCreateByteType(context: MlirContext) -> mlir_sys::MlirType;
+
     /// Creates a `sol::FixedBytesType` of the given byte width.
     pub fn solxCreateFixedBytesType(context: MlirContext, size: u32) -> mlir_sys::MlirType;
 
@@ -158,6 +162,10 @@ unsafe extern "C" {
     /// Whether the type is a `sol::AddressType`, regardless of payability.
     pub fn solxIsAddressType(ty: mlir_sys::MlirType) -> bool;
 
+    /// Whether the type is a `sol::StringType`, the shared representation of dynamic
+    /// `bytes` and `string`.
+    pub fn solxIsStringType(ty: mlir_sys::MlirType) -> bool;
+
     /// Whether the type is bytes-like: `sol::FixedBytesType` or `sol::ByteType`.
     pub fn solxIsBytesLikeType(ty: mlir_sys::MlirType) -> bool;
 
@@ -167,6 +175,10 @@ unsafe extern "C" {
     /// Whether the type is a scalar value type: integer, enum, function reference,
     /// address-like, or bytes-like.
     pub fn solxIsScalarType(ty: mlir_sys::MlirType) -> bool;
+
+    /// Returns the data location of a located reference type, in the same encoding the
+    /// type constructors take.
+    pub fn solxTypeDataLocation(ty: mlir_sys::MlirType) -> u32;
 
     /// Returns the element type of a non-mapping reference type. For
     /// struct types, `struct_field_idx` selects the member.

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -26,6 +26,7 @@ sol_ops! {
     Value::array_literal(elements: values, array_type: ty) -> value {
         ArrayLitOperation.ins(many(elements)).addr(array_type)
     }
+
     Value::cast(self, target_type: ty) -> value nop_if_same(target_type) {
         CastOperation.inp(self).out(target_type)
     }
@@ -35,18 +36,26 @@ sol_ops! {
     Value::address_cast(self, target_type: ty) -> value {
         AddressCastOperation.inp(self).out(target_type)
     }
+    Value::dyn_bytes_to_fixedbytes(self, target_type: ty) -> value {
+        DynBytesToFixedBytesOperation.inp(self).out(target_type)
+    }
+    Value::data_loc_cast(self, target_type: ty) -> value {
+        DataLocCastOperation.inp(self).out(target_type)
+    }
+
     Value::fixed_bytes_index(self, index: value) -> value {
         FixedBytesIndexOperation.value(self).index(index).result(fixed_bytes(1))
-    }
-    Value::push(self, slot_type: ty) -> value {
-        PushOperation.inp(self).addr(slot_type)
-    }
-    Value::pop(self) {
-        PopOperation.inp(self)
     }
     Value::length(self) -> value {
         LengthOperation.inp(self).len(field())
     }
+    Value::slice(self, start: value, end: value) -> value {
+        SliceOperation.arr(self).start(start).end(end).res(self_ty)
+    }
+    Value::concat(operands: values) -> value {
+        ConcatOperation.args(many(operands)).result(memory())
+    }
+
     Value::compare(self, other: value, predicate: predicate) -> value {
         CmpOperation.predicate(predicate_attr(predicate)).lhs(self).rhs(other).result(boolean())
     }
@@ -151,12 +160,19 @@ sol_ops! {
     Place::stack(pointee: ty) -> place {
         AllocaOperation.alloc_type(ty_attr(ptr(pointee, stack))).addr(ptr(pointee, stack))
     }
-    Place::malloc(pointee: ty) -> place {
+    Place::malloc | malloc_zeroed (pointee: ty) -> place {
         MallocOperation.addr(pointee)
+    } flagged .zero_init;
+    Place::default_storage(place_type: ty) -> place {
+        DefaultStorageOperation.result(place_type)
+    }
+    Place::default_calldata(place_type: ty) -> place {
+        DefaultCallDataOperation.result(place_type)
     }
     Place::addr_of(symbol: str, place_type: ty) -> place {
         AddrOfOperation.var(symbol_attr(symbol)).addr(place_type)
     }
+
     Place::load(self, result_type: ty) -> value nop_if_same(result_type) {
         LoadOperation.addr(self).out(result_type)
     }
@@ -166,9 +182,20 @@ sol_ops! {
     Place::copy_from(self, value: value) {
         CopyOperation.src(value).dst(self)
     }
+
+    Place::push(self, slot_type: ty) -> value {
+        PushOperation.inp(self).addr(slot_type)
+    }
+    Place::push_string(self, value: value) {
+        PushStringOperation.addr(self).value(value)
+    }
+    Place::pop(self) {
+        PopOperation.inp(self)
+    }
     Place::delete(self) {
         DeleteOperation.reference(self)
     }
+
     Place::gep(self, index: value, element_type: ty) -> place {
         GepOperation.base_addr(self).idx(index).addr(gep_of(element_type))
     }

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -13,6 +13,8 @@ use melior::ir::r#type::IntegerType;
 use num::BigInt;
 use num::bigint::Sign;
 
+use solx_utils::DataLocation;
+
 use crate::IntoOds;
 use crate::ffi;
 
@@ -107,6 +109,12 @@ impl<'context> Type<'context> {
         })
     }
 
+    /// The `sol::ByteType` singleton (`!sol.byte`), the element a dynamic `bytes` push yields,
+    /// distinct from the one-byte `bytes1`.
+    pub fn byte(context: &'context melior::Context) -> Self {
+        Self::new(unsafe { MlirType::from_raw(ffi::solxCreateByteType(context.to_raw())) })
+    }
+
     /// A `sol::FixedBytesType` of the given byte width.
     pub fn fixed_bytes(context: &'context melior::Context, width: u32) -> Self {
         Self::new(unsafe {
@@ -185,6 +193,12 @@ impl<'context> Type<'context> {
         unsafe { ffi::solxIsAddressType(self.inner.to_raw()) }
     }
 
+    /// Whether this is a `sol::StringType`, the shared representation of dynamic `bytes` and
+    /// `string`.
+    pub fn is_string(self) -> bool {
+        unsafe { ffi::solxIsStringType(self.inner.to_raw()) }
+    }
+
     /// Whether this is a bytes-like type: `sol::FixedBytesType` or `sol::ByteType`.
     pub fn is_bytes_like(self) -> bool {
         unsafe { ffi::solxIsBytesLikeType(self.inner.to_raw()) }
@@ -200,6 +214,12 @@ impl<'context> Type<'context> {
     /// bytes-like.
     pub fn is_scalar(self) -> bool {
         unsafe { ffi::solxIsScalarType(self.inner.to_raw()) }
+    }
+
+    /// The data location a located reference type carries, decoded from the constructors' FFI
+    /// encoding.
+    pub fn data_location(self) -> DataLocation {
+        DataLocation::from(unsafe { ffi::solxTypeDataLocation(self.inner.to_raw()) })
     }
 
     /// The integer attribute of `value` at this type, built via the arbitrary-width FFI constructor

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -9,6 +9,8 @@ use num::One;
 use num::Zero;
 use num::bigint::Sign;
 
+use solx_utils::DataLocation;
+
 use crate::CmpPredicate;
 use crate::Context;
 use crate::IntoOds;
@@ -64,6 +66,27 @@ impl<'context> Value<'context> {
         Self::constant(i64::from(value), Type::boolean(context.melior), context)
     }
 
+    /// Materialises the default-initialized value of `target_type`, matching solc's default-init:
+    /// a scalar's `zero`; an allocated empty memory `bytes`/`string`; a zero-filled memory array
+    /// or struct; the `sol.default_storage` / `sol.default_calldata` designator for a storage or
+    /// calldata reference.
+    pub fn default_initialized(target_type: Type<'context>, context: &Context<'context>) -> Self {
+        if target_type.is_scalar() {
+            return Self::zero(target_type, context);
+        }
+        match target_type.data_location() {
+            DataLocation::Memory if target_type.is_string() => {
+                Place::malloc(target_type, context).into()
+            }
+            DataLocation::Memory => Place::malloc_zeroed(target_type, context).into(),
+            DataLocation::Storage => Place::default_storage(target_type, context).into(),
+            DataLocation::CallData => Place::default_calldata(target_type, context).into(),
+            other => unreachable!(
+                "a reference default-initializes in memory, storage, or calldata; got {other:?}"
+            ),
+        }
+    }
+
     /// Materialises the `bytesN` constant of a string or hex literal: `bytes` left-aligned in
     /// `target_type`'s width, right-zero-padded, built as the unsigned integer of that width and
     /// reinterpreted with `sol.bytes_cast`.
@@ -98,6 +121,9 @@ impl<'context> Value<'context> {
                 .cast(integer_type, context)
                 .bytes_cast(target_type, context);
         }
+        if !self.r#type().is_scalar() && !target_type.is_scalar() {
+            return self.data_loc_cast(target_type, context);
+        }
         self.cast(target_type, context)
     }
 
@@ -117,6 +143,9 @@ impl<'context> Value<'context> {
                 );
             }
             return self.address_cast(target_type, context);
+        }
+        if self.r#type().is_string() && target_type.is_bytes_like() {
+            return self.dyn_bytes_to_fixedbytes(target_type, context);
         }
         self.coerce(target_type, context)
     }

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -345,14 +345,14 @@ macro_rules! sol_ops {
     };
 
     (
-        Value :: $base:ident | $flagged:ident ($($argument:ident : $kind:ident),* $(,)?)
-        -> value { $operation:ident $($chain:tt)* } flagged .$setter:ident ;
+        $receiver:ident :: $base:ident | $flagged:ident ($($argument:ident : $kind:ident),* $(,)?)
+        -> $disposition:ident { $operation:ident $($chain:tt)* } flagged .$setter:ident ;
         $($rest:tt)*
     ) => {
-        sol_ops!(Value :: $base ($($argument : $kind),*) -> value { $operation $($chain)* });
+        sol_ops!($receiver :: $base ($($argument : $kind),*) -> $disposition { $operation $($chain)* });
         sol_ops!(
-            Value :: $flagged ($($argument : $kind),*)
-            -> value { $operation $($chain)* .$setter(unit_flag) }
+            $receiver :: $flagged ($($argument : $kind),*)
+            -> $disposition { $operation $($chain)* .$setter(unit_flag) }
         );
         sol_ops!($($rest)*);
     };

--- a/solx-mlir/tests/lit/aggregate_default_init.sol
+++ b/solx-mlir/tests/lit/aggregate_default_init.sol
@@ -1,0 +1,90 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*local_array.*}}
+// CHECK:   sol.malloc zero_init : !sol.array<? x ui256, Memory>
+
+// CHECK: sol.func @{{.*local_struct.*}}
+// CHECK:   sol.malloc zero_init : !sol.struct<(ui256, ui256), Memory>
+
+// CHECK: sol.func @{{.*local_string.*}}
+// CHECK:   sol.malloc : !sol.string<Memory>
+
+// CHECK: sol.func @{{.*named_array.*}}
+// CHECK:   sol.malloc zero_init : !sol.array<? x ui256, Memory>
+
+// CHECK: sol.func @{{.*unnamed_array.*}}
+// CHECK:   sol.alloca : !sol.ptr<!sol.array<? x ui256, Memory>, Stack>
+// CHECK:   sol.malloc zero_init : !sol.array<? x ui256, Memory>
+// CHECK:   sol.return %{{.*}} : !sol.array<? x ui256, Memory>
+
+// CHECK: sol.func @{{.*local_fixed_array.*}}
+// CHECK:   sol.malloc zero_init : !sol.array<3 x ui256, Memory>
+
+// CHECK: sol.func @{{.*local_bytes.*}}
+// CHECK:   sol.malloc : !sol.string<Memory>
+
+// CHECK: sol.func @{{.*local_struct_with_array.*}}
+// CHECK:   sol.malloc zero_init : !sol.struct<(ui256, !sol.array<? x ui256, Memory>), Memory>
+
+// CHECK: sol.func @{{.*named_storage.*}}
+// CHECK:   sol.default_storage : !sol.array<? x ui256, Storage>
+
+// CHECK: sol.func @{{.*named_calldata.*}}
+// CHECK:   sol.default_calldata : !sol.array<? x ui256, CallData>
+
+contract C {
+    struct S {
+        uint256 a;
+        uint256 b;
+    }
+
+    struct N {
+        uint256 x;
+        uint256[] a;
+    }
+
+    uint256[] stored;
+
+    function local_array() public pure returns (uint256[] memory) {
+        uint256[] memory a;
+        return a;
+    }
+
+    function local_struct() public pure returns (S memory) {
+        S memory s;
+        return s;
+    }
+
+    function local_string() public pure returns (string memory) {
+        string memory t;
+        return t;
+    }
+
+    function named_array() public pure returns (uint256[] memory a) {}
+
+    function unnamed_array() public pure returns (uint256[] memory) {}
+
+    function local_fixed_array() public pure returns (uint256[3] memory) {
+        uint256[3] memory a;
+        return a;
+    }
+
+    function local_bytes() public pure returns (bytes memory) {
+        bytes memory b;
+        return b;
+    }
+
+    function local_struct_with_array() public pure returns (N memory) {
+        N memory n;
+        return n;
+    }
+
+    function named_storage() internal view returns (uint256[] storage r) {
+        r = stored;
+    }
+
+    function named_calldata(uint256[] calldata a) external pure returns (uint256[] calldata r) {
+        r = a;
+    }
+}

--- a/solx-mlir/tests/lit/array_slice.sol
+++ b/solx-mlir/tests/lit/array_slice.sol
@@ -1,0 +1,63 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}bounded{{.*}}-> !sol.array<? x ui256, CallData>
+// CHECK:   sol.slice %{{.*}}[%{{.*}} : %{{.*}}] : !sol.array<? x ui256, CallData>, ui256, ui256 -> !sol.array<? x ui256, CallData>
+
+// CHECK: sol.func {{.*}}from_start{{.*}}-> !sol.array<? x ui256, CallData>
+// CHECK:   sol.constant 0 : ui256
+// CHECK:   sol.slice %{{.*}}[%{{.*}} : %{{.*}}] : !sol.array<? x ui256, CallData>, ui256, ui256 -> !sol.array<? x ui256, CallData>
+
+// CHECK: sol.func {{.*}}to_end{{.*}}-> !sol.array<? x ui256, CallData>
+// CHECK:   sol.length %{{.*}} : !sol.array<? x ui256, CallData>
+// CHECK:   sol.slice %{{.*}}[%{{.*}} : %{{.*}}] : !sol.array<? x ui256, CallData>, ui256, ui256 -> !sol.array<? x ui256, CallData>
+
+// CHECK: sol.func {{.*}}full_open{{.*}}-> !sol.array<? x ui256, CallData>
+// CHECK:   sol.constant 0 : ui256
+// CHECK:   sol.length %{{.*}} : !sol.array<? x ui256, CallData>
+// CHECK:   sol.slice %{{.*}}[%{{.*}} : %{{.*}}] : !sol.array<? x ui256, CallData>, ui256, ui256 -> !sol.array<? x ui256, CallData>
+
+// CHECK: sol.func {{.*}}of_bytes{{.*}}-> !sol.string<CallData>
+// CHECK:   sol.slice %{{.*}}[%{{.*}} : %{{.*}}] : !sol.string<CallData>, ui256, ui256 -> !sol.string<CallData>
+
+contract ArraySlice {
+    function bounded(uint256[] calldata array, uint256 start, uint256 end)
+        external
+        pure
+        returns (uint256[] calldata)
+    {
+        return array[start:end];
+    }
+
+    function from_start(uint256[] calldata array, uint256 end)
+        external
+        pure
+        returns (uint256[] calldata)
+    {
+        return array[:end];
+    }
+
+    function to_end(uint256[] calldata array, uint256 start)
+        external
+        pure
+        returns (uint256[] calldata)
+    {
+        return array[start:];
+    }
+
+    function full_open(uint256[] calldata array)
+        external
+        pure
+        returns (uint256[] calldata)
+    {
+        return array[:];
+    }
+
+    function of_bytes(bytes calldata data, uint256 start, uint256 end)
+        external
+        pure
+        returns (bytes calldata)
+    {
+        return data[start:end];
+    }
+}

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -8,6 +8,23 @@
 // CHECK: sol.func {{.*}}pushEmpty
 // CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
 // CHECK-NOT: sol.store
+
+// CHECK: sol.func {{.*}}pushAssign
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func {{.*}}pushCompound
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+// CHECK:   sol.cadd %{{.*}}, %{{.*}} : ui256
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func {{.*}}pushByte
+// CHECK:   sol.push_string %{{.*}}, %{{.*}} : <Storage>, !sol.fixedbytes<1>
+
+// CHECK: sol.func {{.*}}pushByteEmpty
+// CHECK:   sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
+
 // CHECK: sol.func {{.*}}popLast
 // CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>
 
@@ -27,6 +44,22 @@ contract C {
 
     function pushEmpty() public {
         arr.push();
+    }
+
+    function pushAssign(uint256 x) public {
+        arr.push() = x;
+    }
+
+    function pushCompound(uint256 x) public {
+        arr.push() += x;
+    }
+
+    function pushByte(bytes1 element) public {
+        data.push(element);
+    }
+
+    function pushByteEmpty() public {
+        data.push();
     }
 
     function popLast() public {

--- a/solx-mlir/tests/lit/bytes.sol
+++ b/solx-mlir/tests/lit/bytes.sol
@@ -1,8 +1,0 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
-
-// CHECK: sol.func {{.*}}bytes_id{{.*}}!sol.string<Memory>{{.*}}!sol.string<Memory>
-
-contract C {
-    function bytes_id(bytes memory b) public pure returns (bytes memory) { return b; }
-}

--- a/solx-mlir/tests/lit/concat.sol
+++ b/solx-mlir/tests/lit/concat.sol
@@ -1,0 +1,32 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func {{.*}}bytes_concat{{.*}}-> !sol.string<Memory>
+// CHECK:   sol.concat %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.string<Memory> -> <Memory>
+
+// CHECK: sol.func {{.*}}string_concat{{.*}}-> !sol.string<Memory>
+// CHECK:   sol.concat %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.string<Memory> -> <Memory>
+
+// CHECK: sol.func {{.*}}mixed{{.*}}-> !sol.string<Memory>
+// CHECK:   sol.concat %{{.*}}, %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.fixedbytes<4>, !sol.string<Memory> -> <Memory>
+
+// CHECK: sol.func {{.*}}empty{{.*}}-> !sol.string<Memory>
+// CHECK:   sol.concat -> <Memory>
+
+contract Concat {
+    function bytes_concat(bytes memory a, bytes memory b) public pure returns (bytes memory) {
+        return bytes.concat(a, b);
+    }
+
+    function string_concat(string memory a, string memory b) public pure returns (string memory) {
+        return string.concat(a, b);
+    }
+
+    function mixed(bytes memory a, bytes4 t, bytes memory b) public pure returns (bytes memory) {
+        return bytes.concat(a, t, b);
+    }
+
+    function empty() public pure returns (bytes memory) {
+        return bytes.concat();
+    }
+}

--- a/solx-mlir/tests/lit/delete.sol
+++ b/solx-mlir/tests/lit/delete.sol
@@ -24,6 +24,18 @@
 // CHECK: sol.func @{{.*delete_local.*}}
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
 
+// CHECK: sol.func @{{.*delete_memory_struct.*}}
+// CHECK:   sol.malloc zero_init : !sol.struct<(ui256, ui256), Memory>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, !sol.ptr<!sol.struct<(ui256, ui256), Memory>, Stack>
+
+// CHECK: sol.func @{{.*delete_memory_array.*}}
+// CHECK:   sol.malloc zero_init : !sol.array<? x ui256, Memory>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.array<? x ui256, Memory>, !sol.ptr<!sol.array<? x ui256, Memory>, Stack>
+
+// CHECK: sol.func @{{.*delete_memory_string.*}}
+// CHECK:   sol.malloc : !sol.string<Memory>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
+
 contract C {
     uint256 scalar;
     bytes32 word;
@@ -64,5 +76,17 @@ contract C {
     function delete_local(uint256 value) public pure returns (uint256) {
         delete value;
         return value;
+    }
+
+    function delete_memory_struct(S memory value) public pure {
+        delete value;
+    }
+
+    function delete_memory_array(uint256[] memory value) public pure {
+        delete value;
+    }
+
+    function delete_memory_string(string memory value) public pure {
+        delete value;
     }
 }

--- a/solx-mlir/tests/lit/reference_assignment.sol
+++ b/solx-mlir/tests/lit/reference_assignment.sol
@@ -16,6 +16,12 @@
 // CHECK: sol.func @{{.*rebind.*}}
 // CHECK:   sol.length %{{.*}} : !sol.array<? x ui256, Storage>
 
+// CHECK: sol.func @{{.*from_calldata.*}}
+// CHECK:   sol.data_loc_cast %{{.*}} : !sol.array<? x ui256, CallData>, !sol.array<? x ui256, Memory>
+
+// CHECK: sol.func @{{.*from_storage.*}}
+// CHECK:   sol.data_loc_cast %{{.*}} : !sol.array<? x ui256, Storage>, !sol.array<? x ui256, Memory>
+
 contract C {
     uint256[3] fixed_array;
     uint256[] dynamic_array;
@@ -47,5 +53,15 @@ contract C {
     function rebind() public view returns (uint256) {
         uint256[] storage pointer = dynamic_array;
         return pointer.length;
+    }
+
+    function from_calldata(uint256[] calldata source) external pure returns (uint256) {
+        uint256[] memory copy = source;
+        return copy.length;
+    }
+
+    function from_storage() public view returns (uint256) {
+        uint256[] memory copy = dynamic_array;
+        return copy.length;
     }
 }

--- a/solx-mlir/tests/lit/scoping.sol
+++ b/solx-mlir/tests/lit/scoping.sol
@@ -9,8 +9,11 @@
 // CHECK:   sol.constant 42
 // CHECK:   %[[X_PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
 // CHECK:   sol.store %{{.*}}, %[[X_PTR]]
-// CHECK:   sol.constant 0 : ui256
-// CHECK:   sol.return %{{.*}} : ui256
+// CHECK:   %[[Z_PTR:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui256
+// CHECK:   sol.store %[[ZERO]], %[[Z_PTR]]
+// CHECK:   %[[R:.*]] = sol.load %[[Z_PTR]]
+// CHECK:   sol.return %[[R]] : ui256
 
 contract C {
     function nested_scope() public pure returns (uint256) {

--- a/solx-mlir/tests/lit/state_var_initializer.sol
+++ b/solx-mlir/tests/lit/state_var_initializer.sol
@@ -5,6 +5,7 @@
 // CHECK: sol.state_var @s_{{[0-9]+}} slot 1 offset 0 : !sol.string<Storage>
 // CHECK: sol.state_var @small_{{[0-9]+}} slot 2 offset 0 : ui8
 // CHECK: sol.state_var @flag_{{[0-9]+}} slot 2 offset 1 : i1
+// CHECK: sol.state_var @data_{{[0-9]+}} slot 3 offset 0 : !sol.array<3 x ui256, Storage>
 
 // CHECK: sol.func @{{.*}} attributes {kind = #Constructor
 // CHECK:   sol.addr_of @x_{{[0-9]+}} : !sol.ptr<ui256, Storage>
@@ -13,6 +14,9 @@
 // CHECK:   sol.addr_of @s_{{[0-9]+}} : !sol.string<Storage>
 // CHECK:   sol.string_lit "hello" -> !sol.string<Memory>
 // CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.string<Memory>, !sol.string<Storage>
+// CHECK:   sol.addr_of @data_{{[0-9]+}} : !sol.array<3 x ui256, Storage>
+// CHECK:   sol.array_lit %{{.*}}, %{{.*}}, %{{.*}} : (ui8, ui8, ui8) -> !sol.array<3 x ui8, Memory>
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui8, Memory>, !sol.array<3 x ui256, Storage>
 // CHECK:   sol.return
 
 contract C {
@@ -20,4 +24,5 @@ contract C {
     string s = "hello";
     uint8 small;
     bool flag;
+    uint256[3] data = [1, 2, 3];
 }

--- a/solx-mlir/tests/lit/string.sol
+++ b/solx-mlir/tests/lit/string.sol
@@ -3,6 +3,10 @@
 
 // CHECK: sol.func {{.*}}string_id{{.*}}!sol.string<Memory>{{.*}}!sol.string<Memory>
 
+// CHECK: sol.func {{.*}}bytes_id{{.*}}!sol.string<Memory>{{.*}}!sol.string<Memory>
+
 contract C {
     function string_id(string memory s) public pure returns (string memory) { return s; }
+
+    function bytes_id(bytes memory b) public pure returns (bytes memory) { return b; }
 }

--- a/solx-mlir/tests/lit/struct_constructor.sol
+++ b/solx-mlir/tests/lit/struct_constructor.sol
@@ -10,10 +10,20 @@
 // CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Memory>
 
+// CHECK: sol.func {{.*}}build_tagged{{.*}}-> !sol.struct<(!sol.fixedbytes<4>, ui256), Memory>
+// CHECK:   sol.constant {{.*}} : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+
 contract C {
     struct S { uint256 a; uint256 b; }
 
+    struct T { bytes4 tag; uint256 n; }
+
     function build(uint256 x, uint256 y) public pure returns (S memory) {
         return S(x, y);
+    }
+
+    function build_tagged() public pure returns (T memory) {
+        return T("abcd", 7);
     }
 }

--- a/solx-mlir/tests/lit/type_casts.sol
+++ b/solx-mlir/tests/lit/type_casts.sol
@@ -25,6 +25,18 @@
 // CHECK: sol.func @{{.*narrow_bytes.*}}
 // CHECK:   sol.bytes_cast %{{.*}} : !sol.fixedbytes<32> to !sol.fixedbytes<16>
 
+// CHECK: sol.func @{{.*memory_to_bytes32.*}}
+// CHECK:   sol.dyn_bytes_to_fixedbytes %{{.*}} : <Memory> to <32>
+
+// CHECK: sol.func @{{.*calldata_to_bytes32.*}}
+// CHECK:   sol.dyn_bytes_to_fixedbytes %{{.*}} : <CallData> to <32>
+
+// CHECK: sol.func @{{.*bytes_to_memory.*}}
+// CHECK:   sol.data_loc_cast %{{.*}} : !sol.string<CallData>, !sol.string<Memory>
+
+// CHECK: sol.func @{{.*array_to_memory.*}}
+// CHECK:   sol.data_loc_cast %{{.*}} : !sol.array<? x ui256, CallData>, !sol.array<? x ui256, Memory>
+
 contract C {
     function uint8_to_uint256(uint8 x) public pure returns (uint256) {
         return uint256(x);
@@ -56,5 +68,22 @@ contract C {
 
     function narrow_bytes(bytes32 x) public pure returns (bytes16) {
         return bytes16(x);
+    }
+
+    function memory_to_bytes32(bytes memory b) public pure returns (bytes32) {
+        return bytes32(b);
+    }
+
+    function calldata_to_bytes32(bytes calldata b) external pure returns (bytes32) {
+        return bytes32(b);
+    }
+
+    function bytes_to_memory(bytes calldata source) external pure returns (uint256) {
+        bytes memory copy = bytes(source);
+        return copy.length;
+    }
+
+    function array_to_memory(uint256[] calldata source) external pure returns (uint256[] memory) {
+        return uint256[](source);
     }
 }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -346,7 +346,7 @@ impl Call {
                 ))
             }
             Some(BuiltIn::ArrayPop) => {
-                scope.expression(&access.operand()).pop(scope);
+                scope.expression_place(&access.operand()).0.pop(scope);
                 None
             }
             Some(BuiltIn::ArrayPush) => {
@@ -355,26 +355,33 @@ impl Call {
                     .get_type()
                     .expect("base of array push has a resolved type");
                 let value_argument = arguments.iter().next();
-                if value_argument.is_some() && matches!(&base_slang_type, Type::Bytes(_)) {
-                    unimplemented!(
-                        "bytes.push(x) lowers to sol.push_string, which is not yet wired"
+                let (place, _) = scope.expression_place(&base);
+
+                if let Type::Bytes(_) = &base_slang_type
+                    && let Some(value_argument) = &value_argument
+                {
+                    let appended = scope.coerced(
+                        value_argument,
+                        MlirType::fixed_bytes(scope.melior, solx_utils::BYTE_LENGTH_BYTE as u32),
                     );
+                    place.push_string(appended, scope);
+                    return None;
                 }
+
                 let (element_type, slang_location) = match &base_slang_type {
                     Type::Array(array_type) => (
                         scope.resolve_type(&array_type.element_type(), None),
                         array_type.location(),
                     ),
-                    Type::Bytes(bytes_type) => (
-                        MlirType::fixed_bytes(scope.melior, solx_utils::BYTE_LENGTH_BYTE as u32),
-                        bytes_type.location(),
-                    ),
+                    Type::Bytes(bytes_type) => {
+                        (MlirType::byte(scope.melior), bytes_type.location())
+                    }
                     other => unreachable!(
                         "Solidity's .push is a member of dynamic arrays and bytes only; got {:?}",
                         std::mem::discriminant(other)
                     ),
                 };
-                let new_slot = scope.expression(&base).push(
+                let new_slot = place.push(
                     MlirType::pointer(
                         scope.melior,
                         element_type,
@@ -382,11 +389,15 @@ impl Call {
                     ),
                     scope,
                 );
+
                 let Some(value_argument) = value_argument else {
                     return Some(new_slot);
                 };
                 Place::from(new_slot).store(scope.coerced(&value_argument, element_type), scope);
                 None
+            }
+            Some(BuiltIn::BytesConcat | BuiltIn::StringConcat) => {
+                Some(Value::concat(&scope.positional_arguments(arguments), scope))
             }
             _ => unimplemented!("unsupported member call: {}", access.member().name()),
         }
@@ -415,5 +426,20 @@ impl Call {
             scope,
         )
         .expect("sol.call yields its declared results")
+    }
+}
+
+impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
+    /// `arr.push()` is the sole call assignable in place position; the slot it grows is the value the
+    /// push emits, and the element type is the call's own.
+    pub fn function_call_place(
+        &mut self,
+        node: &FunctionCallExpression,
+    ) -> (Place<'context>, MlirType<'context>) {
+        let slot = Call::emit(node, self)
+            .into_iter()
+            .next()
+            .expect("an array push in place position yields the new element's slot");
+        (Place::from(slot), self.typing(node.get_type()))
     }
 }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -431,7 +431,7 @@ impl Call {
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `arr.push()` is the sole call assignable in place position; the slot it grows is the value the
-    /// push emits, and the element type is the call's own.
+    /// push emits, and its element type is that slot's pointee.
     pub fn function_call_place(
         &mut self,
         node: &FunctionCallExpression,
@@ -440,6 +440,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .into_iter()
             .next()
             .expect("an array push in place position yields the new element's slot");
-        (Place::from(slot), self.typing(node.get_type()))
+        (Place::from(slot), slot.r#type().element_type(0))
     }
 }

--- a/solx-slang/src/contract/function/expression/conditional.rs
+++ b/solx-slang/src/contract/function/expression/conditional.rs
@@ -31,7 +31,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             ),
         };
         let condition = self.expression(&node.operand()).is_nonzero(self);
-        let slots: Vec<Place<'context>> = element_types
+        let places: Vec<Place<'context>> = element_types
             .iter()
             .map(|&element_type| Place::stack(element_type, self))
             .collect();
@@ -41,19 +41,19 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             (else_block, node.false_expression()),
         ] {
             self.region(block, |scope| {
-                for ((slot, &element_type), value) in slots
+                for ((place, &element_type), value) in places
                     .iter()
                     .zip(&element_types)
                     .zip(scope.expression_values(&branch))
                 {
-                    slot.store(value.coerce(element_type, scope), scope);
+                    place.store(value.coerce(element_type, scope), scope);
                 }
             });
         }
-        slots
+        places
             .iter()
             .zip(&element_types)
-            .map(|(slot, &element_type)| slot.load(element_type, self))
+            .map(|(place, &element_type)| place.load(element_type, self))
             .collect()
     }
 

--- a/solx-slang/src/contract/function/expression/index_access.rs
+++ b/solx-slang/src/contract/function/expression/index_access.rs
@@ -15,6 +15,9 @@ use crate::scope::function::FunctionScope;
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `b[i]` on fixed bytes indexes the word directly; everything else loads from its place.
     pub fn index_access(&mut self, node: &IndexAccessExpression) -> Value<'context> {
+        if node.is_slice() {
+            return self.index_slice(node);
+        }
         let base_type = node
             .operand()
             .get_type()
@@ -37,10 +40,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         &mut self,
         node: &IndexAccessExpression,
     ) -> (Place<'context>, MlirType<'context>) {
-        if node.end().is_some() {
-            unimplemented!("range index (a[i:j]) is not yet supported");
-        }
-
         let base = node.operand();
         let base_type = base
             .get_type()
@@ -78,5 +77,23 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 )
             }
         }
+    }
+
+    /// `a[start:end]` on a calldata array or `bytes`, defaulting an omitted `start` to zero and an
+    /// omitted `end` to the length.
+    fn index_slice(&mut self, node: &IndexAccessExpression) -> Value<'context> {
+        let base = self.expression(&node.operand());
+        let start = match node.start() {
+            Some(start) => self.expression(&start),
+            None => Value::zero(
+                MlirType::unsigned(self.melior, solx_utils::BIT_LENGTH_FIELD),
+                self,
+            ),
+        };
+        let end = match node.end() {
+            Some(end) => self.expression(&end),
+            None => base.length(self),
+        };
+        base.slice(start, end, self)
     }
 }

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -106,6 +106,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             Expression::Identifier(inner) => self.identifier_place(inner),
             Expression::MemberAccessExpression(inner) => self.member_access_place(inner),
             Expression::IndexAccessExpression(inner) => self.index_access_place(inner),
+            Expression::FunctionCallExpression(inner) => self.function_call_place(inner),
             Expression::TupleExpression(inner) if inner.items().len() == 1 => {
                 let operand = inner
                     .items()

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -85,14 +85,14 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     }
 
     /// Emits `delete <lvalue>`, a value-less reset. A reference-typed storage aggregate, which is its
-    /// own address, recursively clears through `sol.delete`; every other place, a scalar slot, struct
-    /// field, mapping entry, or local, stores its element type's zero, which is `delete` for a scalar.
+    /// own address, recursively clears through `sol.delete`; every other place — a scalar slot, struct
+    /// field, mapping entry, local, or memory aggregate — stores its element type's default.
     fn delete(&mut self, operand: &Expression) {
         let (place, element_type) = self.expression_place(operand);
         if place.r#type() == element_type {
             place.delete(self);
         } else {
-            place.store(Value::zero(element_type, self), self);
+            place.store(Value::default_initialized(element_type, self), self);
         }
     }
 }

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -70,13 +70,8 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                         .map(|(index, parameter)| {
                             let identifier = parameter.name()?;
                             let return_type = scope.return_types[index];
-                            if !return_type.is_scalar() {
-                                unimplemented!(
-                                    "default-initialization for non-scalar named return: {return_type}"
-                                );
-                            }
                             Some(scope.define_local(identifier.name(), return_type, |scope| {
-                                Value::zero(return_type, scope)
+                                Value::default_initialized(return_type, scope)
                             }))
                         })
                         .collect()
@@ -96,7 +91,11 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     .zip(&return_pointers)
                     .map(|(&return_type, return_pointer)| match return_pointer {
                         Some(pointer) => pointer.load(return_type, scope),
-                        None => Value::zero(return_type, scope),
+                        None => {
+                            let pointer = Place::stack(return_type, scope);
+                            pointer.store(Value::default_initialized(return_type, scope), scope);
+                            pointer.load(return_type, scope)
+                        }
                     })
                     .collect();
                 scope.current_block().r#return(&values, scope);

--- a/solx-slang/src/contract/function/statement/variable_declaration.rs
+++ b/solx-slang/src/contract/function/statement/variable_declaration.rs
@@ -30,8 +30,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     }
 
     /// A single-typed variable declaration. An explicit initializer is evaluated before the slot is
-    /// allocated, matching solc's order; an absent one default-initializes the freshly allocated
-    /// slot, which every scalar value type zero-fills.
+    /// allocated, matching solc's order; an absent one default-initializes the slot to the type's
+    /// default value.
     pub fn single_typed_declaration(&mut self, node: &SingleTypedDeclaration) {
         let declared_type = self.typing(node.declaration().get_type());
         match node.value() {
@@ -41,12 +41,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                     value
                 });
             }
-            None if declared_type.is_scalar() => {
+            None => {
                 self.define_local(node.declaration().name().name(), declared_type, |scope| {
-                    Value::zero(declared_type, scope)
+                    Value::default_initialized(declared_type, scope)
                 });
             }
-            None => unimplemented!("default-initialization for non-scalar type {declared_type}"),
         }
     }
 

--- a/solx-slang/src/contract/state_variable.rs
+++ b/solx-slang/src/contract/state_variable.rs
@@ -34,9 +34,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             })
             .collect();
         for (state_variable, slot_name, initializer) in initializers {
-            if matches!(initializer, Expression::ArrayExpression(_)) {
-                unimplemented!("array-literal state variable initializers are not yet supported");
-            }
             let (storage_ref, element_type) =
                 self.state_variable_place(&state_variable, &slot_name);
             if storage_ref.r#type() == element_type {

--- a/solx-utils/src/data_location.rs
+++ b/solx-utils/src/data_location.rs
@@ -25,6 +25,20 @@ pub enum DataLocation {
     Transient = 5,
 }
 
+impl From<u32> for DataLocation {
+    fn from(discriminant: u32) -> Self {
+        match discriminant {
+            0 => Self::Storage,
+            1 => Self::CallData,
+            2 => Self::Memory,
+            3 => Self::Stack,
+            4 => Self::Immutable,
+            5 => Self::Transient,
+            other => unreachable!("no DataLocation with discriminant {other}"),
+        }
+    }
+}
+
 impl From<AddressSpace> for DataLocation {
     fn from(space: AddressSpace) -> Self {
         match space {


### PR DESCRIPTION
Completes memory data structures on the Slang frontend:

- An uninitialized local, named return, or fall-through return of any type now default-initializes: a memory `bytes`/`string` as an empty `sol.malloc`, every other memory aggregate as a zero-filled `sol.malloc zero_init`, and a storage or calldata reference through the `sol.default_storage` / `sol.default_calldata` designators; an unnamed fall-through return materializes through the same anonymous stack slot solc emits.
- `a[start:end]` on a calldata array or `bytes` lowers to `sol.slice`, an omitted start defaulting to zero and an omitted end to `sol.length`; the sliced view keeps the base's own type.
- `bytes.concat` / `string.concat` lower to the variadic `sol.concat`, accepting `bytesN` operands and the empty call, and produce a fresh memory string.
- The push family homes on `Place` as reference-aggregate mutations: `bytes.push(x)` appends through `sol.push_string`, and the argumentless `bytes.push()` yields the dialect's `!sol.ptr<!sol.byte>` slot.
- An implicit reference relocation between data locations — calldata or storage into a memory binding — emits `sol.data_loc_cast`; the explicit `bytes32(b)` narrowing of dynamic bytes emits `sol.dyn_bytes_to_fixedbytes`.
- An array-literal state-variable initializer lands in the constructor as `sol.array_lit` + `sol.copy`.