### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "solx"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "solx-benchmark-converter"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "askama",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "solx-codegen-evm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "solx-compiler-downloader"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "colored",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "solx-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "ciborium",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "solx-dev"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "solx-evm-assembly"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "ciborium",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "solx-mlir"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "cc",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "solx-slang"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "num-bigint 0.5.1",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "solx-solc-test-adapter"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4575,7 +4575,7 @@ dependencies = [
 
 [[package]]
 name = "solx-standard-json"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "solx-tester"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "solx-utils"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base58",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "solx-yul"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "inkwell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ authors = [
     "Nomic Foundation <alex@nomic.foundation>",
 ]
 edition = "2024"
-version = "0.1.5"
+version = "0.1.6"
 
 [workspace.dependencies]
 # Error handling

--- a/docs/src/user-guide/02-command-line-interface.md
+++ b/docs/src/user-guide/02-command-line-interface.md
@@ -118,7 +118,7 @@ The **solx** metadata format is compatible with the [Solidity metadata format](h
     // Optional: only set for Solidity and Yul contracts.
     "solc_version": "0.8.34",
     // Mandatory: current version of solx.
-    "solx_version": "0.1.5"
+    "solx_version": "0.1.6"
   }
 }
 ```
@@ -134,7 +134,7 @@ Output:
 ```text
 ======= Simple.sol:Simple =======
 Metadata:
-{"compiler":{"version":"0.8.34+commit.79519a9b"},"language":"Solidity","output":{"abi":[{"inputs":[],"name":"first","outputs":[{"internalType":"uint64","name":"","type":"uint64"}],"stateMutability":"pure","type":"function"},{"inputs":[],"name":"second","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"Simple.sol":"Simple"},"evmVersion":"osaka","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"Simple.sol":{"keccak256":"0x402fe0b38cc9d81e8c9f6d07854cca27fbb307f06d8a129998026907a10c7ca1","license":"MIT","urls":["bzz-raw://04714cab56c1f931e3cc1ddae4c7ff0c8832d0849e23966c6326028f6783d45a","dweb:/ipfs/QmehmUFKCtytG8WcWQ676KvqwURfkVYK89VHZEvSzyLc2Z"]}},"version":1}
+{"compiler":{"version":"0.8.34+commit.ebeac7c2"},"language":"Solidity","output":{"abi":[{"inputs":[],"name":"first","outputs":[{"internalType":"uint64","name":"","type":"uint64"}],"stateMutability":"pure","type":"function"},{"inputs":[],"name":"second","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"Simple.sol":"Simple"},"evmVersion":"osaka","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"Simple.sol":{"keccak256":"0x402fe0b38cc9d81e8c9f6d07854cca27fbb307f06d8a129998026907a10c7ca1","license":"MIT","urls":["bzz-raw://04714cab56c1f931e3cc1ddae4c7ff0c8832d0849e23966c6326028f6783d45a","dweb:/ipfs/QmehmUFKCtytG8WcWQ676KvqwURfkVYK89VHZEvSzyLc2Z"]}},"version":1}
 ```
 
 
@@ -318,7 +318,7 @@ object "Simple_24" {
         code {
             ...
         }
-        data ".metadata" hex"a264697066735822122079ca4620ae16ea2714d740f9b6965b44fc2ec4f860ff2f53840fb596f5baf9d264736f6c63430008220033"
+        data ".metadata" hex"a2646970667358221220799c46ef67c25f9cee07fabf455ec2c828831289a75c9720f777886717f05e9964736f6c63430008220033"
     }
 }
 ```
@@ -733,7 +733,7 @@ Output with `ipfs`:
 ```text
 ======= Simple.sol:Simple =======
 Binary:
-34601557630000008480630000001a6080396080f35b5f5ffdfe34600b57600336116016575b5f5ffd5b5060016031565b5f3560e01c633df4ddf48114600f57635a8ac02d03600b5760025b60805260206080f3fea2646970667358221220bec8fa0149a786c5810200ef5a436a154cff832af68ace5beeabcbb82166cb9264736f6c637816736f6c783a302e312e353b736f6c633a302e382e33340047
+34601557630000008480630000001a6080396080f35b5f5ffdfe34600b57600336116016575b5f5ffd5b5060016031565b5f3560e01c633df4ddf48114600f57635a8ac02d03600b5760025b60805260206080f3fea2646970667358221220a1c9557d1ba161f8b10cbf71bbb227befd112b91b438365ac59448a2b9f0d74c64736f6c637816736f6c783a302e312e363b736f6c633a302e382e33340047
 ```
 
 The byte array starting with `a2` at the end of the bytecode is a CBOR-encoded compiler version data and an optional metadata hash.
@@ -745,12 +745,12 @@ JSON representation of the CBOR payload:
 ```javascript
 {
     // Optional: included if `--metadata-hash` is set to `ipfs`.
-    "ipfs": "1220bec8fa0149a786c5810200ef5a436a154cff832af68ace5beeabcbb82166cb92",
+    "ipfs": "1220a1c9557d1ba161f8b10cbf71bbb227befd112b91b438365ac59448a2b9f0d74c",
 
     // Required: consists of semicolon-separated pairs of colon-separated compiler names and versions.
     // `solx:<version>` is always included.
     // `solc:<version>` is only included for Solidity and Yul contracts, but not included for LLVM IR ones.
-    "solc": "solx:0.1.5;solc:0.8.34"
+    "solc": "solx:0.1.6;solc:0.8.34"
 }
 ```
 


### PR DESCRIPTION
Bump the version in preparation for the 0.1.6 release.


## Claude Summary

Version bump for the 0.1.6 release: `workspace.package.version` 0.1.5 → 0.1.6, plus the corresponding `Cargo.lock` sync (14 workspace members only, via `cargo update --workspace`; no dependency changes). Same 3-file shape as #558 minus the docs commit.

A follow-up commit on this PR will regenerate the CLI documentation examples in `docs/src/user-guide/02-command-line-interface.md` from the `ci:release` dry-run binary. Beyond the two literal version strings, the shown outputs may have drifted since 0.1.5 — `#582` (DWARF line-0), `#583` (inline-asm source refs) and `#584` (solc tip / CRLF `-text` fix) all landed in the interval and plausibly shift the `--debug-info` / `--metadata` blocks — so this is regenerated against a real binary, not a string swap.

The `ci:release` label runs the full release pipeline as a dry run (5-platform build, bundle, review, changelog) to validate the flow before tagging.
