### PR TITLE
ci(coverage): harden Codecov upload step

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -292,5 +292,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: 'llvm/codecov.lcov'
+          # Upload only the lcov above; don't walk the tree or run the gcov
+          # plugin over the thousands of solx-llvm test fixtures.
+          disable_search: true
+          plugins: noop
           slug: ${{ github.repository }}
-          fail_ci_if_error: false
+          # Surface upload failures instead of silently going green.
+          fail_ci_if_error: true


### PR DESCRIPTION
Codecov has shown **no results for HEAD** on recent PRs (e.g. #565). Root cause: every upload was being rejected by Codecov with `{"message":"Repository not found"}` after the repo was moved orgs (which invalidated the old upload token). The failure went unnoticed for ~8 months because the step ran with `fail_ci_if_error: false`, so the job stayed green while nothing landed. Codecov's last stored commit was 2025-11-01.

I've now rotated the token and updated it in solx GitHub secrets, which unblocks uploads. This PR hardens the step so it can't silently rot again.  See https://app.codecov.io/gh/NomicFoundation/solx/pull/586 for an example of a successful report.

Note: I will follow up later to look into covering MLIR in LLVM and others.

# Claude summary

## Changes

- `fail_ci_if_error: true` — surface upload failures instead of silently going green.
- `disable_search: true` + `plugins: noop` — the lcov is passed explicitly via `files:`, so skip the tree walk and the gcov plugin, which otherwise runs `gcov` over the thousands of `solx-llvm` test fixtures (`.gcno`) on every run.

## Verification

The token fix + this hardening are validated by the coverage run this PR triggers. Success = step logs `processing complete` with no `Repository not found`, and:

```
curl -s -o /dev/null -w "%{http_code}\n" \
  https://codecov.io/api/v2/github/nomicfoundation/repos/solx/commits/<head-sha>
```

returns `200` (was `404`).