### PR TITLE
fix(debug-info): resolve inline-assembly source refs to Yul AST nodes

### DIFF
--- a/solx-codegen-evm/src/codegen/context/solidity_data.rs
+++ b/solx-codegen-evm/src/codegen/context/solidity_data.rs
@@ -94,9 +94,9 @@ impl ISolidityData for SolidityData {
             .ast_nodes
             .get(&solc_location.source_id)?
             .get(&start)?;
-        if debug_info
-            .function_definitions
-            .contains_key(&ast_node.ast_id)
+        if ast_node
+            .ast_id
+            .is_some_and(|ast_id| debug_info.function_definitions.contains_key(&ast_id))
         {
             return None;
         }

--- a/solx-standard-json/src/output/source.rs
+++ b/solx-standard-json/src/output/source.rs
@@ -134,7 +134,15 @@ impl Source {
     ) -> Option<solx_utils::DebugInfoAstNode> {
         let ast = ast.as_object()?;
 
-        let ast_id = ast.get("id")?.as_u64()? as usize;
+        // Yul nodes (inside `InlineAssembly.AST`) carry no `id`, but their
+        // `src` points into the Solidity source like any other node's.
+        let ast_id = match ast.get("id") {
+            Some(id) => Some(id.as_u64()? as usize),
+            None => {
+                (ast.get("nodeType")?.as_str()?.starts_with("Yul")).as_option()?;
+                None
+            }
+        };
         let solc_location = solx_utils::DebugInfoSolcLocation::parse(
             ast.get("src")?.as_str()?,
             solx_utils::DebugInfoSolcLocationOrdering::Ast,

--- a/solx-standard-json/src/output/source.rs
+++ b/solx-standard-json/src/output/source.rs
@@ -158,3 +158,48 @@ impl Source {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Source;
+
+    fn ast_node(ast: serde_json::Value) -> Option<solx_utils::DebugInfoAstNode> {
+        let source_code = "contract C {}\n";
+        let line_index = solx_utils::DebugInfoLineIndex::new(source_code);
+        Source::ast_node("Test.sol", &ast, &line_index)
+    }
+
+    /// Yul nodes inside `InlineAssembly.AST` carry no `id`; rejecting them drops the
+    /// per-opcode source refs that solc emits for `assembly {}` bodies.
+    #[test]
+    fn resolves_yul_node_without_id() {
+        let node = ast_node(serde_json::json!({
+            "nodeType": "YulFunctionCall",
+            "src": "0:8:0",
+        }))
+        .expect("Yul nodes without an `id` must resolve");
+        assert_eq!(node.ast_id, None);
+    }
+
+    #[test]
+    fn resolves_solidity_node_with_id() {
+        let node = ast_node(serde_json::json!({
+            "nodeType": "ExpressionStatement",
+            "id": 7,
+            "src": "0:8:0",
+        }))
+        .expect("Solidity nodes with an `id` must resolve");
+        assert_eq!(node.ast_id, Some(7));
+    }
+
+    #[test]
+    fn rejects_solidity_node_without_id() {
+        assert!(
+            ast_node(serde_json::json!({
+                "nodeType": "ExpressionStatement",
+                "src": "0:8:0",
+            }))
+            .is_none()
+        );
+    }
+}

--- a/solx-utils/src/debug_info/ast_node.rs
+++ b/solx-utils/src/debug_info/ast_node.rs
@@ -13,6 +13,7 @@ use crate::debug_info::solc_location::SolcLocation;
 pub struct AstNode {
     /// AST ID. `None` for Yul nodes inside `InlineAssembly`, which solc
     /// emits without an `id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ast_id: Option<usize>,
     /// solc-style location.
     pub solc_location: SolcLocation,

--- a/solx-utils/src/debug_info/ast_node.rs
+++ b/solx-utils/src/debug_info/ast_node.rs
@@ -11,8 +11,9 @@ use crate::debug_info::solc_location::SolcLocation;
 ///
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AstNode {
-    /// AST ID.
-    pub ast_id: usize,
+    /// AST ID. `None` for Yul nodes inside `InlineAssembly`, which solc
+    /// emits without an `id`.
+    pub ast_id: Option<usize>,
     /// solc-style location.
     pub solc_location: SolcLocation,
     /// Line-number-style location.
@@ -24,7 +25,7 @@ impl AstNode {
     /// A shortcut constructor.
     ///
     pub fn new(
-        ast_id: usize,
+        ast_id: Option<usize>,
         solc_location: SolcLocation,
         mapped_location: MappedLocation,
     ) -> Self {

--- a/solx/tests/data/standard_json_input/debug_info_inline_assembly.json
+++ b/solx/tests/data/standard_json_input/debug_info_inline_assembly.json
@@ -1,0 +1,20 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "AsmProbe.sol": {
+      "content": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\ncontract AsmProbe {\n    uint256 public value;\n\n    function set(uint256 newValue) public {\n        assembly {\n            if gt(newValue, 100) {\n                revert(0, 0)\n            }\n            sstore(1, newValue)\n        }\n        value = newValue;\n    }\n}\n"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.deployedBytecode.debugInfo"
+        ]
+      }
+    }
+  }
+}

--- a/solx/tests/debug_info/mod.rs
+++ b/solx/tests/debug_info/mod.rs
@@ -135,6 +135,46 @@ fn generated_code_line_zero(via_ir: bool) -> anyhow::Result<()> {
 }
 
 ///
+/// solc emits per-opcode source refs for `assembly {}` bodies; dropping them attributes the
+/// opcodes to the enclosing declaration lines instead of the assembly statements. The
+/// `revert(0, 0)` row is not asserted: the backend merges identical revert sequences and
+/// merged locations drop per the DWARF convention. EVMLA only — the via-IR pipeline does
+/// not resolve assembly refs yet.
+///
+#[test]
+fn inline_assembly_lines() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let input = fixture(crate::common::standard_json!(
+        "debug_info_inline_assembly.json"
+    ))?;
+    let source = input.sources["AsmProbe.sol"]
+        .content
+        .clone()
+        .expect("Always exists");
+
+    let output = compile_standard_json(&input)?;
+
+    let row_counts = debug_line_row_counts(
+        deployed_debug_info(&output, "AsmProbe.sol", "AsmProbe")?.as_slice(),
+    )?;
+
+    for needle in [
+        "if gt(newValue, 100)",
+        "sstore(1, newValue)",
+        "value = newValue;",
+    ] {
+        let line = line_of(&source, needle);
+        assert!(
+            row_counts.contains_key(&line),
+            "`{needle}` (line {line}) is missing from the line table: {row_counts:?}",
+        );
+    }
+
+    Ok(())
+}
+
+///
 /// Debug info must never influence codegen: compiling with and without `debugInfo` in
 /// `outputSelection` must produce byte-identical bytecode. Both compilations are derived
 /// from the same input and differ only in the output selection, so the invariance holds


### PR DESCRIPTION
Stacked on #582 (base: `dwarf-line-zero-for-synthetic-code`); merge that first. Fixes on more issue from https://github.com/NomicFoundation/edr/pull/1552. Tested locally within that branch, and regenerated the fixtures in that branch to make sure the DWARF fix made a difference.


# Claude Summary
Opcodes originating from `assembly { ... }` blocks carried no meaningful rows in `.debug_line` — consumers saw the enclosing declaration line instead of the assembly statement. Yet the data was there all along: solc emits precise per-opcode source refs for assembly bodies (e.g. `REVERT` mapped exactly to its `revert(0, 0)` statement), and the generic AST walker already recurses into `InlineAssembly.AST`.

The drop happened in `Source::ast_node`: it required an `id` field, which Yul AST nodes don't carry, so every Yul node was rejected and the refs failed the `ast_nodes` lookup at codegen time. This PR accepts `Yul*`-typed nodes without an `id` (`AstNode::ast_id` becomes an `Option`; it's an internal format, and its one consumer — #582's function-definition padding check — is adapted in the fix commit); their `src` points into the Solidity source like any other node's.

## Measured effect

Probe (`assembly { if gt(v, 100) { revert(0, 0) } sstore(1, v) }` inside a function):

- The `gt` guard (2 rows) and `sstore` (1 row) lines appear in the line table.
- Two rows previously mis-attributed to the function-declaration line move to their true statement line.
- Creation and deployed bytecode are **byte-identical** to a `main` build — debug info only.

Pipeline scope: this resolves the EVMLA pipeline's refs (solc's EVM-assembly source maps). The via-IR pipeline still emits no assembly statement lines — its rows sit on the contract-declaration line (line 0 once #582 lands); resolving via-IR's assembly refs is a separate path, left as follow-up.

Known residual: the `revert(0, 0)` row itself stays absent — the backend merges identical revert sequences and merged locations drop per the DWARF convention. This is the same (intentional, size-saving) merge that loses bare `revert()` statement lines outside assembly; consumers recover by walking back to the nearest mapped statement.

## Review follow-ups

- **Unit tests at the fix site**: `solx-standard-json` now pins `Source::ast_node` id resolution directly — a Yul node without an `id` must resolve (fails on the pre-fix logic), a node with an `id` must keep resolving, and a non-Yul node without an `id` must stay rejected. These complement (not replace) the e2e test: the fixed bug was a cross-crate contract mismatch, and the line-table property itself is only defined end-to-end.
- **Serde hygiene**: absent Yul ids are skipped during serialization instead of encoding `null`.
- **Test category**: the e2e regression test lives in the `tests/debug_info/` integration category introduced on #582 — it pins a pipeline property (what DWARF consumers read after solc refs → EVMLA translation → LLVM optimization), not CLI behavior. It runs the compiler binary because contracts are compiled in subprocesses of the driver executable; there is no in-process path through the pipeline. Standard JSON I/O goes through the typed `solx-standard-json` structures and the module's shared DWARF helpers.

## Validation

- Regression test: `debug_info::inline_assembly_lines` decodes the probe's `.debug_line` and asserts the `gt` guard and `sstore` lines appear alongside the plain statement line; red with the fix reverted (both assembly lines absent), green with it.
- Unit tests: `cargo test -p solx-standard-json --lib` — the Yul-without-id case proven red against the pre-fix resolution logic.
- Stacked branch: full `cargo test --test mod` suite 402 passed (incl. all 8 `debug_info::*` tests from both PRs); `cargo test --lib` green.
- solx-tester `tests/solidity/simple/algorithm`: 1640 passed, 0 failed.
- **Consumer check (EDR)**: built the pre-stack head (`3edb5a73`), regenerated EDR's solx fixtures with it, and ran the full solx stack-trace suite on edr#1552's branch — 32/32 provider goldens + 77/77 `edr_solidity` unit tests pass unchanged. This is a no-regression check only: the regenerable EDR fixtures contain no inline assembly, and their `debugInfo` is byte-identical after regen (all 22 bytecode objects differ only in the CBOR metadata tail — compiler build hash). The asm-line improvement itself is covered by the probe above.

## Interaction with #582

Now stacked on #582 (base: `dwarf-line-zero-for-synthetic-code`). The fixes remain logically independent — this makes Yul refs *resolve*, so they never reach the fallback paths #582 rewrites — but stacking let us validate the one semantic touch point directly: #582's function-definition padding check consumes `AstNode::ast_id`, adapted to the `Option` type with `is_some_and` inside the fix commit. The combined branch is fully tested (full `--test mod` suite: 402 passed).
