### PR TITLE
test(codegen): reproducer for optimizer eliminating gas-consuming loops

### DIFF
--- a/tests/solidity/simple/loop_infinite_gas.sol
+++ b/tests/solidity/simple/loop_infinite_gas.sol
@@ -1,0 +1,31 @@
+//! { "cases": [ {
+//!     "name": "default",
+//!     "inputs": [
+//!         {
+//!             "method": "run",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [ {
+//!         "return_data": [
+//!         ],
+//!         "exception": true
+//!     } ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract Test {
+    uint256 public sink;
+
+    function run() external returns (uint256) {
+        uint256 i = 0;
+        while (true) {
+            i += 1;
+        }
+        return 42;
+    }
+}


### PR DESCRIPTION
## What

Adds a failing reproducer, `tests/solidity/simple/loop_infinite_gas.sol`, for a
middle-end miscompilation: an effectively non-terminating, side-effect-free loop
is optimized away, changing observable EVM behavior.

```solidity
function run() external returns (uint256) {
    uint256 i = 0;
    while (true) { i += 1; }
    return 42;
}
```

Under EVM gas semantics `run()` must burn gas every iteration and halt
**out-of-gas**. Instead, at every optimizing level solx emits an immediate
`Panic(0x11)` (arithmetic overflow) revert.

The reproducer asserts the correct behavior (out-of-gas halt: empty return data
+ exception). It **holds at `M0`** and **fails at `M1/M2/M3/Mz`** (both `Y` and
`E` pipelines), where the loop is eliminated. It is intentionally red until the
optimizer fix lands; flip the case to `"ignore": true` if a green branch is
preferred meanwhile.

## Root cause — not `mustprogress`

The original hypothesis was that the frontend emits the LLVM `mustprogress`
attribute by default. That is **not** what happens:

- The FE never emits `mustprogress`. Unoptimized IR for the user function is
  `attributes #18 = { nofree null_pointer_is_valid "target-features"="+osaka" }`
  — matching `Function::set_default_attributes`, which sets only `NoFree`,
  `NullPointerIsValid`, and `TargetFeatures`.
- `mustprogress` appears only **after** optimization, inferred by LLVM
  (`willreturn` ⟹ `mustprogress` in `llvm/lib/Transforms/Utils/Local.cpp`
  `inferAttributesFromOthers`).
- Genuinely non-terminating loops are **preserved**: `while (true) {}` and
  `while (true) { unchecked { i += 1; } }` both survive full `O3` (a bare
  infinite loop does not get `willreturn`/`mustprogress` inferred).

The reported loop is deleted by a different mechanism. Because the increment is
checked, the loop's only exit is the overflow-to-`Panic(0x11)` path, so
`IndVarSimplify` proves a finite `2^256` backedge-taken count, rewrites the exit
value to closed form, the side-effect-free body goes dead, and `LoopDeletion`
removes the loop — collapsing the function to its terminal panic. Minimal IR
confirms this is independent of `mustprogress`:

- `opt -passes='loop-deletion'` on a finite-trip, side-effect-free loop with **no**
  `mustprogress`: loop preserved.
- `opt -passes='indvars,loop-deletion'`: loop deleted, exit value folded.

The elimination is sound in a language where side-effect-free iterations are
unobservable, but in EVM every iteration costs gas; discarding them turns an
out-of-gas halt into a clean `Panic(0x11)` revert. The fix belongs in the LLVM
optimizer.

## Tracking

LLVM-side fix tracked in NomicFoundation/solx-llvm#125.

`ci:integration` is set to exercise the reproducer across the mode matrix.
