### PR TITLE
feat(slang): complete expression tail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint 0.4.6",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4555,12 +4555,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=e04e567421393be60bfbbd73e280ed2558df29c6#e04e567421393be60bfbbd73e280ed2558df29c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
@@ -4593,6 +4593,7 @@ dependencies = [
  "sha3 0.12.0",
  "slang_solidity_v2_common",
  "slang_solidity_v2_ir",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "e04e567421393be60bfbbd73e280ed2558df29c6"
+rev = "6daec8fef8f0151ccac1413e0c882053b4e850d4"

--- a/solx-mlir/src/context/environment.rs
+++ b/solx-mlir/src/context/environment.rs
@@ -54,14 +54,14 @@ impl<'context> Environment<'context> {
     /// Registers a variable with its alloca'd pointer and element type in the current scope.
     pub fn define_variable(
         &mut self,
-        name: String,
+        name: &str,
         pointer: Place<'context>,
         element_type: Type<'context>,
     ) {
         self.scopes
             .last_mut()
             .expect("at least one scope exists")
-            .insert(name, (pointer, element_type));
+            .insert(name.to_owned(), (pointer, element_type));
     }
 
     /// Looks up a variable's alloca'd pointer and element type by name.

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -122,6 +122,12 @@ sol_ops! {
     Value::ripemd160(data: value) -> value {
         Ripemd160Operation.data(data).result(fixed_bytes(20))
     }
+    Value::blockhash(block_number: value) -> value {
+        BlockHashOperation.block_number(block_number).val(fixed_bytes(32))
+    }
+    Value::blobhash(index: value) -> value {
+        BlobHashOperation.idx(index).val(fixed_bytes(32))
+    }
 
     Value::balance(address: value) -> value {
         BalanceOperation.cont_addr(address).out(field())
@@ -137,6 +143,9 @@ sol_ops! {
     }
     Value::transfer(address: value, amount: value) {
         TransferOperation.addr(address).val(amount)
+    }
+    Value::selfdestruct(recipient: value) {
+        SelfdestructOperation.recipient(recipient)
     }
 
     Value::block_number() -> value { BlockNumberOperation.val(field()) }

--- a/solx-mlir/src/ir/place.rs
+++ b/solx-mlir/src/ir/place.rs
@@ -39,6 +39,24 @@ impl<'context> Place<'context> {
         )
     }
 
+    /// Assigns `value` under the reference-vs-value idiom: a reference-typed place is its own address
+    /// and takes a `sol.copy` that bridges type and data location, while a scalar slot stores the
+    /// value converted to `element_type`. Yields the value the assignment expression evaluates to.
+    pub fn assign(
+        self,
+        value: Value<'context>,
+        element_type: Type<'context>,
+        context: &Context<'context>,
+    ) -> Value<'context> {
+        if self.r#type() == element_type {
+            self.copy_from(value, context);
+            return Value::from(self);
+        }
+        let value = value.convert(element_type, context);
+        self.store(value, context);
+        value
+    }
+
     /// The pointer type `!sol.ptr<T, Loc>`.
     pub fn r#type(self) -> Type<'context> {
         Type::new(self.inner.r#type())

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -39,6 +39,14 @@ impl<'context> Type<'context> {
         Self { inner }
     }
 
+    /// The boolean type: a signless `i1`.
+    pub fn boolean(context: &'context melior::Context) -> Self {
+        Self::new(MlirType::from(IntegerType::new(
+            context,
+            solx_utils::BIT_LENGTH_BOOLEAN as u32,
+        )))
+    }
+
     /// An unsigned integer type of `bits` width (`ui<bits>`).
     pub fn unsigned(context: &'context melior::Context, bits: usize) -> Self {
         Self::new(MlirType::from(IntegerType::unsigned(context, bits as u32)))
@@ -58,19 +66,16 @@ impl<'context> Type<'context> {
         }
     }
 
-    /// The boolean type: a signless `i1`.
-    pub fn boolean(context: &'context melior::Context) -> Self {
-        Self::new(MlirType::from(IntegerType::new(
-            context,
-            solx_utils::BIT_LENGTH_BOOLEAN as u32,
-        )))
-    }
-
     /// A `sol::AddressType` with the given payability.
     pub fn address(context: &'context melior::Context, payable: bool) -> Self {
         Self::new(unsafe {
             MlirType::from_raw(ffi::solxCreateAddressType(context.to_raw(), payable))
         })
+    }
+
+    /// The unsigned 256-bit integer, the native EVM word.
+    pub fn field(context: &'context melior::Context) -> Self {
+        Self::unsigned(context, solx_utils::BIT_LENGTH_FIELD)
     }
 
     /// A `sol::PointerType` with the given element type and data location.

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -104,30 +104,9 @@ impl<'context> Value<'context> {
         integer.bytes_cast(target_type, context)
     }
 
-    /// Coerces to `target_type` under Solidity's implicit conversions.
-    pub fn coerce(self, target_type: Type<'context>, context: &Context<'context>) -> Self {
-        if self.r#type() == target_type {
-            return self;
-        }
-        if self.r#type().is_bytes_like() {
-            return self.bytes_cast(target_type, context);
-        }
-        if target_type.is_bytes_like() {
-            let integer_type = Type::unsigned(
-                context.melior,
-                target_type.bytes_like_width() as usize * solx_utils::BIT_LENGTH_BYTE,
-            );
-            return self
-                .cast(integer_type, context)
-                .bytes_cast(target_type, context);
-        }
-        if !self.r#type().is_scalar() && !target_type.is_scalar() {
-            return self.data_loc_cast(target_type, context);
-        }
-        self.cast(target_type, context)
-    }
-
-    /// Converts to `target_type` under an explicit `T(x)` cast.
+    /// Emits the cast reconciling `self` to `target_type`, be it a computed common type or an
+    /// explicit `T(x)`. The address and string-to-`bytesN` arms, reachable only under an explicit
+    /// cast, precede the bytes and scalar arms an address or string would otherwise fall into.
     pub fn convert(mut self, target_type: Type<'context>, context: &Context<'context>) -> Self {
         if self.r#type() == target_type {
             return self;
@@ -147,7 +126,22 @@ impl<'context> Value<'context> {
         if self.r#type().is_string() && target_type.is_bytes_like() {
             return self.dyn_bytes_to_fixedbytes(target_type, context);
         }
-        self.coerce(target_type, context)
+        if self.r#type().is_bytes_like() {
+            return self.bytes_cast(target_type, context);
+        }
+        if target_type.is_bytes_like() {
+            let integer_type = Type::unsigned(
+                context.melior,
+                target_type.bytes_like_width() as usize * solx_utils::BIT_LENGTH_BYTE,
+            );
+            return self
+                .cast(integer_type, context)
+                .bytes_cast(target_type, context);
+        }
+        if !self.r#type().is_scalar() && !target_type.is_scalar() {
+            return self.data_loc_cast(target_type, context);
+        }
+        self.cast(target_type, context)
     }
 
     /// The `i1` truthiness of `self` via `sol.cmp ne 0`; a no-op when `self` is already `i1`.

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -147,7 +147,7 @@ macro_rules! sol_predicate_attribute {
     };
 }
 
-/// Coerces an op-builder setter argument to the type the ODS setter expects.
+/// Converts an op-builder setter argument to the type the ODS setter expects.
 ///
 /// A local trait rather than `From`/`Into`: the orphan rule forbids implementing `From` for the
 /// foreign melior setter types the domain conversions target, so the macros route every argument
@@ -211,7 +211,7 @@ macro_rules! sol_ops {
         $receiver.r#type().gep_result_type($element)
     };
     (@arg [$context:ident] [$receiver:tt] field()) => {
-        $crate::Type::unsigned($context.melior, solx_utils::BIT_LENGTH_FIELD)
+        $crate::Type::field($context.melior)
     };
     (@arg [$context:ident] [$receiver:tt] address()) => {
         $crate::Type::address($context.melior, false)

--- a/solx-mlir/tests/lit/addmod.sol
+++ b/solx-mlir/tests/lit/addmod.sol
@@ -1,10 +1,21 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.addmod {{.*}} : ui256
+// CHECK: sol.func @{{.*variables.*}}
+// CHECK:   sol.addmod {{.*}} : ui256
+
+// CHECK: sol.func @{{.*literals.*}}
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.addmod {{.*}} : ui256
 
 contract C {
-    function f(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
+    function variables(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
         return addmod(x, y, m);
+    }
+
+    function literals() public pure returns (uint256) {
+        return addmod(2, 3, 5);
     }
 }

--- a/solx-mlir/tests/lit/blobhash.sol
+++ b/solx-mlir/tests/lit/blobhash.sol
@@ -1,0 +1,11 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*versioned_hash.*}}(%{{.*}}: ui256) -> !sol.fixedbytes<32>
+// CHECK:   sol.blobhash %{{.*}} : <32>
+
+contract C {
+    function versioned_hash(uint256 index) external view returns (bytes32) {
+        return blobhash(index);
+    }
+}

--- a/solx-mlir/tests/lit/blockhash.sol
+++ b/solx-mlir/tests/lit/blockhash.sol
@@ -1,0 +1,11 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*bh.*}}(%{{.*}}: ui256) -> !sol.fixedbytes<32>
+// CHECK:   sol.blockhash %{{.*}} : <32>
+
+contract C {
+    function bh(uint256 n) public view returns (bytes32) {
+        return blockhash(n);
+    }
+}

--- a/solx-mlir/tests/lit/conditional.sol
+++ b/solx-mlir/tests/lit/conditional.sol
@@ -12,6 +12,14 @@
 // CHECK:   }
 // CHECK:   sol.load %[[SLOT]] : !sol.ptr<ui256, Stack>, ui256
 
