### PR TITLE
ci: add actionlint + zizmor GitHub Actions linters

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Self-hosted runner labels, so actionlint doesn't flag `runs-on:` as unknown.
+self-hosted-runner:
+  labels:
+    - solx-linux-amd64
+    - solx-linux-amd64-self-hosted

--- a/.github/actions/build-rust/action.yml
+++ b/.github/actions/build-rust/action.yml
@@ -57,7 +57,7 @@ runs:
         RUSTC_BOOTSTRAP: 1
         RUSTFLAGS: '-C target-feature=+crt-static'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash -ex {0}' }}
-      run: |
+      run: | # zizmor: ignore[github-env] the only GITHUB_PATH write is BINARY_DIR, built from repo-controlled inputs
         # Sanitize build environment: clear variables that could tamper with compilation.
         # RUSTC_WRAPPER / RUSTC_WORKSPACE_WRAPPER: could redirect compilation through a malicious wrapper.
         # LD_PRELOAD / LD_LIBRARY_PATH / DYLD_*: could inject code into compiler and linker processes.

--- a/.github/actions/deploy-mdbook/action.yml
+++ b/.github/actions/deploy-mdbook/action.yml
@@ -9,42 +9,34 @@ inputs:
     description: 'GitHub token for deployment.'
     required: true
   version:
-    type: string
     description: "Version of the documentation to deploy"
     required: false
     default: "latest"
   docs-dir:
-    type: string
     description: "Directory containing the mdbook documentation"
     required: false
     default: "docs"
   mdbook-version:
-    type: string
     description: "Version of mdbook to use"
     required: false
     default: "latest"
   enable-tests:
-    type: boolean
     description: "Disable mdbook tests"
     required: false
     default: true
   publish-branch:
-    type: string
     description: "Branch to publish the documentation"
     required: false
     default: "gh-pages"
   project:
-    type: string
     description: "Name of the project to deploy"
     required: false
     default: ""
   deploy:
-    type: boolean
     description: "Enable or disable the deployment"
     required: false
     default: false
   create-latest-symlink:
-    type: boolean
     description: "Create a symlink to the latest version"
     required: false
     default: false

--- a/.github/actions/deploy-mdbook/action.yml
+++ b/.github/actions/deploy-mdbook/action.yml
@@ -21,9 +21,9 @@ inputs:
     required: false
     default: "latest"
   enable-tests:
-    description: "Disable mdbook tests"
+    description: "Run mdbook tests before deploying"
     required: false
-    default: true
+    default: "true"
   publish-branch:
     description: "Branch to publish the documentation"
     required: false
@@ -35,11 +35,11 @@ inputs:
   deploy:
     description: "Enable or disable the deployment"
     required: false
-    default: false
+    default: "false"
   create-latest-symlink:
     description: "Create a symlink to the latest version"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: composite

