### PR TITLE
ci(windows): drop rustc's stale libwinpthread so C++ proc-macros load

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -59,6 +59,20 @@ runs:
       shell: bash
       run: rm -v target-llvm/target-final/lib/libstdc++.a
 
+    # Consequence of the shared libstdc++ above: rustc loads proc-macros with
+    # the default Windows DLL search order, where the application dir —
+    # rustc's sysroot bin/ — beats PATH. The windows-gnu dist ships a stale
+    # libwinpthread-1.dll there (imported by nothing in bin/; rust-lld has
+    # its own copy under rustlib/), lacking the mingw-w64 v14 64-bit-time
+    # symbols that GCC 16's shared libstdc++-6.dll needs, so loading any
+    # C++-linking proc-macro (melior-macro via tblgen) fails with E0463.
+    # Drop it so the dependency resolves to MSYS2's copy via PATH. -f: the
+    # step self-noops (and can be deleted) once rust ships mingw-w64 >= v14.
+    - name: Drop rustc's stale libwinpthread (Windows)
+      if: runner.os == 'Windows' && inputs.llvm == 'true'
+      shell: bash
+      run: rm -fv "$(rustc --print sysroot)/bin/libwinpthread-1.dll"
+
     - name: Build solc
       if: inputs.solc == 'true'
       uses: ./.github/actions/build-solc


### PR DESCRIPTION
Workaround for #589 (the load-time sequel to #550).

## Problem

**Slang Tests → Windows is deterministically red on `main`** since #557 merged (runs [29910202004](https://github.com/NomicFoundation/solx/actions/runs/29910202004), [29912409528](https://github.com/NomicFoundation/solx/actions/runs/29912409528)):

```
error[E0463]: can't find crate for `melior_macro`
error: could not compile `melior` (lib) due to 1 previous error
```

The melior rev bump in #557 is the trigger, not the cause — it invalidated the cargo cache entry and forced the first fresh `melior` compile (= first proc-macro *load*) since the #550 shared-libstdc++ workaround landed. `melior-macro`'s source is byte-identical across the two revs, and no good `melior` artifact can ever be cached while the load fails, so the leg stays red without this fix.

## Root cause (confirmed by PE import/export analysis — full trail in #589)

`melior-macro` is a proc-macro that links LLVM C++ (via `tblgen`). Since the #550 workaround switched test builds to shared libstdc++, the built `melior_macro.dll` needs GCC 16's `libstdc++-6.dll` at load time.

rustc loads proc-macros via `libloading` → `LoadLibraryExW(path, 0)` → the **default Windows DLL search order**, in which the application directory — rustc's sysroot `bin/` — beats PATH. The windows-gnu dist ships a stale `libwinpthread-1.dll` there, and GCC 16's `libstdc++-6.dll` imports three mingw-w64 v14 64-bit-time symbols the stale copy doesn't export:

| GCC 16 `libstdc++-6.dll` imports from winpthread | rust 1.97.1's bundled `libwinpthread-1.dll` |
|---|---|
| `clock_gettime64` | ❌ absent |
| `nanosleep64` | ❌ absent |
| `pthread_cond_timedwait64` | ❌ absent |

The dependency chain fails to load and rustc surfaces it as the generic `E0463: can't find crate`. PATH-based fixes cannot work — the app dir always wins.

## Fix

Delete the stale DLL from the sysroot `bin/` in `build-toolchain` (next to the existing #550 workaround, same guards), so the dependency falls through to MSYS2's mingw-w64 v14 copy via PATH:

```bash
rm -fv "$(rustc --print sysroot)/bin/libwinpthread-1.dll"
```

**Verified safe:** nothing in the sysroot `bin/` imports winpthread — `rustc.exe`, `rustdoc.exe`, `rustc_driver-*.dll`, and `std-*.dll` all checked (they depend only on KERNEL32/msvcrt/ntdll/libgcc). `rust-lld.exe` does need it, but has its own copies under `rustlib/<triple>/bin/` (rust-lang/rust#128876), untouched here. The libgcc half of the chain needs no intervention: all 14 symbols GCC 16's libstdc++ imports from `libgcc_s_seh-1.dll` are exported by rust's bundled copy. `-f` makes the step self-nooping (and deletable) once rust ships mingw-w64 ≥ v14.

## Prior art — same class, same fix shape

- rust-lang/rust#99534 (via rust-lang/rustup#3045): rustc's stale bundled `libgcc_s_dw2-1.dll` broke MSYS2 gcc ≥ 11.3; reporter's workaround was deleting the DLL; fixed upstream by a bundled-mingw bump (rust-lang/rust#100178).
- ddnet/ddnet#10203 and a [ruby-core report](https://ml.ruby-lang.org/archives/list/ruby-core@ml.ruby-lang.org/message/JMJT7OIYUAPI22W4PGTLSL772RYD3S7Y): identical stale-winpthread failures outside Rust, both resolved by removing/replacing the stale DLL.

An upstream report against rust-lang/rust is being filed in parallel (the `bin/` copy is imported by nothing there and shadows newer runtimes during in-process loads); this workaround stays until a fixed toolchain reaches our pinned `rust-toolchain.toml`. The structural fix that makes it deletable on our side — getting tblgen out of macro-expansion time in the melior fork — is tracked in #589.

## Verification

Verified in run [29923864614](https://github.com/NomicFoundation/solx/actions/runs/29923864614): the **Windows leg passes** — the cached GCC-16-linked `melior_macro.dll` (the exact artifact that failed on `main`) loads, `melior` compiles, and the slang suite runs green, with this one-file change as the only difference from the failing configuration. The run's overall red comes from `solx-mlir :: conditional.sol` failing on Linux ARM64 + macOS x86 — a pre-existing `main` breakage from #563, unrelated to this Windows-gated change; tracked in #591.