+// CHECK: sol.func @{{.*ternary_literal_arms.*}}(%{{.*}}: i1) -> ui256
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.constant 1 : ui8
+// CHECK:   } else {
+// CHECK:     sol.constant 2 : ui8
+// CHECK:   }
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+
 // CHECK: sol.func @{{.*ternary_string.*}}(%{{.*}}: i1) -> !sol.string<Memory>
 // CHECK:   %[[STR_SLOT:.*]] = sol.alloca : !sol.ptr<!sol.string<Memory>, Stack>
 // CHECK:   sol.if
@@ -19,6 +27,10 @@
 // CHECK:     sol.store %[[Y]], %[[STR_SLOT]] : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
 // CHECK:     %[[N:.*]] = sol.string_lit "no" -> !sol.string<Memory>
 // CHECK:     sol.store %[[N]], %[[STR_SLOT]] : !sol.string<Memory>, !sol.ptr<!sol.string<Memory>, Stack>
+
+// CHECK: sol.func @{{.*ternary_nested.*}}
+// CHECK:   sol.if %{{.*}} {
+// CHECK:     sol.if %{{.*}} {
 
 // CHECK: sol.func @{{.*ternary_statement.*}}
 // CHECK:   sol.if %{{.*}} {
@@ -34,8 +46,20 @@ contract C {
         return c ? a : b;
     }
 
+    function ternary_literal_arms(bool c) public pure returns (uint256) {
+        return c ? 1 : 2;
+    }
+
     function ternary_string(bool c) public pure returns (string memory) {
         return c ? "yes" : "no";
+    }
+
+    function ternary_nested(bool c1, bool c2, uint256 a, uint256 b, uint256 d)
+        public
+        pure
+        returns (uint256)
+    {
+        return c1 ? (c2 ? a : b) : d;
     }
 
     function effect_a() internal pure {}

--- a/solx-mlir/tests/lit/ecrecover.sol
+++ b/solx-mlir/tests/lit/ecrecover.sol
@@ -1,10 +1,24 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.ecrecover{{.*}}: (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
+// CHECK: sol.func @{{.*variables.*}}
+// CHECK:   sol.ecrecover{{.*}}: (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
+
+// CHECK: sol.func @{{.*literals.*}}
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+// CHECK:   sol.ecrecover{{.*}}: (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
 
 contract C {
-    function recover(bytes32 h, uint8 v, bytes32 r, bytes32 s) public pure returns (address) {
+    function variables(bytes32 h, uint8 v, bytes32 r, bytes32 s) public pure returns (address) {
         return ecrecover(h, v, r, s);
+    }
+
+    function literals() public pure returns (address) {
+        return ecrecover(bytes32(uint256(1)), 27, bytes32(uint256(2)), bytes32(uint256(3)));
     }
 }

--- a/solx-mlir/tests/lit/evaluation_order/assignment.sol
+++ b/solx-mlir/tests/lit/evaluation_order/assignment.sol
@@ -1,0 +1,28 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/assignment.sol | FileCheck %s
+
+// solc print-init evaluates an assignment's place before its value, unlike legacy, so this is solx-only.
+
+// CHECK: sol.func @{{.*scalar.*}}
+// CHECK:   sol.call @{{.*rightValue.*}}
+// CHECK:   sol.call @{{.*leftIndex.*}}
+
+// CHECK: sol.func @{{.*compound.*}}
+// CHECK:   sol.call @{{.*rightValue.*}}
+// CHECK:   sol.call @{{.*leftIndex.*}}
+
+// CHECK: sol.func @{{.*destructure.*}}
+// CHECK:   %[[RIGHT_FIRST:.*]] = sol.call @{{.*rightFirst.*}}
+// CHECK:   %[[RIGHT_SECOND:.*]] = sol.call @{{.*rightSecond.*}}
+// CHECK:   sol.call @{{.*leftFirst.*}}
+// CHECK:   sol.call @{{.*leftSecond.*}}
+// CHECK:   sol.store %[[RIGHT_SECOND]],
+// CHECK:   sol.store %[[RIGHT_FIRST]],
+
+// CHECK: sol.func @{{.*tupleStore.*}}
+// CHECK:   %[[X:.*]] = sol.alloca : !sol.ptr<ui256, Stack>
+// CHECK:   %[[ONE:.*]] = sol.constant 1 : ui8
+// CHECK:   %[[TWO:.*]] = sol.constant 2 : ui8
+// CHECK:   %[[TWO_CAST:.*]] = sol.cast %[[TWO]] : ui8 to ui256
+// CHECK:   sol.store %[[TWO_CAST]], %[[X]]
+// CHECK:   %[[ONE_CAST:.*]] = sol.cast %[[ONE]] : ui8 to ui256
+// CHECK:   sol.store %[[ONE_CAST]], %[[X]]

--- a/solx-mlir/tests/lit/evaluation_order/binary.sol
+++ b/solx-mlir/tests/lit/evaluation_order/binary.sol
@@ -1,0 +1,40 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/binary.sol | FileCheck %s
+
+// solc print-init emits binary operands left-first rather than legacy's right-first, so this is solx-only.
+
+// CHECK: sol.func @{{.*arithmetic.*}}
+// CHECK:   %[[ARITHMETIC_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[ARITHMETIC_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.csub %[[ARITHMETIC_LEFT]], %[[ARITHMETIC_RIGHT]] : ui256
+
+// CHECK: sol.func @{{.*bitwise.*}}
+// CHECK:   %[[BITWISE_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[BITWISE_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.xor %[[BITWISE_LEFT]], %[[BITWISE_RIGHT]] : ui256
+
+// CHECK: sol.func @{{.*comparison.*}}
+// CHECK:   %[[COMPARISON_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[COMPARISON_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.cmp gt, %[[COMPARISON_LEFT]], %[[COMPARISON_RIGHT]] : ui256
+
+// CHECK: sol.func @{{.*exponentiation.*}}
+// CHECK:   %[[EXPONENTIATION_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[EXPONENTIATION_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.cexp %[[EXPONENTIATION_LEFT]], %[[EXPONENTIATION_RIGHT]] : ui256, ui256 -> ui256
+
+// CHECK: sol.func @{{.*shift.*}}
+// CHECK:   %[[SHIFT_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[SHIFT_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.shl %[[SHIFT_LEFT]], %[[SHIFT_RIGHT]] : ui256, ui256
+
+// CHECK: sol.func @{{.*addmod.*}}
+// CHECK:   %[[ADDMOD_MODULUS:.*]] = sol.call @{{.*modulus.*}}
+// CHECK:   %[[ADDMOD_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[ADDMOD_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.addmod %[[ADDMOD_LEFT]], %[[ADDMOD_RIGHT]], %[[ADDMOD_MODULUS]] : ui256
+
+// CHECK: sol.func @{{.*mulmod.*}}
+// CHECK:   %[[MULMOD_MODULUS:.*]] = sol.call @{{.*modulus.*}}
+// CHECK:   %[[MULMOD_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[MULMOD_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   sol.mulmod %[[MULMOD_LEFT]], %[[MULMOD_RIGHT]], %[[MULMOD_MODULUS]] : ui256

--- a/solx-mlir/tests/lit/evaluation_order/left_first.sol
+++ b/solx-mlir/tests/lit/evaluation_order/left_first.sol
@@ -1,0 +1,32 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/left_first.sol | FileCheck %s
+
+// solc print-init aborts on the conditional lowering on some platforms (#591), so this is solx-only.
+
+// CHECK: sol.func @{{.*logicalAnd\(.*}}
+// CHECK:   sol.call @{{.*left.*}}
+// CHECK:   sol.if
+// CHECK:     sol.call @{{.*right.*}}
+
+// CHECK: sol.func @{{.*logicalOrShortCircuit.*}}
+// CHECK:   sol.call @{{.*left.*}}
+// CHECK:   sol.if
+// CHECK:     sol.call @{{.*right.*}}
+
+// CHECK: sol.func @{{.*conditionalTrue.*}}
+// CHECK:   sol.call @{{.*left.*}}
+// CHECK:   sol.if
+// CHECK:     sol.call @{{.*right.*}}
+// CHECK:   } else {
+// CHECK:     sol.call @{{.*modulus.*}}
+
+// CHECK: sol.func @{{.*nestedIndex.*}}
+// CHECK:   sol.call @{{.*left.*}}
+// CHECK:   sol.map
+// CHECK:   sol.call @{{.*right.*}}
+// CHECK:   sol.map
+
+// CHECK: sol.func @{{.*functionCall.*}}
+// CHECK:   %[[CALL_LEFT:.*]] = sol.call @{{.*left.*}}
+// CHECK:   %[[CALL_RIGHT:.*]] = sol.call @{{.*right.*}}
+// CHECK:   %[[CALL_MODULUS:.*]] = sol.call @{{.*modulus.*}}
+// CHECK:   sol.call @{{.*combine.*}}(%[[CALL_LEFT]], %[[CALL_RIGHT]], %[[CALL_MODULUS]])

--- a/solx-mlir/tests/lit/evaluation_order/nested_assignment.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_assignment.sol
@@ -1,0 +1,56 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_assignment.sol | FileCheck %s
+
+// solc print-init resolves an assignment place before its value while solx is value-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*ternary.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 4 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*call.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*indexPlace.*}}
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*compound.*}}
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*tuple.*}}
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 4 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/evaluation_order/nested_binary.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_binary.sol
@@ -1,0 +1,42 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_binary.sol | FileCheck %s
+
+// solc print-init orders binary operands left-first while solx is right-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*ternary.*}}
+// CHECK:   sol.constant 4 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*assignment.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*call.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*index.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/evaluation_order/nested_call.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_call.sol
@@ -1,0 +1,28 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_call.sol | FileCheck %s
+
+// solc print-init orders binary operands left-first while solx is right-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*ternary.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:   sol.constant 4 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*assignment.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/evaluation_order/nested_index.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_index.sol
@@ -1,0 +1,30 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_index.sol | FileCheck %s
+
+// solc print-init orders binary operands left-first while solx is right-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*ternary.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:   sol.constant 4 : ui8
+// CHECK:   sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*call.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/evaluation_order/nested_logical.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_logical.sol
@@ -1,0 +1,39 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_logical.sol | FileCheck %s
+
+// solc print-init orders binary operands left-first while solx is right-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*ternary.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.if
+// CHECK:       sol.constant 3 : ui8
+// CHECK:       sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*assignment.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*logical.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.if
+// CHECK:       sol.constant 3 : ui8
+// CHECK:       sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/evaluation_order/nested_ternary.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_ternary.sol
@@ -1,0 +1,46 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/nested_ternary.sol | FileCheck %s
+
+// solc print-init orders binary operands left-first while solx is right-first to match legacy.
+
+// CHECK: sol.func @{{.*binary.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 4 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*logical.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 4 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*call.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 4 : ui8
+// CHECK:     sol.call @"t(uint256)"
+
+// CHECK: sol.func @{{.*assignment.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.if
+// CHECK:     sol.constant 2 : ui8
+// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.constant 3 : ui8
+// CHECK:     sol.call @"t(uint256)"

