### PR TITLE
ci: extract the standard-config toolchain prologue into build-toolchain

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -1,0 +1,67 @@
+name: Build toolchain
+description: >-
+  Shared CI prologue for the standard toolchain configuration: submodule
+  checkout, Socket Firewall, platform prep (MSYS2 on Windows, disk cleanup
+  on macOS), then the LLVM and solc builds. The build parameters below
+  define the standard-config cache keys shared by test.yaml,
+  slang-tests.yaml, and cache-warmup.yaml — changing them here re-keys all
+  of those workflows together. Workflows needing a different LLVM
+  configuration (sanitizer, coverage, integration, release) call
+  build-llvm/build-solc directly and pair with their own cache-warmup job.
+
+inputs:
+  llvm:
+    description: Whether to build LLVM
+    required: false
+    default: 'true'
+  solc:
+    description: Whether to build solc
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout submodules
+      uses: ./.github/actions/checkout-submodules
+
+    - name: Setup SFW (optional)
+      uses: ./.github/actions/setup-sfw
+      with:
+        optional: 'true'
+
+    - name: Prepare Windows env
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/prepare-msys
+
+    - name: Free disk space (macOS)
+      if: runner.os == 'macOS'
+      uses: ./.github/actions/free-disk-space-macos
+
+    - name: Build LLVM
+      if: inputs.llvm == 'true'
+      uses: ./.github/actions/build-llvm
+      with:
+        build-type: RelWithDebInfo
+        enable-assertions: 'true'
+        enable-mlir: 'true'
+        enable-utils: 'true'
+
+    # Fresh llvm-sys objects under MSYS2 GCC 16 cannot link against the
+    # static libstdc++.a that solx-dev bundles into the LLVM tree; dropping
+    # it resolves -lstdc++ to the shared libstdc++.dll.a instead (#550, fix
+    # option 2). Test builds link libstdc++ shared; release binaries keep
+    # static linking (release.yaml builds LLVM itself and does not use this
+    # action). Runs after build-llvm's mid-action cache save, so the shared
+    # cached tree keeps the archive.
+    - name: Drop bundled static libstdc++ (Windows)
+      if: runner.os == 'Windows' && inputs.llvm == 'true'
+      shell: bash
+      run: rm -v target-llvm/target-final/lib/libstdc++.a
+
+    - name: Build solc
+      if: inputs.solc == 'true'
+      uses: ./.github/actions/build-solc
+      with:
+        cmake-build-type: RelWithDebInfo
+        working-dir: 'solx-solidity'

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -68,27 +68,10 @@ jobs:
         if: runner.os == 'Linux' && matrix.image != ''
         uses: ./.github/actions/free-disk-space-linux
 
-      - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
-
-      - name: Prepare Windows env
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/prepare-msys
-
-      - name: Setup SFW (optional)
-        uses: ./.github/actions/setup-sfw
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
         with:
-          optional: 'true'
-
-      - name: Build LLVM
-        uses: ./.github/actions/build-llvm
-        with:
-          build-type: RelWithDebInfo
-          enable-assertions: 'true'
-          enable-mlir: 'true'
-          enable-utils: 'true'
+          solc: 'false'
 
       # When the artifact cache is warm, build-llvm skips ccache entirely,
       # so the ccache entry's LRU timer isn't refreshed. Touch it explicitly
@@ -144,26 +127,10 @@ jobs:
         if: runner.os == 'Linux' && matrix.image != ''
         uses: ./.github/actions/free-disk-space-linux
 
-      - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
-
-      - name: Prepare Windows env
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/prepare-msys
-
-      - name: Setup SFW (optional)
-        uses: ./.github/actions/setup-sfw
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
         with:
-          optional: 'true'
-
-      - name: Build solc
-        uses: ./.github/actions/build-solc
-        with:
-          cmake-build-type: RelWithDebInfo
-          boost-version: '1.83.0'
-          working-dir: 'solx-solidity'
+          llvm: 'false'
 
       - name: Touch solc ccache
         if: always()

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -74,27 +74,12 @@ jobs:
         with:
           submodules: true
 
-      # This step is required to checkout submodules
-      # that are disabled in .gitmodules config
-      - name: Checkout submodules
-        uses: ./.github/actions/checkout-submodules
-
-      - name: Setup SFW (optional)
-        uses: ./.github/actions/setup-sfw
+      # solc is built separately below: the lit tests need a Release build
+      # against a synced solx-solidity, not the standard config.
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
         with:
-          optional: 'true'
-
-      - name: Prepare Windows env
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/prepare-msys
-
-      - name: Build LLVM
-        uses: ./.github/actions/build-llvm
-        with:
-          build-type: RelWithDebInfo
-          enable-assertions: 'true'
-          enable-mlir: 'true'
-          enable-utils: 'true'
+          solc: 'false'
 
       # TODO: remove this step and the Build solc step below once the lit
       # tests stop running against solc.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,17 +112,10 @@ jobs:
       - name: Free disk space (Linux)
         uses: ./.github/actions/free-disk-space-linux
 
-      # This step is required to checkout submodules
-      # that are disabled in .gitmodules config
-      - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
-
-      - name: Setup SFW (optional)
-        uses: ./.github/actions/setup-sfw
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
         with:
