### PR TITLE
feat(test-harness): cap invariant campaigns, mirroring --fuzz-runs 0

### DIFF
--- a/solx-dev/src/test/foundry/mod.rs
+++ b/solx-dev/src/test/foundry/mod.rs
@@ -434,6 +434,7 @@ pub fn test(
             }
             forge_test_gas_command.args(["--fuzz-runs", "0"]);
             forge_test_gas_command.args(["--fuzz-seed", "0xdeadbeef"]);
+            // Invariant campaigns ignore `--fuzz-runs`; one run mirrors its intent.
             forge_test_gas_command.env("FOUNDRY_INVARIANT_RUNS", "1");
             forge_test_gas_command.args([
                 "--evm-version",

--- a/solx-dev/src/test/foundry/mod.rs
+++ b/solx-dev/src/test/foundry/mod.rs
@@ -367,6 +367,8 @@ pub fn test(
             }
             forge_test_command.args(["--fuzz-runs", "0"]);
             forge_test_command.args(["--fuzz-seed", "0xdeadbeef"]);
+            // Invariant campaigns ignore `--fuzz-runs`; one run mirrors its intent.
+            forge_test_command.env("FOUNDRY_INVARIANT_RUNS", "1");
             forge_test_command.args([
                 "--evm-version",
                 solx_utils::EVMVersion::Prague.to_string().as_str(),
@@ -432,6 +434,7 @@ pub fn test(
             }
             forge_test_gas_command.args(["--fuzz-runs", "0"]);
             forge_test_gas_command.args(["--fuzz-seed", "0xdeadbeef"]);
+            forge_test_gas_command.env("FOUNDRY_INVARIANT_RUNS", "1");
             forge_test_gas_command.args([
                 "--evm-version",
                 solx_utils::EVMVersion::Prague.to_string().as_str(),


### PR DESCRIPTION
When analysing the runtime of integration tests I found that while we put fuzz testing to 0, we have not done so for invariant testing. I did not see a good reason to have more than one run, so I capped invariant tests it similar to fuzz tests.  It gives a surprisingly good test time speed up. 

# Claude summary
## Why

Regular fuzz tests have run with `--fuzz-runs 0` (fixed seed) since the harness landed in #175 — but **invariant campaigns ignore that flag** and run at each project's own defaults (up to 256 runs × full depth), in every tier, twice per toolchain (test + gas passes).

Fixed-seed fuzz depth proves nothing run-to-run: same seed, same paths. This PR applies the existing `--fuzz-runs 0` policy consistently: `FOUNDRY_INVARIANT_RUNS=1` on both forge passes. Invariant suites still execute (setup + one campaign with the fixed seed).

## Measured effect

Comparing this PR's `ci:integration` run ([29657293509](https://github.com/NomicFoundation/solx/actions/runs/29657293509)) against the same day's pre-cap baseline ([29643434263](https://github.com/NomicFoundation/solx/actions/runs/29643434263), restricted to the same solx/solx-main combos), from the harness status-line timestamps:

| Foundry bucket | pre-cap | with cap |
|---|---|---|
| builds | 16.9 min | 16.9 min |
| clones + installs | ~7.3 min | 7.4 min |
| **test passes** | **3.7 min** | **0.7 min** |
| **gas passes** | **5.0 min** | **1.7 min** |

**~6 min off every standard-tier run (~14% of the job, 45 → 38.7 min)**, all of it from the four invariant-suite projects (openzeppelin −223 s, morpho-blue −101 s, maple-erc20 −28 s, solmate −23 s across the combos); the other 21 projects are unchanged to the second. The full tier saves proportionally more (8 combos × 2 passes).

## Interactions — verified on the run above

- **No baseline shift**: Foundry pre-existing failures are exactly **685**, identical to the pre-cap baseline — invariant verdicts are stable at one campaign, and PR-vs-main pairing was sound throughout (both sides run capped in the same job).
- Size comparisons identical at 4,972 rows on both runs; gas rows 5,193 vs 5,208 — the missing ~15 are invariant-campaign gas rows, which are the fuzz jitter the summary comment already excludes from any verdict.

## Verification

- 3-line diff; `cargo build`/`clippy`/`fmt` clean on `solx-dev`.
- Real-data proof above: summary comment on this PR reports output-preserving, 0 new failures.