--- a/solx-mlir/tests/lit/lit.cfg.py
+++ b/solx-mlir/tests/lit/lit.cfg.py
@@ -14,5 +14,9 @@ config.environment["PATH"] = os.pathsep.join(
     [solx_bin_dir, solc_bin_dir, os.environ.get("PATH", "")]
 )
 
+config.substitutions.append(
+    ("%evaluation_order", os.path.join(solx_root, "tests", "solidity", "simple", "evaluation_order").replace("\\", "/"))
+)
+
 config.test_source_root = config_dir
 config.test_exec_root = os.path.join(config_dir, "Output")

--- a/solx-mlir/tests/lit/mulmod.sol
+++ b/solx-mlir/tests/lit/mulmod.sol
@@ -1,10 +1,21 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.mulmod {{.*}} : ui256
+// CHECK: sol.func @{{.*variables.*}}
+// CHECK:   sol.mulmod {{.*}} : ui256
+
+// CHECK: sol.func @{{.*literals.*}}
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.mulmod {{.*}} : ui256
 
 contract C {
-    function f(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
+    function variables(uint256 x, uint256 y, uint256 m) public pure returns (uint256) {
         return mulmod(x, y, m);
+    }
+
+    function literals() public pure returns (uint256) {
+        return mulmod(2, 3, 5);
     }
 }

--- a/solx-mlir/tests/lit/multi_return.sol
+++ b/solx-mlir/tests/lit/multi_return.sol
@@ -33,6 +33,10 @@
 // CHECK: sol.if
 // CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
 
+// CHECK: sol.func @{{.*via_conditional_call_and_tuple.*}}
+// CHECK: sol.if
+// CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
+
 // CHECK: sol.func @{{.*via_nested_conditional.*}}
 // CHECK: sol.if
 // CHECK: sol.return %{{.*}}, %{{.*}} : ui256, ui256
@@ -68,6 +72,10 @@ contract C {
 
     function via_conditional_call(bool c) public pure returns (uint256, uint256) {
         return c ? two_constants() : two_constants();
+    }
+
+    function via_conditional_call_and_tuple(bool c) public pure returns (uint256, uint256) {
+        return c ? two_constants() : (3, 4);
     }
 
     function via_nested_conditional(bool a, bool b) public pure returns (uint256, uint256) {

--- a/solx-mlir/tests/lit/selfdestruct.sol
+++ b/solx-mlir/tests/lit/selfdestruct.sol
@@ -1,0 +1,10 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.selfdestruct %{{.*}} : !sol.address<payable>
+
+contract C {
+    function destroy(address payable recipient) external {
+        selfdestruct(recipient);
+    }
+}

--- a/solx-mlir/tests/lit/tuple_assignment.sol
+++ b/solx-mlir/tests/lit/tuple_assignment.sol
@@ -1,16 +1,15 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func @{{.*assign_from_call.*}}
 // CHECK:   %[[R:.*]]:2 = sol.call @{{.*two.*}}()
-// CHECK:   sol.store %[[R]]#0, %{{.*}}
 // CHECK:   sol.store %[[R]]#1, %{{.*}}
+// CHECK:   sol.store %[[R]]#0, %{{.*}}
 
 // CHECK: sol.func @{{.*swap.*}}
 // CHECK:   %[[V0:.*]] = sol.load
 // CHECK:   %[[V1:.*]] = sol.load
-// CHECK:   sol.store %[[V0]], %{{.*}}
 // CHECK:   sol.store %[[V1]], %{{.*}}
+// CHECK:   sol.store %[[V0]], %{{.*}}
 
 // CHECK: sol.func @{{.*conditional_right.*}}
 // CHECK:   sol.if
@@ -21,8 +20,8 @@
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
 
 // CHECK: sol.func @{{.*reference_element.*}}
-// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui256, Memory>, !sol.array<? x ui256, Storage>
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Stack>
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.array<3 x ui256, Memory>, !sol.array<? x ui256, Storage>
 
 contract C {
     uint256[] array;

--- a/solx-mlir/tests/lit/tuple_assignment_nested.sol
+++ b/solx-mlir/tests/lit/tuple_assignment_nested.sol
@@ -6,13 +6,13 @@
 // CHECK: sol.func @{{.*parenthesized_swap.*}}
 // CHECK:   %[[B:.*]] = sol.load
 // CHECK:   %[[A:.*]] = sol.load
-// CHECK:   sol.store %[[B]], %{{.*}}
 // CHECK:   sol.store %[[A]], %{{.*}}
+// CHECK:   sol.store %[[B]], %{{.*}}
 
 // CHECK: sol.func @{{.*nested.*}}
-// CHECK:   sol.cast %c1_ui8
-// CHECK:   sol.cast %c2_ui8
 // CHECK:   sol.cast %c3_ui8
+// CHECK:   sol.cast %c2_ui8
+// CHECK:   sol.cast %c1_ui8
 
 contract C {
     function parenthesized_swap(uint256 a, uint256 b) public pure returns (uint256, uint256) {

--- a/solx-mlir/tests/lit/value_transfer.sol
+++ b/solx-mlir/tests/lit/value_transfer.sol
@@ -1,10 +1,12 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// solx-only: solc down-casts the payable operand to a plain `address` before send/transfer (an
+// extra `sol.address_cast`), so it diverges here; solx keeps the operand payable.
 
 // CHECK: sol.func {{.*}}pay_send{{.*}}-> i1
-// CHECK:   sol.send {{.*}}, {{.*}} : !sol.address, ui256 -> i1
-// CHECK: sol.func {{.*}}pay_transfer{{.*}}!sol.address{{.*}}ui256
-// CHECK:   sol.transfer {{.*}}, {{.*}} : !sol.address, ui256
+// CHECK:   sol.send {{.*}}, {{.*}} : !sol.address<payable>, ui256 -> i1
+// CHECK: sol.func {{.*}}pay_transfer{{.*}}!sol.address<payable>{{.*}}ui256
+// CHECK:   sol.transfer {{.*}}, {{.*}} : !sol.address<payable>, ui256
 
 contract C {
     function pay_send(address payable r, uint256 v) public returns (bool) { return r.send(v); }

--- a/solx-slang/src/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/contract/function/expression/arithmetic.rs
@@ -1,5 +1,6 @@
 //!
-//! Arithmetic expressions: the additive, multiplicative, and exponentiation operators.
+//! Arithmetic expressions: the additive, multiplicative, and exponentiation operators, and the
+//! `addmod`/`mulmod` modular built-ins.
 //!
 
 use slang_solidity_v2::ast::AdditiveExpression;
@@ -7,26 +8,29 @@ use slang_solidity_v2::ast::AdditiveExpressionOperator;
 use slang_solidity_v2::ast::ExponentiationExpression;
 use slang_solidity_v2::ast::MultiplicativeExpression;
 use slang_solidity_v2::ast::MultiplicativeExpressionOperator;
+use slang_solidity_v2::ast::PositionalArguments;
 
+use solx_mlir::Context;
+use solx_mlir::Type as MlirType;
 use solx_mlir::Value;
 
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `a + b` and `a - b`, both operands coerced to the binder's result type.
+    /// `a + b` and `a - b`, both operands converted to the binder's result type.
     pub fn additive(&mut self, node: &AdditiveExpression) -> Value<'context> {
         let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+            self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         match node.operator() {
             AdditiveExpressionOperator::Plus(_) => lhs.add(rhs, self.checked, self),
             AdditiveExpressionOperator::Minus(_) => lhs.subtract(rhs, self.checked, self),
         }
     }
 
-    /// `a * b`, `a / b`, and `a % b`, both operands coerced to the binder's result type.
+    /// `a * b`, `a / b`, and `a % b`, both operands converted to the binder's result type.
     pub fn multiplicative(&mut self, node: &MultiplicativeExpression) -> Value<'context> {
         let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+            self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         match node.operator() {
             MultiplicativeExpressionOperator::Asterisk(_) => lhs.multiply(rhs, self.checked, self),
             MultiplicativeExpressionOperator::Slash(_) => lhs.divide(rhs, self.checked, self),
@@ -34,11 +38,32 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// `a ** b`, the base coerced to the binder's result type and the exponent kept at its own type.
+    /// `a ** b`, the base converted to the binder's result type and the exponent kept at its own type.
     pub fn exponentiation(&mut self, node: &ExponentiationExpression) -> Value<'context> {
         let result_type = self.typing(node.get_type());
-        let base = self.coerced(&node.left_operand(), result_type);
         let exponent = self.expression(&node.right_operand());
+        let base = self.converted(&node.left_operand(), result_type);
         base.exponentiate(exponent, self.checked, self)
+    }
+
+    /// The shared `addmod`/`mulmod` lowering: the three operands widened to the field width the
+    /// built-in works at rather than their own narrower types, evaluated right-to-left to match
+    /// legacy, then combined by `operator`.
+    pub fn modular(
+        &mut self,
+        arguments: &PositionalArguments,
+        operator: impl FnOnce(
+            Value<'context>,
+            Value<'context>,
+            Value<'context>,
+            &Context<'context>,
+        ) -> Value<'context>,
+    ) -> Value<'context> {
+        let field = MlirType::field(self.melior);
+        let arguments: Vec<_> = arguments.iter().collect();
+        let modulus = self.converted(&arguments[2], field);
+        let right = self.converted(&arguments[1], field);
+        let left = self.converted(&arguments[0], field);
+        operator(left, right, modulus, self)
     }
 }

--- a/solx-slang/src/contract/function/expression/array.rs
+++ b/solx-slang/src/contract/function/expression/array.rs
@@ -10,7 +10,7 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// An array literal, its elements coerced to the declared element type.
+    /// An array literal, its elements converted to the declared element type.
     pub fn array(&mut self, node: &ArrayExpression) -> Value<'context> {
         let result_slang_type = node.get_type().expect("slang types every array literal");
         let element_slang_type = match &result_slang_type {
@@ -25,7 +25,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let element_values = node
             .items()
             .iter()
-            .map(|item| self.coerced(&item, element_type))
+            .map(|item| self.converted(&item, element_type))
             .collect::<Vec<_>>();
         Value::array_literal(
             &element_values,

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -4,69 +4,63 @@
 
 use slang_solidity_v2::ast::AssignmentExpression;
 use slang_solidity_v2::ast::AssignmentExpressionOperator;
+use slang_solidity_v2::ast::Expression;
+use slang_solidity_v2::ast::Type;
 
 use solx_mlir::Value;
 
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `lhs = rhs` and the compound `lhs op= rhs`. A multi-element tuple left operand destructures and
-    /// yields nothing, tuple assignment being value-less; every other form yields the stored value. A
-    /// reference-typed place is its own address and takes a `sol.copy` of the right operand, which
-    /// bridges both its type and its data location. A shift compound keeps its right operand at its
-    /// own type, every other form coerces it to the place's type.
+    /// `lhs = rhs` and the compound `lhs op= rhs`. A multi-element tuple destructures and yields
+    /// nothing, tuple assignment being value-less; every other form yields the stored value. The right
+    /// operand is evaluated before the left place, matching legacy's right-before-left order; a tuple
+    /// evaluates all values then all places left-first and commits the stores right-first. Whether the
+    /// place is a reference (its own address, taking a `sol.copy` that bridges type and data location)
+    /// or a scalar slot (a `store` of the value converted to the slot's own type) is read from the
+    /// resolved place. The lone exception is a string or hex literal at a bytes-like target: it folds
+    /// to a constant that needs the slot type up front and carries no side effect, so its place is
+    /// resolved first. A shift compound keeps its right operand at its own type, every other converts it.
     pub fn assignment(&mut self, node: &AssignmentExpression) -> Option<Value<'context>> {
-        let places = self.expression_places(&node.left_operand());
-        if places.len() > 1 {
-            let targets: Vec<_> = places
-                .iter()
-                .map(|&element| {
-                    let Some((place, element_type)) = element else {
-                        return None;
-                    };
-                    (place.r#type() != element_type).then_some(element_type)
-                })
-                .collect();
-            let values = self.coerced_values(&node.right_operand(), &targets);
-            for (place, value) in places.into_iter().zip(values) {
-                let Some((place, element_type)) = place else {
-                    continue;
-                };
-                if place.r#type() == element_type {
-                    place.copy_from(value, self);
-                } else {
-                    place.store(value, self);
+        let left = node.left_operand();
+        let right = node.right_operand();
+        let left_type = left.get_type();
+
+        if let Some(Type::Tuple(_)) = &left_type {
+            let values = self.expression_values(&right);
+            let places = self.expression_places(&left);
+            for (place, value) in places.into_iter().zip(values).rev() {
+                if let Some((place, r#type)) = place {
+                    place.assign(value, r#type, self);
                 }
             }
             return None;
         }
 
-        let (place, element_type) = places
-            .into_iter()
-            .next()
-            .flatten()
-            .expect("an assignment target denotes a place");
-
-        if place.r#type() == element_type {
-            let source = self.expression(&node.right_operand());
-            place.copy_from(source, self);
-            return Some(Value::from(place));
-        }
+        let element_type = self.typing(left_type);
 
         if let AssignmentExpressionOperator::Equal(_) = node.operator() {
-            let value = self.coerced(&node.right_operand(), element_type);
-            place.store(value, self);
-            return Some(value);
+            if let Expression::StringExpression(_) = &right
+                && element_type.is_bytes_like()
+            {
+                let (place, r#type) = self.expression_place(&left);
+                let value = self.converted(&right, r#type);
+                return Some(place.assign(value, r#type, self));
+            }
+            let value = self.expression(&right);
+            let (place, r#type) = self.expression_place(&left);
+            return Some(place.assign(value, r#type, self));
         }
 
         let rhs = match node.operator() {
             AssignmentExpressionOperator::LessThanLessThanEqual(_)
             | AssignmentExpressionOperator::GreaterThanGreaterThanEqual(_) => {
-                self.expression(&node.right_operand())
+                self.expression(&right)
             }
-            _ => self.coerced(&node.right_operand(), element_type),
+            _ => self.converted(&right, element_type),
         };
-        let current = place.load(element_type, self);
+        let (place, r#type) = self.expression_place(&left);
+        let current = place.load(r#type, self);
         let assigned = match node.operator() {
             AssignmentExpressionOperator::PlusEqual(_) => current.add(rhs, self.checked, self),
             AssignmentExpressionOperator::MinusEqual(_) => {

--- a/solx-slang/src/contract/function/expression/bitwise.rs
+++ b/solx-slang/src/contract/function/expression/bitwise.rs
@@ -13,33 +13,33 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `a & b`, both operands coerced to the binder's result type.
+    /// `a & b`, both operands converted to the binder's result type.
     pub fn bitwise_and(&mut self, node: &BitwiseAndExpression) -> Value<'context> {
         let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+            self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitand(rhs, self)
     }
 
-    /// `a | b`, both operands coerced to the binder's result type.
+    /// `a | b`, both operands converted to the binder's result type.
     pub fn bitwise_or(&mut self, node: &BitwiseOrExpression) -> Value<'context> {
         let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+            self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitor(rhs, self)
     }
 
-    /// `a ^ b`, both operands coerced to the binder's result type.
+    /// `a ^ b`, both operands converted to the binder's result type.
     pub fn bitwise_xor(&mut self, node: &BitwiseXorExpression) -> Value<'context> {
         let (lhs, rhs) =
-            self.coerced_operands(node.get_type(), &node.left_operand(), &node.right_operand());
+            self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitxor(rhs, self)
     }
 
-    /// `a << b` and `a >> b`, the shifted value coerced to the binder's result type and the shift
+    /// `a << b` and `a >> b`, the shifted value converted to the binder's result type and the shift
     /// amount kept at its own type.
     pub fn shift(&mut self, node: &ShiftExpression) -> Value<'context> {
         let result_type = self.typing(node.get_type());
-        let value = self.coerced(&node.left_operand(), result_type);
         let amount = self.expression(&node.right_operand());
+        let value = self.converted(&node.left_operand(), result_type);
         match node.operator() {
             ShiftExpressionOperator::LessThanLessThan(_) => value.shl(amount, self),
             ShiftExpressionOperator::GreaterThanGreaterThan(_) => value.shr(amount, self),

--- a/solx-slang/src/contract/function/expression/call/arguments.rs
+++ b/solx-slang/src/contract/function/expression/call/arguments.rs
@@ -16,7 +16,7 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// Emits each argument in the definition's parameter order, coerced to and paired with its
+    /// Emits each argument in the definition's parameter order, converted to and paired with its
     /// parameter.
     pub fn arguments_declaration(
         &mut self,
@@ -32,7 +32,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .zip(ordered)
             .map(|(parameter, argument)| {
                 let parameter_type = self.typing(parameter.get_type());
-                let value = self.coerced(&argument, parameter_type);
+                let value = self.converted(&argument, parameter_type);
                 (parameter, value)
             })
             .collect()
@@ -50,17 +50,16 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     fn named_arguments(named: &NamedArguments, parameters: &Parameters) -> Vec<Expression> {
         let mut by_name: HashMap<String, Expression> = named
             .iter()
-            .map(|argument| (argument.name().name(), argument.value()))
+            .map(|argument| (argument.name().name().to_owned(), argument.value()))
             .collect();
         parameters
             .iter()
             .map(|parameter| {
-                let name = parameter
+                let identifier = parameter
                     .name()
-                    .expect("slang validates a named argument targets a named parameter")
-                    .name();
+                    .expect("slang validates a named argument targets a named parameter");
                 by_name
-                    .remove(&name)
+                    .remove(identifier.name())
                     .expect("slang validates every parameter receives a named argument")
             })
             .collect()

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -112,7 +112,7 @@ impl Call {
     }
 
     /// Builds the struct value in memory: allocates the call's result type and stores each
-    /// argument, coerced to its field type, through the field's address.
+    /// argument, converted to its field type, through the field's address.
     fn struct_construction<'context>(
         struct_definition: &StructDefinition,
         call: &FunctionCallExpression,
@@ -131,7 +131,7 @@ impl Call {
                 Some(solx_utils::DataLocation::Memory),
             );
             let field_address = struct_address.gep_field(index, field_type, scope);
-            field_address.store(scope.coerced(&argument, field_type), scope);
+            field_address.store(scope.converted(&argument, field_type), scope);
         }
         vec![struct_address.into()]
     }
@@ -187,7 +187,7 @@ impl Call {
                     Some(expression) => {
                         let string_memory_type =
                             MlirType::string(scope.melior, solx_utils::DataLocation::Memory);
-                        let message_value = scope.coerced(&expression, string_memory_type);
+                        let message_value = scope.converted(&expression, string_memory_type);
                         (
                             vec![message_value],
                             Some(Self::ERROR_STRING_SIGNATURE.to_owned()),
@@ -247,13 +247,22 @@ impl Call {
                     values[0], values[1], values[2], values[3], scope,
                 ))
             }
-            BuiltIn::Addmod => {
+            BuiltIn::Addmod => Some(scope.modular(arguments, Value::addmod)),
+            BuiltIn::Mulmod => Some(scope.modular(arguments, Value::mulmod)),
+            BuiltIn::Blockhash => {
+                let field = MlirType::field(scope.melior);
                 let values = scope.positional_arguments(arguments);
-                Some(Value::addmod(values[0], values[1], values[2], scope))
+                Some(Value::blockhash(values[0].convert(field, scope), scope))
             }
-            BuiltIn::Mulmod => {
+            BuiltIn::Blobhash => {
+                let field = MlirType::field(scope.melior);
                 let values = scope.positional_arguments(arguments);
-                Some(Value::mulmod(values[0], values[1], values[2], scope))
+                Some(Value::blobhash(values[0].convert(field, scope), scope))
+            }
+            BuiltIn::Selfdestruct => {
+                let values = scope.positional_arguments(arguments);
+                Value::selfdestruct(values[0], scope);
+                None
             }
             _ => unimplemented!("built-in {built_in:?} is not yet supported in call position"),
         }
@@ -261,7 +270,7 @@ impl Call {
 
     /// Resolves the member to its built-in and lowers it: the array mutators lower to `sol.pop` and
     /// `sol.push`, where the no-argument `arr.push()` yields the new element's slot reference while
-    /// `arr.push(x)` stores the coerced value into that slot and, like `arr.pop()` and `transfer`,
+    /// `arr.push(x)` stores the converted value into that slot and, like `arr.pop()` and `transfer`,
     /// produces no value. `abi.decode` takes its result type from `call` rather than from its
     /// operands, which is why the full call expression is passed alongside the arguments. A member
     /// resolving to no built-in, or to one not lowered yet, is the sole unsupported-member-call site.
@@ -360,7 +369,7 @@ impl Call {
                 if let Type::Bytes(_) = &base_slang_type
                     && let Some(value_argument) = &value_argument
                 {
-                    let appended = scope.coerced(
+                    let appended = scope.converted(
                         value_argument,
                         MlirType::fixed_bytes(scope.melior, solx_utils::BYTE_LENGTH_BYTE as u32),
                     );
@@ -393,7 +402,7 @@ impl Call {
                 let Some(value_argument) = value_argument else {
                     return Some(new_slot);
                 };
-                Place::from(new_slot).store(scope.coerced(&value_argument, element_type), scope);
+                Place::from(new_slot).store(scope.converted(&value_argument, element_type), scope);
                 None
             }
             Some(BuiltIn::BytesConcat | BuiltIn::StringConcat) => {
@@ -403,7 +412,7 @@ impl Call {
         }
     }
 
-    /// Resolves the callee's pre-registered MLIR signature by node id and coerces each argument to
+    /// Resolves the callee's pre-registered MLIR signature by node id and converts each argument to
     /// its declared parameter type before `sol.call`.
     fn function<'context>(
         function_definition: &FunctionDefinition,
@@ -414,14 +423,14 @@ impl Call {
             .contract
             .source_unit
             .function_signature(function_definition.node_id());
-        let coerced: Vec<Value<'context>> = arguments
+        let converted: Vec<Value<'context>> = arguments
             .iter()
             .zip(&signature.parameter_types)
-            .map(|(argument, &parameter_type)| scope.coerced(&argument, parameter_type))
+            .map(|(argument, &parameter_type)| scope.converted(&argument, parameter_type))
             .collect();
         Function::call(
             &signature.mlir_name,
-            &coerced,
+            &converted,
             &signature.return_types,
             scope,
         )

--- a/solx-slang/src/contract/function/expression/comparison.rs
+++ b/solx-slang/src/contract/function/expression/comparison.rs
@@ -2,6 +2,7 @@
 //! Comparison expressions: equality and inequality over reconciled operand types.
 //!
 
+use slang_solidity_v2::ast::BinaryOperatorExpression;
 use slang_solidity_v2::ast::EqualityExpression;
 use slang_solidity_v2::ast::EqualityExpressionOperator;
 use slang_solidity_v2::ast::InequalityExpression;
@@ -13,19 +14,21 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// `a == b` and `a != b`, the operands coerced to the type the binder reconciles them to.
+    /// `a == b` and `a != b`, the operands converted to the type the binder reconciles them to.
     pub fn equality(&mut self, node: &EqualityExpression) -> Value<'context> {
         let predicate = match node.operator() {
             EqualityExpressionOperator::EqualEqual(_) => CmpPredicate::Eq,
             EqualityExpressionOperator::BangEqual(_) => CmpPredicate::Ne,
         };
-        let common = self.typing(node.common_operand_type());
-        let left = self.coerced(&node.left_operand(), common);
-        let right = self.coerced(&node.right_operand(), common);
+        let (left, right) = self.converted_operands(
+            node.common_operand_type(),
+            &node.left_operand(),
+            &node.right_operand(),
+        );
         left.compare(right, predicate, self)
     }
 
-    /// `a < b`, `a <= b`, `a > b`, and `a >= b`, the operands coerced to the type the binder
+    /// `a < b`, `a <= b`, `a > b`, and `a >= b`, the operands converted to the type the binder
     /// reconciles them to.
     pub fn inequality(&mut self, node: &InequalityExpression) -> Value<'context> {
         let predicate = match node.operator() {
@@ -34,9 +37,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             InequalityExpressionOperator::GreaterThan(_) => CmpPredicate::Gt,
             InequalityExpressionOperator::GreaterThanEqual(_) => CmpPredicate::Ge,
         };
-        let common = self.typing(node.common_operand_type());
-        let left = self.coerced(&node.left_operand(), common);
-        let right = self.coerced(&node.right_operand(), common);
+        let (left, right) = self.converted_operands(
+            node.common_operand_type(),
+            &node.left_operand(),
+            &node.right_operand(),
+        );
         left.compare(right, predicate, self)
     }
 }

--- a/solx-slang/src/contract/function/expression/conditional.rs
+++ b/solx-slang/src/contract/function/expression/conditional.rs
@@ -16,19 +16,16 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// arm runs. Each arm stores its element values into per-element stack slots, one for a scalar
     /// result and one per element for a tuple, loaded after the merge.
     pub fn conditional_values(&mut self, node: &ConditionalExpression) -> Vec<Value<'context>> {
-        let element_types: Vec<Type<'context>> = match node.get_type() {
-            Some(SlangType::Tuple(tuple_type)) => tuple_type
+        let element_types: Vec<Type<'context>> = match node
+            .get_type()
+            .expect("slang types every conditional expression")
+        {
+            SlangType::Tuple(tuple_type) => tuple_type
                 .types()
                 .iter()
                 .map(|element_type| self.typing(Some(element_type.clone())))
                 .collect(),
-            Some(scalar) => vec![self.typing(Some(scalar))],
-            // TODO: Slang does not resolve the type of a conditional whose arms differ in shape,
-            // such as a call versus a tuple literal, though the common type is well-defined; remove
-            // this arm once Slang v2 types such conditionals.
-            None => unimplemented!(
-                "conditional with heterogeneously-shaped arms: Slang does not resolve its type"
-            ),
+            scalar => vec![self.typing(Some(scalar))],
         };
         let condition = self.expression(&node.operand()).is_nonzero(self);
         let places: Vec<Place<'context>> = element_types
@@ -46,7 +43,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                     .zip(&element_types)
                     .zip(scope.expression_values(&branch))
                 {
-                    place.store(value.coerce(element_type, scope), scope);
+                    place.store(value.convert(element_type, scope), scope);
                 }
             });
         }

--- a/solx-slang/src/contract/function/expression/identifier.rs
+++ b/solx-slang/src/contract/function/expression/identifier.rs
@@ -36,7 +36,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 self.state_variable_place(&state_variable, &slot_name)
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {
-                self.environment.variable_with_type(&node.name())
+                self.environment.variable_with_type(node.name())
             }
             None => unreachable!("slang resolves every identifier reference: {}", node.name()),
             Some(_) => unreachable!("identifier {} is not an assignable place", node.name()),

--- a/solx-slang/src/contract/function/expression/index_access.rs
+++ b/solx-slang/src/contract/function/expression/index_access.rs
@@ -85,10 +85,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let base = self.expression(&node.operand());
         let start = match node.start() {
             Some(start) => self.expression(&start),
-            None => Value::zero(
-                MlirType::unsigned(self.melior, solx_utils::BIT_LENGTH_FIELD),
-                self,
-            ),
+            None => Value::zero(MlirType::field(self.melior), self),
         };
         let end = match node.end() {
             Some(end) => self.expression(&end),

--- a/solx-slang/src/contract/function/expression/member.rs
+++ b/solx-slang/src/contract/function/expression/member.rs
@@ -61,7 +61,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             unreachable!("slang StructType always references a Struct definition");
         };
 
-        let member_name = node.member().name();
+        let member = node.member();
+        let member_name = member.name();
         let field_index = struct_definition
             .members()
             .iter()

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -158,10 +158,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// Emits an expression and coerces its value to `target_type`. A string literal reaching a
-    /// bytes-like target folds to that constant directly, since a materialized `sol.string_lit`
-    /// value cannot be reinterpreted.
-    pub fn coerced(
+    /// Emits an expression and converts its value to `target_type`, be it an implicit reconciliation
+    /// to the binder's type or an explicit `T(x)` cast. A string literal reaching a bytes-like target
+    /// folds to that constant directly, since a materialized `sol.string_lit` value cannot be
+    /// reinterpreted.
+    pub fn converted(
         &mut self,
         expression: &Expression,
         target_type: MlirType<'context>,
@@ -171,40 +172,28 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         {
             return Value::left_aligned_bytes(literal.value(), target_type, self);
         }
-        self.expression(expression).coerce(target_type, self)
-    }
-
-    /// Emits an expression and converts its value to `target_type` through an explicit `T(x)` cast.
-    pub fn converted(
-        &mut self,
-        expression: &Expression,
-        target_type: MlirType<'context>,
-    ) -> Value<'context> {
-        if let Expression::StringExpression(_) = expression {
-            return self.coerced(expression, target_type);
-        }
         self.expression(expression).convert(target_type, self)
     }
 
-    /// Evaluates both operands of a binary expression and coerces them to the binder's result type.
-    pub fn coerced_operands(
+    /// Evaluates both operands right-first for legacy compatibility, converts them to the binder's
+    /// common type, and returns them in source order.
+    pub fn converted_operands(
         &mut self,
         slang_type: Option<Type>,
         left: &Expression,
         right: &Expression,
     ) -> (Value<'context>, Value<'context>) {
         let result_type = self.typing(slang_type);
-        (
-            self.coerced(left, result_type),
-            self.coerced(right, result_type),
-        )
+        let right = self.converted(right, result_type);
+        let left = self.converted(left, result_type);
+        (left, right)
     }
 
-    /// Lowers a multi-value expression to values coerced to `targets`, a nested tuple flattening into
+    /// Lowers a multi-value expression to values converted to `targets`, a nested tuple flattening into
     /// the same list as `tuple_values` and a string-literal element folding to its bytes-like constant
-    /// as `coerced` does. A call or conditional coerces each result it yields; a `None` target passes
+    /// as `converted` does. A call or conditional converts each result it yields; a `None` target passes
     /// its value through, for a blank destructuring slot.
-    pub fn coerced_values(
+    pub fn converted_values(
         &mut self,
         node: &Expression,
         targets: &[Option<MlirType<'context>>],
@@ -214,7 +203,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 let mut values = Vec::with_capacity(targets.len());
                 for item in tuple.items().iter() {
                     let element = item.expression().expect("slang validates tuple elements");
-                    values.extend(self.coerced_values(&element, &targets[values.len()..]));
+                    values.extend(self.converted_values(&element, &targets[values.len()..]));
                 }
                 values
             }
@@ -223,12 +212,12 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 .into_iter()
                 .zip(targets)
                 .map(|(value, target)| match target {
-                    Some(target) => value.coerce(*target, self),
+                    Some(target) => value.convert(*target, self),
                     None => value,
                 })
                 .collect(),
             _ => match targets[0] {
-                Some(target) => vec![self.coerced(node, target)],
+                Some(target) => vec![self.converted(node, target)],
                 None => vec![self.expression(node)],
             },
         }

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -25,7 +25,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             }
             PrefixExpressionOperator::Tilde(_) => {
                 let result_type = self.typing(node.get_type());
-                Some(self.coerced(&node.operand(), result_type).not(self))
+                Some(self.converted(&node.operand(), result_type).not(self))
             }
             PrefixExpressionOperator::Bang(_) => {
                 let value = self.expression(&node.operand());
@@ -41,7 +41,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 Some(match magnitude {
                     Some(magnitude) => Value::constant_from_bigint(&-magnitude, result_type, self),
                     None => {
-                        let value = self.coerced(&node.operand(), result_type);
+                        let value = self.converted(&node.operand(), result_type);
                         Value::zero(result_type, self).subtract(value, self.checked, self)
                     }
                 })

--- a/solx-slang/src/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/contract/function/statement/control_flow.rs
@@ -90,14 +90,14 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         self.current_block().r#continue(self);
     }
 
-    /// The `return` statement, its values coerced to the function's declared return types.
+    /// The `return` statement, its values converted to the function's declared return types.
     pub fn return_statement(&mut self, node: &ReturnStatement) {
         let Some(expression) = node.expression() else {
             self.current_block().r#return(&[], self);
             return;
         };
         let targets: Vec<_> = self.return_types.iter().copied().map(Some).collect();
-        let values = self.coerced_values(&expression, &targets);
+        let values = self.converted_values(&expression, &targets);
         self.current_block().r#return(&values, self);
     }
 }

--- a/solx-slang/src/contract/function/statement/variable_declaration.rs
+++ b/solx-slang/src/contract/function/statement/variable_declaration.rs
@@ -36,7 +36,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let declared_type = self.typing(node.declaration().get_type());
         match node.value() {
             Some(initializer) => {
-                let value = self.coerced(&initializer, declared_type);
+                let value = self.converted(&initializer, declared_type);
                 self.define_local(node.declaration().name().name(), declared_type, |_scope| {
                     value
                 });
@@ -49,7 +49,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// A multi-typed variable declaration, destructuring a tuple or a call through `coerced_values`,
+    /// A multi-typed variable declaration, destructuring a tuple or a call through `converted_values`,
     /// so a string-literal tuple element folds to its bytes-like constant. A blank slot evaluates its
     /// operand but binds nothing.
     pub fn multi_typed_declaration(&mut self, node: &MultiTypedDeclaration) {
@@ -62,7 +62,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                     .map(|declaration| self.typing(declaration.get_type()))
             })
             .collect();
-        let values = self.coerced_values(&node.value(), &targets);
+        let values = self.converted_values(&node.value(), &targets);
         for ((member, target), value) in elements.iter().zip(targets).zip(values) {
             if let Some(declaration) = member.member() {
                 let target = target.expect("a bound slot has a declared type");

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -29,7 +29,7 @@ impl<'context> SourceUnitScope<'context> {
     /// Inherited state variables are not yet declared: derived contracts do not compile through
     /// this path.
     pub fn contract_definition(&mut self, node: &ContractDefinition) -> BTreeMap<String, String> {
-        let contract_name = node.name().name();
+        let contract_identifier = node.name();
 
         for function in node.functions().into_iter().chain(node.constructor()) {
             let parameter_types = function
@@ -78,13 +78,13 @@ impl<'context> SourceUnitScope<'context> {
         };
 
         let sol_contract = Contract::define(
-            &contract_name,
+            contract_identifier.name(),
             solx_mlir::ContractKind::Contract,
             self,
             Block::from(self.module.body()),
         );
         self.contract(
-            MlirType::contract(self.melior, &contract_name, node.is_payable()),
+            MlirType::contract(self.melior, contract_identifier.name(), node.is_payable()),
             sol_contract.body,
             state_variables,
             storage_layout,

--- a/solx-slang/src/contract/state_variable.rs
+++ b/solx-slang/src/contract/state_variable.rs
@@ -15,7 +15,7 @@ use crate::scope::function::FunctionScope;
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// Emits every state variable's inline initializer (`T x = <expr>;`) in source order as the
     /// constructor prologue, storing each into its storage slot. Reference-typed slots take a
-    /// `sol.copy`; value-typed slots coerce to the declared element type and `sol.store`.
+    /// `sol.copy`; value-typed slots convert to the declared element type and `sol.store`.
     pub fn state_variable_initializers(&mut self) {
         let initializers: Vec<(StateVariableDefinition, String, Expression)> = self
             .contract
@@ -39,7 +39,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             if storage_ref.r#type() == element_type {
                 storage_ref.copy_from(self.expression(&initializer), self);
             } else {
-                storage_ref.store(self.coerced(&initializer, element_type), self);
+                storage_ref.store(self.converted(&initializer, element_type), self);
             }
         }
     }

--- a/solx-slang/src/scope/contract.rs
+++ b/solx-slang/src/scope/contract.rs
@@ -47,7 +47,7 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
     }
 
     /// Opens the function scope around `emit`: a fresh variable environment, the declared return
-    /// types a `return` coerces to, and checked arithmetic, with the MLIR cursor on `entry` for the
+    /// types a `return` converts to, and checked arithmetic, with the MLIR cursor on `entry` for the
     /// body's duration.
     pub fn function(
         &mut self,

--- a/solx-slang/src/scope/function.rs
+++ b/solx-slang/src/scope/function.rs
@@ -18,13 +18,13 @@ use solx_mlir::Value;
 use crate::scope::contract::ContractScope;
 
 /// The function scope: the enclosing contract scope, the lexical variable environment, the declared
-/// return types a `return` coerces to, and whether arithmetic is checked at the current position.
+/// return types a `return` converts to, and whether arithmetic is checked at the current position.
 pub struct FunctionScope<'contract, 'source_unit, 'context> {
     /// The contract scope this function body is lowered within.
     pub contract: &'contract mut ContractScope<'source_unit, 'context>,
     /// The lexically scoped variable bindings.
     pub environment: Environment<'context>,
-    /// The declared return types a `return` coerces to.
+    /// The declared return types a `return` converts to.
     pub return_types: Vec<MlirType<'context>>,
     /// Whether arithmetic reverts on overflow at the current position.
     pub checked: bool,
@@ -49,7 +49,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// the slot precedes the value that initializes it, matching solc's emission order.
     pub fn define_local(
         &mut self,
-        name: String,
+        name: &str,
         element_type: MlirType<'context>,
         initializer: impl FnOnce(&mut Self) -> Value<'context>,
     ) -> Place<'context> {
@@ -100,7 +100,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// Branches `condition` into one `result_type` pointer and loads the merge. The pointer is first
     /// stored with whatever `initializer` yields, then each arm that yields a value stores it,
-    /// coerced to `result_type`, while an arm that yields none leaves the initializing value in
+    /// converted to `result_type`, while an arm that yields none leaves the initializing value in
     /// place. The shared lowering of `?:` (no initializer, both arms store) and the short-circuit
     /// `&&` / `||` (initialized, the short-circuiting arm empty).
     pub fn branch_value(
@@ -118,12 +118,12 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let (then_block, else_block) = self.current_block().branch_with_else(condition, self);
         self.region(then_block, |scope| {
             if let Some(value) = then(scope) {
-                pointer.store(value.coerce(result_type, scope), scope);
+                pointer.store(value.convert(result_type, scope), scope);
             }
         });
         self.region(else_block, |scope| {
             if let Some(value) = r#else(scope) {
-                pointer.store(value.coerce(result_type, scope), scope);
+                pointer.store(value.convert(result_type, scope), scope);
             }
         });
         pointer.load(result_type, self)

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -33,7 +33,7 @@ impl<'context> SourceUnitScope<'context> {
         let mut scope = SourceUnitScope::new(Context::new(&melior, evm_version));
         let method_identifiers = scope.contract_definition(contract);
 
-        let name = contract.name().name();
+        let name = contract.name().name().to_owned();
         let mlir = Context::from(scope).finalize_module(
             &format!("{name}{}", solx_codegen_evm::DEPLOYED_OBJECT_SUFFIX),
             capture_sol_dialect(&name),

--- a/solx-slang/src/type.rs
+++ b/solx-slang/src/type.rs
@@ -35,7 +35,7 @@ impl<'context> SourceUnitScope<'context> {
                 fixed_point_type.is_signed(),
             ),
             Type::Boolean(_) => MlirType::boolean(self.melior),
-            Type::Address(_) => MlirType::address(self.melior, false),
+            Type::Address(address) => MlirType::address(self.melior, address.is_payable()),
             Type::Literal(literal_type) => match literal_type.kind() {
                 LiteralKind::Address { .. } => MlirType::address(self.melior, false),
                 LiteralKind::Integer { value } => {
@@ -141,7 +141,7 @@ impl<'context> SourceUnitScope<'context> {
                 };
                 MlirType::contract(
                     self.melior,
-                    contract_definition.name().name().as_str(),
+                    contract_definition.name().name(),
                     contract_definition.is_payable(),
                 )
             }
@@ -150,11 +150,7 @@ impl<'context> SourceUnitScope<'context> {
                 else {
                     unreachable!("Slang InterfaceType always references an Interface definition");
                 };
-                MlirType::contract(
-                    self.melior,
-                    interface_definition.name().name().as_str(),
-                    false,
-                )
+                MlirType::contract(self.melior, interface_definition.name().name(), false)
             }
             Type::Enum(enum_type) => {
                 let Definition::Enum(enum_definition) = enum_type.definition() else {

--- a/tests/solidity/simple/evaluation_order/assignment.sol
+++ b/tests/solidity/simple/evaluation_order/assignment.sol
@@ -1,0 +1,81 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "scalar",
+//!     "inputs": [ { "method": "scalar", "calldata": [] } ],
+//!     "expected": [ "2", "21" ]
+//! }, {
+//!     "name": "compound",
+//!     "inputs": [ { "method": "compound", "calldata": [] } ],
+//!     "expected": [ "5", "21" ]
+//! }, {
+//!     "name": "destructure",
+//!     "inputs": [ { "method": "destructure", "calldata": [] } ],
+//!     "expected": [ "40", "50", "4512" ]
+//! }, {
+//!     "name": "tuple_store",
+//!     "inputs": [ { "method": "tupleStore", "calldata": [] } ],
+//!     "expected": [ "1" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 sequence;
+    mapping(uint256 => uint256) values;
+
+    function leftIndex() internal returns (uint256) {
+        sequence = sequence * 10 + 1;
+        return 1;
+    }
+
+    function rightValue() internal returns (uint256) {
+        sequence = sequence * 10 + 2;
+        return 2;
+    }
+
+    function leftFirst() internal returns (uint256) {
+        sequence = sequence * 10 + 1;
+        return 1;
+    }
+
+    function leftSecond() internal returns (uint256) {
+        sequence = sequence * 10 + 2;
+        return 2;
+    }
+
+    function rightFirst() internal returns (uint256) {
+        sequence = sequence * 10 + 4;
+        return 40;
+    }
+
+    function rightSecond() internal returns (uint256) {
+        sequence = sequence * 10 + 5;
+        return 50;
+    }
+
+    function scalar() public returns (uint256, uint256) {
+        sequence = 0;
+        values[leftIndex()] = rightValue();
+        return (values[1], sequence);
+    }
+
+    function compound() public returns (uint256, uint256) {
+        values[1] = 3;
+        sequence = 0;
+        values[leftIndex()] += rightValue();
+        return (values[1], sequence);
+    }
+
+    function destructure() public returns (uint256, uint256, uint256) {
+        sequence = 0;
+        (values[leftFirst()], values[leftSecond()]) = (rightFirst(), rightSecond());
+        return (values[1], values[2], sequence);
+    }
+
+    function tupleStore() public pure returns (uint256) {
+        uint256 value;
+        (value, value) = (1, 2);
+        return value;
+    }
+}

--- a/tests/solidity/simple/evaluation_order/binary.sol
+++ b/tests/solidity/simple/evaluation_order/binary.sol
@@ -1,0 +1,94 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "arithmetic",
+//!     "inputs": [ { "method": "arithmetic", "calldata": [] } ],
+//!     "expected": [ "1", "34" ]
+//! }, {
+//!     "name": "bitwise",
+//!     "inputs": [ { "method": "bitwise", "calldata": [] } ],
+//!     "expected": [ "7", "34" ]
+//! }, {
+//!     "name": "comparison",
+//!     "inputs": [ { "method": "comparison", "calldata": [] } ],
+//!     "expected": [ "1", "34" ]
+//! }, {
+//!     "name": "exponentiation",
+//!     "inputs": [ { "method": "exponentiation", "calldata": [] } ],
+//!     "expected": [ "64", "34" ]
+//! }, {
+//!     "name": "shift",
+//!     "inputs": [ { "method": "shift", "calldata": [] } ],
+//!     "expected": [ "32", "34" ]
+//! }, {
+//!     "name": "addmod",
+//!     "inputs": [ { "method": "addmodOrder", "calldata": [] } ],
+//!     "expected": [ "2", "534" ]
+//! }, {
+//!     "name": "mulmod",
+//!     "inputs": [ { "method": "mulmodOrder", "calldata": [] } ],
+//!     "expected": [ "2", "534" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 sequence;
+
+    function left() internal returns (uint256) {
+        sequence = sequence * 10 + 4;
+        return 4;
+    }
+
+    function right() internal returns (uint256) {
+        sequence = sequence * 10 + 3;
+        return 3;
+    }
+
+    function modulus() internal returns (uint256) {
+        sequence = sequence * 10 + 5;
+        return 5;
+    }
+
+    function arithmetic() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = left() - right();
+        return (result, sequence);
+    }
+
+    function bitwise() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = left() ^ right();
+        return (result, sequence);
+    }
+
+    function comparison() public returns (bool, uint256) {
+        sequence = 0;
+        bool result = left() > right();
+        return (result, sequence);
+    }
+
+    function exponentiation() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = left() ** right();
+        return (result, sequence);
+    }
+
+    function shift() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = left() << right();
+        return (result, sequence);
+    }
+
+    function addmodOrder() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = addmod(left(), right(), modulus());
+        return (result, sequence);
+    }
+
+    function mulmodOrder() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = mulmod(left(), right(), modulus());
+        return (result, sequence);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/left_first.sol
+++ b/tests/solidity/simple/evaluation_order/left_first.sol
@@ -1,0 +1,115 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "logical_and",
+//!     "inputs": [ { "method": "logicalAnd", "calldata": [] } ],
+//!     "expected": [ "1", "43" ]
+//! }, {
+//!     "name": "logical_and_short_circuit",
+//!     "inputs": [ { "method": "logicalAndShortCircuit", "calldata": [] } ],
+//!     "expected": [ "0", "2" ]
+//! }, {
+//!     "name": "logical_or_short_circuit",
+//!     "inputs": [ { "method": "logicalOrShortCircuit", "calldata": [] } ],
+//!     "expected": [ "1", "4" ]
+//! }, {
+//!     "name": "logical_or_fallback",
+//!     "inputs": [ { "method": "logicalOrFallback", "calldata": [] } ],
+//!     "expected": [ "1", "23" ]
+//! }, {
+//!     "name": "conditional_true",
+//!     "inputs": [ { "method": "conditionalTrue", "calldata": [] } ],
+//!     "expected": [ "3", "43" ]
+//! }, {
+//!     "name": "conditional_false",
+//!     "inputs": [ { "method": "conditionalFalse", "calldata": [] } ],
+//!     "expected": [ "5", "25" ]
+//! }, {
+//!     "name": "nested_index",
+//!     "inputs": [ { "method": "nestedIndex", "calldata": [] } ],
+//!     "expected": [ "9", "43" ]
+//! }, {
+//!     "name": "function_call",
+//!     "inputs": [ { "method": "functionCall", "calldata": [] } ],
+//!     "expected": [ "435", "435" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 sequence;
+    mapping(uint256 => mapping(uint256 => uint256)) nested;
+
+    function left() internal returns (uint256) {
+        sequence = sequence * 10 + 4;
+        return 4;
+    }
+
+    function right() internal returns (uint256) {
+        sequence = sequence * 10 + 3;
+        return 3;
+    }
+
+    function modulus() internal returns (uint256) {
+        sequence = sequence * 10 + 5;
+        return 5;
+    }
+
+    function falseCondition() internal returns (bool) {
+        sequence = sequence * 10 + 2;
+        return false;
+    }
+
+    function combine(uint256 a, uint256 b, uint256 c) internal pure returns (uint256) {
+        return a * 100 + b * 10 + c;
+    }
+
+    function logicalAnd() public returns (bool, uint256) {
+        sequence = 0;
+        bool result = left() != 0 && right() != 0;
+        return (result, sequence);
+    }
+
+    function logicalAndShortCircuit() public returns (bool, uint256) {
+        sequence = 0;
+        bool result = falseCondition() && right() != 0;
+        return (result, sequence);
+    }
+
+    function logicalOrShortCircuit() public returns (bool, uint256) {
+        sequence = 0;
+        bool result = left() != 0 || right() != 0;
+        return (result, sequence);
+    }
+
+    function logicalOrFallback() public returns (bool, uint256) {
+        sequence = 0;
+        bool result = falseCondition() || right() != 0;
+        return (result, sequence);
+    }
+
+    function conditionalTrue() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = left() != 0 ? right() : modulus();
+        return (result, sequence);
+    }
+
+    function conditionalFalse() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = falseCondition() ? right() : modulus();
+        return (result, sequence);
+    }
+
+    function nestedIndex() public returns (uint256, uint256) {
+        nested[4][3] = 9;
+        sequence = 0;
+        uint256 result = nested[left()][right()];
+        return (result, sequence);
+    }
+
+    function functionCall() public returns (uint256, uint256) {
+        sequence = 0;
+        uint256 result = combine(left(), right(), modulus());
+        return (result, sequence);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_assignment.sol
+++ b/tests/solidity/simple/evaluation_order/nested_assignment.sol
@@ -1,0 +1,81 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "5", "321" ]
+//! }, {
+//!     "name": "ternary",
+//!     "inputs": [ { "method": "ternary", "calldata": [] } ],
+//!     "expected": [ "3", "231" ]
+//! }, {
+//!     "name": "call",
+//!     "inputs": [ { "method": "call", "calldata": [] } ],
+//!     "expected": [ "23", "231" ]
+//! }, {
+//!     "name": "index_place",
+//!     "inputs": [ { "method": "indexPlace", "calldata": [] } ],
+//!     "expected": [ "3", "312" ]
+//! }, {
+//!     "name": "compound",
+//!     "inputs": [ { "method": "compound", "calldata": [] } ],
+//!     "expected": [ "105", "321" ]
+//! }, {
+//!     "name": "tuple",
+//!     "inputs": [ { "method": "tuple", "calldata": [] } ],
+//!     "expected": [ "3", "4", "3412" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    mapping(uint256 => uint256) slot;
+    mapping(uint256 => mapping(uint256 => uint256)) grid;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function pair(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x * 10 + y;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        slot[t(1)] = t(2) + t(3);
+        return (slot[1], order);
+    }
+
+    function ternary() public returns (uint256, uint256) {
+        order = 0;
+        slot[t(1)] = t(2) != 0 ? t(3) : t(4);
+        return (slot[1], order);
+    }
+
+    function call() public returns (uint256, uint256) {
+        order = 0;
+        slot[t(1)] = pair(t(2), t(3));
+        return (slot[1], order);
+    }
+
+    function indexPlace() public returns (uint256, uint256) {
+        order = 0;
+        grid[t(1)][t(2)] = t(3);
+        return (grid[1][2], order);
+    }
+
+    function compound() public returns (uint256, uint256) {
+        slot[1] = 100;
+        order = 0;
+        slot[t(1)] += t(2) + t(3);
+        return (slot[1], order);
+    }
+
+    function tuple() public returns (uint256, uint256, uint256) {
+        order = 0;
+        (slot[t(1)], slot[t(2)]) = (t(3), t(4));
+        return (slot[1], slot[2], order);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_binary.sol
+++ b/tests/solidity/simple/evaluation_order/nested_binary.sol
@@ -1,0 +1,70 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "6", "321" ]
+//! }, {
+//!     "name": "ternary",
+//!     "inputs": [ { "method": "ternary", "calldata": [] } ],
+//!     "expected": [ "6", "412" ]
+//! }, {
+//!     "name": "assignment",
+//!     "inputs": [ { "method": "assignment", "calldata": [] } ],
+//!     "expected": [ "3", "21" ]
+//! }, {
+//!     "name": "call",
+//!     "inputs": [ { "method": "call", "calldata": [] } ],
+//!     "expected": [ "24", "231" ]
+//! }, {
+//!     "name": "index",
+//!     "inputs": [ { "method": "index", "calldata": [] } ],
+//!     "expected": [ "1", "21" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    mapping(uint256 => uint256) slot;
+    uint256 store;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function pair(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x * 10 + y;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = (t(1) + t(2)) + t(3);
+        return (result, order);
+    }
+
+    function ternary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = (t(1) != 0 ? t(2) : t(3)) + t(4);
+        return (result, order);
+    }
+
+    function assignment() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) + (store = t(2));
+        return (result, order);
+    }
+
+    function call() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) + pair(t(2), t(3));
+        return (result, order);
+    }
+
+    function index() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) + slot[t(2)];
+        return (result, order);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_call.sol
+++ b/tests/solidity/simple/evaluation_order/nested_call.sol
@@ -1,0 +1,49 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "33", "213" ]
+//! }, {
+//!     "name": "ternary",
+//!     "inputs": [ { "method": "ternary", "calldata": [] } ],
+//!     "expected": [ "24", "124" ]
+//! }, {
+//!     "name": "assignment",
+//!     "inputs": [ { "method": "assignment", "calldata": [] } ],
+//!     "expected": [ "12", "12" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    uint256 store;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function pair(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x * 10 + y;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = pair(t(1) + t(2), t(3));
+        return (result, order);
+    }
+
+    function ternary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = pair(t(1) != 0 ? t(2) : t(3), t(4));
+        return (result, order);
+    }
+
+    function assignment() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = pair((store = t(1)), t(2));
+        return (result, order);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_index.sol
+++ b/tests/solidity/simple/evaluation_order/nested_index.sol
@@ -1,0 +1,50 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "0", "213" ]
+//! }, {
+//!     "name": "ternary",
+//!     "inputs": [ { "method": "ternary", "calldata": [] } ],
+//!     "expected": [ "0", "124" ]
+//! }, {
+//!     "name": "call",
+//!     "inputs": [ { "method": "call", "calldata": [] } ],
+//!     "expected": [ "0", "123" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    mapping(uint256 => mapping(uint256 => uint256)) grid;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function first(uint256 x, uint256 y) internal pure returns (uint256) {
+        y;
+        return x;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = grid[t(1) + t(2)][t(3)];
+        return (result, order);
+    }
+
+    function ternary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = grid[t(1) != 0 ? t(2) : t(3)][t(4)];
+        return (result, order);
+    }
+
+    function call() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = grid[first(t(1), t(2))][t(3)];
+        return (result, order);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_logical.sol
+++ b/tests/solidity/simple/evaluation_order/nested_logical.sol
@@ -1,0 +1,55 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "1", "213" ]
+//! }, {
+//!     "name": "ternary",
+//!     "inputs": [ { "method": "ternary", "calldata": [] } ],
+//!     "expected": [ "1", "123" ]
+//! }, {
+//!     "name": "assignment",
+//!     "inputs": [ { "method": "assignment", "calldata": [] } ],
+//!     "expected": [ "1", "12" ]
+//! }, {
+//!     "name": "logical",
+//!     "inputs": [ { "method": "logical", "calldata": [] } ],
+//!     "expected": [ "1", "12" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    uint256 store;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        bool result = t(1) + t(2) != 0 && t(3) != 0;
+        return (result ? 1 : 0, order);
+    }
+
+    function ternary() public returns (uint256, uint256) {
+        order = 0;
+        bool result = t(1) != 0 && (t(2) != 0 ? t(3) : 0) != 0;
+        return (result ? 1 : 0, order);
+    }
+
+    function assignment() public returns (uint256, uint256) {
+        order = 0;
+        bool result = t(1) != 0 && (store = t(2)) != 0;
+        return (result ? 1 : 0, order);
+    }
+
+    function logical() public returns (uint256, uint256) {
+        order = 0;
+        bool result = t(1) != 0 && (t(2) != 0 || t(3) != 0);
+        return (result ? 1 : 0, order);
+    }
+}

--- a/tests/solidity/simple/evaluation_order/nested_ternary.sol
+++ b/tests/solidity/simple/evaluation_order/nested_ternary.sol
@@ -1,0 +1,59 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "binary",
+//!     "inputs": [ { "method": "binary", "calldata": [] } ],
+//!     "expected": [ "5", "132" ]
+//! }, {
+//!     "name": "logical",
+//!     "inputs": [ { "method": "logical", "calldata": [] } ],
+//!     "expected": [ "3", "123" ]
+//! }, {
+//!     "name": "call",
+//!     "inputs": [ { "method": "call", "calldata": [] } ],
+//!     "expected": [ "23", "123" ]
+//! }, {
+//!     "name": "assignment",
+//!     "inputs": [ { "method": "assignment", "calldata": [] } ],
+//!     "expected": [ "2", "12" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 order;
+    uint256 store;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function pair(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x * 10 + y;
+    }
+
+    function binary() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) != 0 ? t(2) + t(3) : t(4);
+        return (result, order);
+    }
+
+    function logical() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) != 0 && t(2) != 0 ? t(3) : t(4);
+        return (result, order);
+    }
+
+    function call() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) != 0 ? pair(t(2), t(3)) : t(4);
+        return (result, order);
+    }
+
+    function assignment() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = t(1) != 0 ? (store = t(2)) : (store = t(3));
+        return (result, order);
+    }
+}