-          optional: 'true'
+          solc: 'false'
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -130,14 +123,6 @@ jobs:
           prefix-key: cargo-checks-v1
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build LLVM
-        uses: ./.github/actions/build-llvm
-        with:
-          build-type: RelWithDebInfo
-          enable-assertions: 'true'
-          enable-mlir: 'true'
-          enable-utils: 'true'
 
       - name: Cargo checks
         uses: ./.github/actions/cargo-check
@@ -234,46 +219,18 @@ jobs:
         if: runner.os == 'Linux' && matrix.image != ''
         uses: ./.github/actions/free-disk-space-linux
 
-      # This step is required to checkout submodules
-      # that are disabled in .gitmodules config
-      - name: Checkout submodules
-        run: |
-          git config --global --add safe.directory '*'
-          git submodule update --force --depth=1 --recursive --checkout
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
 
-      - name: Setup SFW (optional)
-        uses: ./.github/actions/setup-sfw
-        with:
-          optional: 'true'
-
-      - name: Prepare Windows env
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/prepare-msys
-
-      - name: Free disk space (macOS)
-        if: runner.os == 'macOS'
-        uses: ./.github/actions/free-disk-space-macos
-
+      # Positioned after build-toolchain: prepare-msys switches the rustup
+      # host, which is part of the cache key, so only the post-msys position
+      # matches the keys already saved on main.
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: build-and-test-v2
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build LLVM
-        uses: ./.github/actions/build-llvm
-        with:
-          build-type: RelWithDebInfo
-          enable-assertions: 'true'
-          enable-mlir: 'true'
-          enable-utils: 'true'
-
-      - name: Building solc
-        uses: ./.github/actions/build-solc
-        with:
-          cmake-build-type: RelWithDebInfo
-          working-dir: 'solx-solidity'
 
       - name: Free disk space (remove LLVM source and build artifacts)
         shell: bash


### PR DESCRIPTION
Share more of the toolchain between Tests and Slang tests, and fix the Free disk space (macOS) mixing for Slang while we're at it.


# Claude summary
## Why now

[Run 29762518487](https://github.com/NomicFoundation/solx/actions/runs/29762518487/job/88420787837) (Slang Tests on #554, macOS arm64) failed with `ld: write() failed, errno=28` — ENOSPC at 98% disk during the test-binary link. `test.yaml` gained a `free-disk-space-macos` prologue step; `slang-tests.yaml` never did. That's the drift class this PR removes: the same six-step prologue existed in five near-identical copies, and each new prologue step had to be added five times.

## What

New `.github/actions/build-toolchain` composite encoding the standard prologue exactly once:

> checkout-submodules → setup-sfw (optional) → prepare-msys (Windows) → free-disk-space-macos → build-llvm → build-solc

with `llvm:`/`solc:` toggles. Converted call sites:

| Call site | Config |
|---|---|
| `test.yaml` / cargo-checks | `solc: 'false'` |
| `test.yaml` / build-and-test | defaults |
| `cache-warmup.yaml` / warm-llvm | `solc: 'false'` |
| `cache-warmup.yaml` / warm-solc | `llvm: 'false'` |
| `slang-tests.yaml` | `solc: 'false'` (keeps its own Release+MLIR solc build for the lit tests) |

The LLVM/solc build params in the composite define the standard-config cache keys — drift between copies was a silent cache miss; now changing them re-keys all consumers together.

## Behavior changes (all deliberate)

- **slang-tests + cache-warmup macOS legs now run `free-disk-space-macos`** — previously missing exactly where the coldest LLVM builds happen. Fixes the #554 failure mode.
- **#550 libstdc++ workaround applies to every standard-config Windows consumer**: the bundled static `libstdc++.a` is dropped from the restored LLVM tree (after build-llvm's mid-action cache save, so the cached tree keeps it). Defuses the landmine documented in #550 for test.yaml's Windows leg, which was green only while the cargo cache kept llvm-sys Fresh. Release binaries keep static linking (release.yaml doesn't use this action).
- **rust-cache steps move after the composite**: prepare-msys switches the rustup host (part of the Swatinem key), so the post-msys position keeps hitting caches already saved on main. Late restore costs nothing on artifact-cache hits.
- **cache-warmup warm jobs get SFW-first order** (previously msys-before-SFW) — matching test.yaml's proven order.
- **warm-solc drops explicit `boost-version: '1.83.0'`** — it's the build-solc default; solc cache key unchanged.
- **Inline submodule-checkout scripts → existing `checkout-submodules` action** (same update, plus `--init`).

## Not included

- Specialty configs (sanitizer, coverage, integration, release) stay on direct build-llvm/build-solc calls: one-producer/one-consumer pairs with distinct params; folding them in would make the composite a switch bag.
- The shared 5-leg matrix stays duplicated — composite actions can't carry a matrix, and a reusable workflow would drag job-level structure (container/volumes anchors, permissions, per-workflow cache config) into a shared file for little gain.

## Relation to #553

Extracted from the cross-os-tester branch (#553), which will rebase onto this and add `cross-os-tests.yaml` as a sixth consumer. One deliberate difference: this version passes `optional: 'true'` to setup-sfw, preserving what every current call site does. The #553 copy omits it, and setup-sfw defaults to mandatory — that would make a socket.dev outage fail all five jobs, a change the extraction shouldn't smuggle in (worth a look on #553 whether that was intended).

## Validation

- actionlint clean on all three touched workflows.
- Cache-key-neutral by construction for LLVM/solc artifact caches and Swatinem caches (params unchanged, post-msys cache position preserved for build-and-test; cargo-checks is Linux-container-only so its key has no msys sensitivity).