--- a/.github/actions/setup-sfw/action.yml
+++ b/.github/actions/setup-sfw/action.yml
@@ -104,7 +104,7 @@ runs:
       env:
         SFW_OPTIONAL: ${{ inputs.optional }}
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] the only GITHUB_ENV write is SFW_PREFIX, a static RUNNER_TEMP wrapper path
         fail() {
           if [ "${SFW_OPTIONAL}" = "true" ]; then
             echo "::warning::$1 — dependency installs will run UNPROTECTED."

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         if: runner.os == 'Linux' && matrix.image != ''
@@ -122,6 +123,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         if: runner.os == 'Linux' && matrix.image != ''
@@ -154,6 +156,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux
@@ -197,6 +200,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux
@@ -241,6 +245,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux

--- a/.github/workflows/compile-benchmark.yaml
+++ b/.github/workflows/compile-benchmark.yaml
@@ -64,6 +64,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: true
+          persist-credentials: false
 
       # actions/checkout's `git clean -ffdx` doesn't recurse into submodules,
       # so on a persistent self-hosted workspace a previous run can leave
@@ -77,6 +78,7 @@ jobs:
         with:
           ref: main
           submodules: true
+          persist-credentials: false
           path: temp-solx-main
 
       - name: Checkout submodules (PR)

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux
@@ -108,16 +109,18 @@ jobs:
           target: 'x86_64-unknown-linux-gnu'
 
       - name: Run integration tests
+        env:
+          SOLX_BINARY: ${{ steps.build-solx.outputs.binary-path }}
         run: |
           TMP="${PROFDATA_FILE}.tmp"
           TARGET_DIR="./target/x86_64-unknown-linux-gnu/release"
           for TEST_PATH in tests/solidity/simple/default.sol tests/solidity/complex/default; do
-            WORKDIR=$(basename ${TEST_PATH})
+            WORKDIR=$(basename "${TEST_PATH}")
             mkdir -p "${GITHUB_WORKSPACE}/${WORKDIR}"
             "${TARGET_DIR}/solx-dev" test solx-tester \
               --binary "${TARGET_DIR}/solx-tester" \
-              --solidity-compiler ${{ steps.build-solx.outputs.binary-path }} \
-              --path ${TEST_PATH} --workflow build --optimizer M3B3
+              --solidity-compiler "${SOLX_BINARY}" \
+              --path "${TEST_PATH}" --workflow build --optimizer M3B3
             mv *.profraw "${GITHUB_WORKSPACE}/${WORKDIR}/" || true
             find "${GITHUB_WORKSPACE}/${WORKDIR}" -type f -name '*.profraw' -print > profiles.lst
             if [[ -f "${PROFDATA_FILE}" ]]; then
@@ -126,7 +129,7 @@ jobs:
               llvm-profdata merge -sparse -num-threads="$(nproc)" -o "${TMP}" @profiles.lst
             fi
             mv -f "${TMP}" "${PROFDATA_FILE}"
-            rm -rf "${GITHUB_WORKSPACE}/${WORKDIR}"
+            rm -rf "${GITHUB_WORKSPACE}/${WORKDIR:?}"
           done
 
       - name: Preserve instrumented binary

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -46,6 +46,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] deploy-mdbook pushes to the docs branch over `origin` using the token this checkout persists
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Deploy

--- a/.github/workflows/docker-ci-image.yaml
+++ b/.github/workflows/docker-ci-image.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU (for arm64 cross-build)
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: true
+          persist-credentials: false
 
       # actions/checkout's `git clean -ffdx` doesn't recurse into submodules,
       # so on a persistent self-hosted workspace a previous run can leave
@@ -73,6 +74,7 @@ jobs:
         with:
           ref: main
           submodules: true
+          persist-credentials: false
           path: temp-solx-main
 
       - name: Checkout submodules (PR)
@@ -410,21 +412,27 @@ jobs:
       # here would misattribute it.
       - name: Fail workflow if tests or benchmarks failed
         if: always()
+        env:
+          SOLX_TESTER_TESTS_OUTCOME: ${{ steps.solx_tester_tests.outcome }}
+          SOLX_TESTER_BENCH_PR_OUTCOME: ${{ steps.solx_tester_bench_pr.outcome }}
+          BENCHMARK_CONVERTER_OUTCOME: ${{ steps.benchmark_converter.outcome }}
+          HARDHAT_TESTS_OUTCOME: ${{ steps.hardhat_tests.outcome }}
+          FOUNDRY_TESTS_OUTCOME: ${{ steps.foundry_tests.outcome }}
         run: |
           failures=()
-          if [ "${{ steps.solx_tester_tests.outcome }}" = "failure" ]; then
+          if [ "${SOLX_TESTER_TESTS_OUTCOME}" = "failure" ]; then
             failures+=("solx-tester tests")
           fi