### PR DESCRIPTION
- Lowered the remaining expression forms: conditional (ternary) `a ? b : c` in value, multi-value (tuple), and statement-effect positions.
- Construct-specific legacy evaluation order: built-in binary operands and `addmod`/`mulmod` arguments evaluate right-first, an assignment evaluates its value before its place, and tuple values then places evaluate left-to-right with the stores committed right-to-left. The order sinks into `Place::assign` and the arithmetic operand sequencing over a thin Slang dispatch, matching solc's legacy codegen rather than `print-init`, which orders operands left-first.
- Unified the cast surface: `Value::coerce` folds into a single `Value::convert`, and the frontend `coerced`/`coerced_operands`/`coerced_values` become `converted`/`converted_operands`/`converted_values` — one cast op whose caller owns whether the target is a computed common type or an explicit `T(x)`.
- Consolidated the executable evaluation-order fixtures under one `evaluation_order/` LIT directory behind the `%evaluation_order` substitution, and pinned the explicit `!sol.fixedbytes<32>` return type on the `blockhash`/`blobhash` fixtures.
- EVM built-ins `blockhash`, `blobhash`, and `selfdestruct`, plus builtin math literal widening (a folded literal argument, e.g. the `ecrecover` literal case).
- Advanced the Slang pin to the rebased, trimmed `az-dev-solx-clean` fork tip.