-          if [ "${{ steps.solx_tester_bench_pr.outcome }}" = "failure" ]; then
+          if [ "${SOLX_TESTER_BENCH_PR_OUTCOME}" = "failure" ]; then
             failures+=("solx-tester benchmarks (PR)")
           fi
-          if [ "${{ steps.benchmark_converter.outcome }}" = "failure" ]; then
+          if [ "${BENCHMARK_CONVERTER_OUTCOME}" = "failure" ]; then
             failures+=("benchmark converter")
           fi
-          if [ "${{ steps.hardhat_tests.outcome }}" = "failure" ]; then
+          if [ "${HARDHAT_TESTS_OUTCOME}" = "failure" ]; then
             failures+=("hardhat tests")
           fi
-          if [ "${{ steps.foundry_tests.outcome }}" = "failure" ]; then
+          if [ "${FOUNDRY_TESTS_OUTCOME}" = "failure" ]; then
             failures+=("foundry tests")
           fi
           if [ ${#failures[@]} -ne 0 ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,10 +106,18 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: 'recursive'
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       - name: Prepare matrix
         id: prepare-matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_WINDOWS_AMD64: ${{ github.event.inputs.release_windows_amd64 }}
+          RELEASE_MACOS_AMD64: ${{ github.event.inputs.release_macos_amd64 }}
+          RELEASE_MACOS_ARM64: ${{ github.event.inputs.release_macos_arm64 }}
+          RELEASE_LINUX_AMD64_GNU: ${{ github.event.inputs.release_linux_amd64_gnu }}
+          RELEASE_LINUX_ARM64_GNU: ${{ github.event.inputs.release_linux_arm64_gnu }}
         run: |
           # Define general matrix parameters
           WINDOWS='{"name":"Windows","runner":"windows-2025","release-suffix":"windows-amd64-gnu"}'
@@ -118,14 +126,18 @@ jobs:
           LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"ubuntu-24.04","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
           LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"ubuntu-24.04-arm","image":"ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
           # Disable platforms for non-tag builds if user requested
-          if [ '${{ github.event_name }}' = 'workflow_dispatch' ] && [ "${GITHUB_REF_TYPE}" != tag ]; then
-            [ "${{ github.event.inputs.release_windows_amd64 }}" != true ] && WINDOWS=
-            [ "${{ github.event.inputs.release_macos_amd64 }}" != true ] && MACOS_AMD64=
-            [ "${{ github.event.inputs.release_macos_arm64 }}" != true ] && MACOS_ARM64=
-            [ "${{ github.event.inputs.release_linux_amd64_gnu }}" != true ] && LINUX_AMD64_GNU=
-            [ "${{ github.event.inputs.release_linux_arm64_gnu }}" != true ] && LINUX_ARM64_GNU=
+          if [ "${EVENT_NAME}" = 'workflow_dispatch' ] && [ "${GITHUB_REF_TYPE}" != tag ]; then
+            [ "${RELEASE_WINDOWS_AMD64}" != true ] && WINDOWS=
+            [ "${RELEASE_MACOS_AMD64}" != true ] && MACOS_AMD64=
+            [ "${RELEASE_MACOS_ARM64}" != true ] && MACOS_ARM64=
+            [ "${RELEASE_LINUX_AMD64_GNU}" != true ] && LINUX_AMD64_GNU=
+            [ "${RELEASE_LINUX_ARM64_GNU}" != true ] && LINUX_ARM64_GNU=
           fi
-          PLATFORMS=(${WINDOWS} ${MACOS_AMD64} ${MACOS_ARM64} ${LINUX_AMD64_GNU} ${LINUX_ARM64_GNU})
+          # Collect only the platforms left non-empty above; disabled ones are dropped.
+          PLATFORMS=()
+          for platform in "${WINDOWS}" "${MACOS_AMD64}" "${MACOS_ARM64}" "${LINUX_AMD64_GNU}" "${LINUX_ARM64_GNU}"; do
+            [ -n "${platform}" ] && PLATFORMS+=("${platform}")
+          done
           echo "matrix={ \"include\": [ $(IFS=, ; echo "${PLATFORMS[*]}") ] }" | tee -a "${GITHUB_OUTPUT}"
 
   build:
@@ -145,6 +157,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: 'recursive'
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       # This step is required to checkout submodules
@@ -204,6 +217,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       # Gets the tag of the published release marked `latest`
@@ -239,6 +253,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       - name: Download artifacts
@@ -249,26 +264,31 @@ jobs:
 
       - name: Identify release name
         id: release
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          EVENT_NAME: ${{ github.event_name }}
+          PRERELEASE_SUFFIX: ${{ github.event.inputs.prerelease_suffix }}
         run: |
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-          if [ '${{ github.ref_type }}' = 'tag' ]; then
+          if [ "${REF_TYPE}" = 'tag' ]; then
             VERSION_OR_SHA="${GITHUB_REF#refs/tags/}"
-            echo "release_title=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
+            echo "release_title=${VERSION_OR_SHA}" >> "$GITHUB_OUTPUT"
           else
             VERSION_OR_SHA=$(git rev-parse --short HEAD)
-            echo "full_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-            if [ '${{ github.event_name }}' = 'pull_request' ]; then
-              echo "release_title=pr-dry-run-${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
+            echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            if [ "${EVENT_NAME}" = 'pull_request' ]; then
+              echo "release_title=pr-dry-run-${VERSION_OR_SHA}" >> "$GITHUB_OUTPUT"
             else
-              echo "release_title=prerelease-${VERSION_OR_SHA}-${{ github.event.inputs.prerelease_suffix }}" >> $GITHUB_OUTPUT
+              echo "release_title=prerelease-${VERSION_OR_SHA}-${PRERELEASE_SUFFIX}" >> "$GITHUB_OUTPUT"
             fi
           fi
-          echo "version_or_sha=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
+          echo "version_or_sha=${VERSION_OR_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Check release version
         if: github.ref_type == 'tag'
+        env:
+          TAG: ${{ steps.release.outputs.version_or_sha }}
         run: |
-          TAG="${{ steps.release.outputs.version_or_sha }}"
           CARGO_PACKAGE_VERSION="$(${SFW_PREFIX:-} cargo pkgid --manifest-path solx/Cargo.toml | cut -d "#" -f2)"
           # All versions must be equal
           if [ "${CARGO_PACKAGE_VERSION}" != "${TAG}" ]; then
@@ -525,6 +545,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       - name: Download release bundle
@@ -583,6 +604,7 @@ jobs:
 
       - name: Publish release
         if: github.event_name != 'pull_request'
+        # zizmor: ignore[superfluous-actions] deliberate: gh-release handles release creation, asset globbing, changelog body, and prerelease flag in one step
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: ${{ needs.prepare.outputs.release_title }}
@@ -632,20 +654,25 @@ jobs:
           echo "============================================"
 
       - name: Summary
+        env:
+          RELEASE_TITLE: ${{ needs.prepare.outputs.release_title }}
+          VERSION_OR_SHA: ${{ needs.prepare.outputs.version_or_sha }}
+          IS_PRERELEASE: ${{ github.ref_type != 'tag' }}
+          ENVIRONMENT: ${{ github.event_name != 'pull_request' && 'solx-release' || 'none (dry-run)' }}
         run: |
-          echo "### Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| **Title** | \`${{ needs.prepare.outputs.release_title }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Version** | \`${{ needs.prepare.outputs.version_or_sha }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Prerelease** | \`${{ github.ref_type != 'tag' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Environment** | \`${{ github.event_name != 'pull_request' && 'solx-release' || 'none (dry-run)' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Files:**" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          find releases -type f -not -name '*.sha256' | sort >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### Release Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Title** | \`${RELEASE_TITLE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Version** | \`${VERSION_OR_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Prerelease** | \`${IS_PRERELEASE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Environment** | \`${ENVIRONMENT}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Files:**" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          find releases -type f -not -name '*.sha256' | sort >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
   deploy-docs:
     if: github.ref_type == 'tag'
@@ -679,7 +706,8 @@ jobs:
       - name: Download and run installation script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          curl -fsSL -o "${{ runner.temp }}/install-solx" \
-            "https://raw.githubusercontent.com/NomicFoundation/solx/${{ github.ref_name }}/install-solx"
-          bash "${{ runner.temp }}/install-solx"
+          curl -fsSL -o "${RUNNER_TEMP}/install-solx" \
+            "https://raw.githubusercontent.com/NomicFoundation/solx/${REF_NAME}/install-solx"
+          bash "${RUNNER_TEMP}/install-solx"

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
   packages: read
 
 concurrency:
@@ -38,6 +37,11 @@ jobs:
   sanitizer:
     needs: [label-check, cooldown-check]
     runs-on: solx-linux-amd64-self-hosted
+    # checks: write for the rust-unit-tests action's test-results check run.
+    permissions:
+      contents: read
+      checks: write
+      packages: read
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       options: -m 110g
@@ -50,6 +54,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Checkout submodules
         uses: ./.github/actions/checkout-submodules

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
   packages: read
 
 concurrency:
@@ -41,6 +40,11 @@ jobs:
 
   slang-tests:
     needs: [label-check, cooldown-check]
+    # checks: write for the rust-unit-tests action's test-results check run.
+    permissions:
+      contents: read
+      checks: write
+      packages: read
     env:
       CARGO_TARGET_DIR: target-slang
       CARGO_INCREMENTAL: "0"
@@ -73,6 +77,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       # solc is built separately below: the lit tests need a Release build
       # against a synced solx-solidity, not the standard config.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
       devcontainer: ${{ steps.filter-devcontainer.outputs.devcontainer }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -71,6 +73,8 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Shellcheck devcontainer scripts
         run: shellcheck .devcontainer/*.sh
@@ -108,6 +112,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux
@@ -250,6 +255,42 @@ jobs:
         with:
           target: ${{ matrix.target || '' }}
 
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # Official image bundles shellcheck + pyflakes, so `run:` linting needs no runner deps.
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        env:
+          # Gate on shellcheck warnings/errors; info-level style nits are noise.
+          SHELLCHECK_OPTS: --severity=warning
+        with:
+          args: -color
+
+  zizmor:
+    name: Audit GitHub Actions security (zizmor)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        with:
+          tool: zizmor@1.26.1
+      # GH_TOKEN enables the online audits (known-vulnerabilities, tag->SHA resolution).
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: zizmor --format github .github
+
   # Special job that allows some of the jobs to be skipped or failed
   # requiring others to be successful
   pr-checks:
@@ -262,6 +303,8 @@ jobs:
       - build-and-test
       - cooldown-check
       - renovate-config-check
+      - actionlint
+      - zizmor
     steps:
       - name: Decide on PR checks
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# Template injection inside a composite action is a call-site concern: an
+# action's `inputs.*` are supplied by whatever workflow invokes it, so the
+# injection risk lives where the action is called, not in the action body.
+# Every composite action here is fed only repo-controlled values (build flags,
+# targets, runner facts), never external event data. Workflows stay fully
+# gated, so any new `github.event.*`-into-`run:` sink is still caught.
+#
+# zizmor matches `ignore` entries by basename, and every composite action is
+# named `action.yml`, so this single entry exempts them all.
+rules:
+  template-injection:
+    ignore:
+      - action.yml


### PR DESCRIPTION
Based on successful usage for EDR ([#1545](https://github.com/NomicFoundation/edr/pull/1545)) and Slang, adds `actionlint` (workflow correctness) and `zizmor` (Actions security auditing).

# Claude summary

Two static-analysis gates for the repo's own GitHub Actions, as parallel blocking jobs in `test.yaml` (wired into the `pr-checks` alls-green gate).

## How they run

| Tool | Mechanism | Notes |
|---|---|---|
| actionlint | `uses: docker://rhysd/actionlint@<digest>` | digest-pinned official image; bundles shellcheck + pyflakes, so `run:` linting needs no runner deps. `SHELLCHECK_OPTS: --severity=warning` gates on warnings/errors, drops info-level style nits. |
| zizmor | `taiki-e/install-action` with `tool: zizmor@1.26.1` | `GH_TOKEN` enables the online audits. |

Both run with `permissions: contents: read` and `persist-credentials: false`, and have no `needs:`, so they run in parallel with the rest of CI. They always run (no `changes` filter), so they're in `pr-checks`' `needs:` but not its `allowed-skips`.

## Config

- `.github/actionlint.yaml` declares the self-hosted runner labels (`solx-linux-amd64`, `solx-linux-amd64-self-hosted`) so `runs-on:` isn't flagged as unknown.
- `.github/zizmor.yml` exempts **composite actions** from `template-injection`. solx's composite actions (`build-llvm`, `build-rust`, `rust-unit-tests`, …) are parameter-heavy build orchestration, and template-injection inside a composite action is a *call-site* concern: an action's `inputs.*` are supplied by whatever workflow invokes it, so the risk lives where the action is called, not in the body. Every one here is fed only repo-controlled values (build flags, targets, runner facts), never external event data. **Workflows stay fully gated**, so any new `github.event.*`-into-`run:` sink is still caught. (zizmor matches ignores by basename, and every composite action is `action.yml`, so a single entry expresses this.)

## Findings resolved (both gates land green)

The first run surfaced 199 zizmor findings, dominated by 115 `template-injection` — ~95% of which were the internal composite-action inputs described above.

- **`template-injection` (workflows)** — routed `github.ref_name`, `github.event.inputs.*`, step outcomes, and `needs.*` outputs through `env:` in `release.yaml`, `integration-tests.yaml`, `coverage.yaml`. No behaviour change.
- **`excessive-permissions`** — moved `checks: write` (needed only by the `rust-unit-tests` action's test-results check run) from workflow level down to the `sanitizer` / `slang-tests` jobs, matching how `test.yaml` already scopes it.
- **`artipacked`** — added `persist-credentials: false` to checkouts. Both submodules (`solx-llvm`, `solx-solidity`) are public HTTPS, so later `git submodule update` needs no token.
- **`github-env` (verified-safe suppressions)** — `build-rust`'s only `GITHUB_PATH` write is `BINARY_DIR`, built from repo-controlled inputs; `setup-sfw`'s only `GITHUB_ENV` write is a static `RUNNER_TEMP` path.
- **`superfluous-actions`** — suppressed `softprops/action-gh-release` (deliberate: handles release creation, asset globbing, changelog body, and prerelease flag in one step).

### Suppression kept with justification

- **`artipacked` on `deploy-docs`** — its `deploy-mdbook` step does `git fetch`/`git push --force` over `origin` using the token this checkout persists, so `persist-credentials: false` would break the docs deploy.

## actionlint content fixes

- Removed the invalid `type:` keys from `deploy-mdbook` composite-action inputs (unsupported for composite actions; GitHub ignores them at runtime but actionlint rejects the metadata).
- `coverage.yaml`: guarded `rm -rf` with `${WORKDIR:?}` (SC2115).
- `release.yaml`: build the platform-matrix array by filtering non-empty entries instead of unquoted word-splitting (SC2206).

## Verification

Ran both tools locally against `.github`: actionlint (`--severity=warning`) and zizmor both report **no findings** (exit 0).

---

**Note:** CI-only change — no changeset/label gymnastics expected, but flag if the changeset or cooldown gates want anything before this goes ready.