### PR TITLE
fix(codegen): place the spill area above the memory guard

### DIFF
--- a/solx-codegen-evm/src/codegen/context/mod.rs
+++ b/solx-codegen-evm/src/codegen/context/mod.rs
@@ -72,6 +72,12 @@ pub struct Context<'ctx> {
     /// The output configuration telling whether to dump the needed IRs.
     output_config: Option<OutputConfig>,
 
+    /// The unit's `memoryguard` base offset, above which the spill area is placed so it never
+    /// overlaps solc's statically allocated memory below the guard, such as the immutable
+    /// staging slots of deploy code. Defaults to the free-memory start and is refined when a
+    /// `MEMORYGUARD` sets the reserved-memory boundary.
+    memory_guard: u64,
+
     /// The Solidity data.
     solidity_data: Option<SolidityData>,
     /// The EVM legacy assembly data.
@@ -140,6 +146,8 @@ impl<'ctx> Context<'ctx> {
             debug_info,
             output_config,
 
+            memory_guard: crate::r#const::SOLC_USER_MEMORY_OFFSET,
+
             solidity_data,
             evmla_data: None,
 
@@ -169,8 +177,12 @@ impl<'ctx> Context<'ctx> {
             "InitVerify",
             self.optimizer.settings(),
         );
-        let target_machine =
-            TargetMachine::new(self.optimizer.settings(), self.llvm_options.as_slice())?;
+        let spill_area_size = self.optimizer.settings().spill_area_size();
+        let target_machine = TargetMachine::new(
+            self.optimizer.settings(),
+            self.llvm_options.as_slice(),
+            spill_area_size.map(|size| (self.memory_guard, size)),
+        )?;
         target_machine.set_target_data(self.module());
         target_machine.set_asm_verbosity(true);
 
@@ -179,18 +191,12 @@ impl<'ctx> Context<'ctx> {
             self.debug_info = Some(debug_info);
         }
 
-        let spill_area = self
-            .optimizer
-            .settings()
-            .spill_area_size()
-            .map(|spill_area_size| (crate::r#const::SOLC_USER_MEMORY_OFFSET, spill_area_size));
-
         if let Some(output_config) = self.output_config.as_ref() {
             output_config.dump_llvm_ir_unoptimized(
                 contract_path,
                 self.module(),
                 is_size_fallback,
-                spill_area,
+                spill_area_size,
             )?;
         }
 
@@ -226,7 +232,7 @@ impl<'ctx> Context<'ctx> {
                 contract_path,
                 self.module(),
                 is_size_fallback,
-                spill_area,
+                spill_area_size,
             )?;
         }
 
@@ -271,7 +277,7 @@ impl<'ctx> Context<'ctx> {
                     contract_path,
                     assembly_text.as_ref(),
                     is_size_fallback,
-                    spill_area,
+                    spill_area_size,
                 )?;
             }
 
@@ -406,6 +412,13 @@ impl<'ctx> Context<'ctx> {
         self.module()
             .verify()
             .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    ///
+    /// Sets the memory guard base offset, above which the spill area is placed.
+    ///
+    pub fn set_memory_guard(&mut self, offset: u64) {
+        self.memory_guard = offset;
     }
 
     ///

--- a/solx-codegen-evm/src/debug_config/mod.rs
+++ b/solx-codegen-evm/src/debug_config/mod.rs
@@ -129,12 +129,12 @@ impl OutputConfig {
         contract_path: &str,
         code: &str,
         is_size_fallback: bool,
-        spill_area: Option<(u64, u64)>,
+        spill_area_size: Option<u64>,
     ) -> anyhow::Result<()> {
         if !self.output_evmla {
             return Ok(());
         }
-        let suffix = Self::build_suffix(is_size_fallback, spill_area);
+        let suffix = Self::build_suffix(is_size_fallback, spill_area_size);
         let mut file_path = self.output_directory.to_owned();
         let full_file_name = Self::full_file_name(contract_path, suffix.as_deref(), IRType::EVMLA);
         file_path.push(full_file_name);
@@ -151,12 +151,12 @@ impl OutputConfig {
         contract_path: &str,
         code: &str,
         is_size_fallback: bool,
-        spill_area: Option<(u64, u64)>,
+        spill_area_size: Option<u64>,
     ) -> anyhow::Result<()> {
         if !self.output_ethir {
             return Ok(());
         }
-        let suffix = Self::build_suffix(is_size_fallback, spill_area);
+        let suffix = Self::build_suffix(is_size_fallback, spill_area_size);
         let mut file_path = self.output_directory.to_owned();
         let full_file_name = Self::full_file_name(contract_path, suffix.as_deref(), IRType::EthIR);
         file_path.push(full_file_name);
@@ -168,16 +168,16 @@ impl OutputConfig {
     ///
     /// Builds a suffix string from size fallback and spill area parameters.
     ///
-    fn build_suffix(is_size_fallback: bool, spill_area: Option<(u64, u64)>) -> Option<String> {
+    fn build_suffix(is_size_fallback: bool, spill_area_size: Option<u64>) -> Option<String> {
         let mut suffix = String::new();
         if is_size_fallback {
             suffix.push_str("size_fallback");
         }
-        if let Some((offset, size)) = spill_area {
+        if let Some(size) = spill_area_size {
             if !suffix.is_empty() {
                 suffix.push('.');
             }
-            suffix.push_str(format!("o{offset}s{size}").as_str());
+            suffix.push_str(format!("s{size}").as_str());
         }
         if suffix.is_empty() {
             None
@@ -194,7 +194,7 @@ impl OutputConfig {
         contract_path: &str,
         module: &inkwell::module::Module,
         is_size_fallback: bool,
-        spill_area: Option<(u64, u64)>,
+        spill_area_size: Option<u64>,
     ) -> anyhow::Result<()> {
         if !self.output_llvm_ir {
             return Ok(());
@@ -202,11 +202,9 @@ impl OutputConfig {
         let llvm_code = module.print_to_string().to_string();
 
         let mut suffix = "unoptimized".to_owned();
-        if is_size_fallback {
-            suffix.push_str(".size_fallback");
-        }
-        if let Some((offset, size)) = spill_area {
-            suffix.push_str(format!(".o{offset}s{size}").as_str());
+        if let Some(extra) = Self::build_suffix(is_size_fallback, spill_area_size) {
+            suffix.push('.');
+            suffix.push_str(extra.as_str());
         }
 
         let mut file_path = self.output_directory.to_owned();
@@ -226,7 +224,7 @@ impl OutputConfig {
         contract_path: &str,
         module: &inkwell::module::Module,
         is_size_fallback: bool,
-        spill_area: Option<(u64, u64)>,
+        spill_area_size: Option<u64>,
     ) -> anyhow::Result<()> {
         if !self.output_llvm_ir {
             return Ok(());
@@ -234,11 +232,9 @@ impl OutputConfig {
         let llvm_code = module.print_to_string().to_string();
 
         let mut suffix = "optimized".to_owned();
-        if is_size_fallback {
-            suffix.push_str(".size_fallback");
-        }
-        if let Some((offset, size)) = spill_area {
-            suffix.push_str(format!(".o{offset}s{size}").as_str());
+        if let Some(extra) = Self::build_suffix(is_size_fallback, spill_area_size) {
+            suffix.push('.');
+            suffix.push_str(extra.as_str());
         }
 
         let mut file_path = self.output_directory.to_owned();
@@ -258,21 +254,12 @@ impl OutputConfig {
         contract_path: &str,
         code: &str,
         is_size_fallback: bool,
-        spill_area: Option<(u64, u64)>,
+        spill_area_size: Option<u64>,
     ) -> anyhow::Result<()> {
         if !self.output_assembly {
             return Ok(());
         }
-        let mut suffix = if is_size_fallback {
-            Some("size_fallback".to_owned())
-        } else {
-            None
-        };
-        if let Some((offset, size)) = spill_area {
-            suffix
-                .get_or_insert_with(String::new)
-                .push_str(format!(".o{offset}s{size}").as_str());
-        }
+        let suffix = Self::build_suffix(is_size_fallback, spill_area_size);
 
         let mut file_path = self.output_directory.to_owned();
         let full_file_name =

--- a/solx-codegen-evm/src/target_machine.rs
+++ b/solx-codegen-evm/src/target_machine.rs
@@ -33,15 +33,13 @@ impl TargetMachine {
     pub fn new(
         optimizer_settings: &OptimizerSettings,
         llvm_options: &[String],
+        spill_area: Option<(u64, u64)>,
     ) -> anyhow::Result<Self> {
         let mut arguments = Vec::with_capacity(4 + llvm_options.len());
         arguments.push(Self::TARGET.to_string());
         arguments.extend_from_slice(llvm_options);
-        if let Some(size) = optimizer_settings.spill_area_size {
-            arguments.push(format!(
-                "-evm-stack-region-offset={}",
-                crate::r#const::SOLC_USER_MEMORY_OFFSET
-            ));
+        if let Some((offset, size)) = spill_area {
+            arguments.push(format!("-evm-stack-region-offset={offset}"));
             arguments.push(format!("-evm-stack-region-size={size}"));
         }
         if let Some(size) = optimizer_settings.metadata_size {

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -348,11 +348,7 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
             .to_owned();
 
         let is_size_fallback = context.optimizer().settings().is_fallback_to_size_enabled();
-        let spill_area = context
-            .optimizer()
-            .settings()
-            .spill_area_size()
-            .map(|size| (solx_codegen_evm::SOLC_USER_MEMORY_OFFSET, size));
+        let spill_area_size = context.optimizer().settings().spill_area_size();
 
         let output_evmla = context
             .output_config()
@@ -372,7 +368,7 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
                     contract_path.as_str(),
                     evmla_string.as_str(),
                     is_size_fallback,
-                    spill_area,
+                    spill_area_size,
                 )?,
                 None => context.set_captured_evmla(evmla_string),
             }
@@ -400,7 +396,7 @@ impl solx_codegen_evm::WriteLLVM for Assembly {
                     contract_path.as_str(),
                     ethir_string.as_str(),
                     is_size_fallback,
-                    spill_area,
+                    spill_area_size,
                 )?,
                 None => context.set_captured_ethir(ethir_string),
             }

--- a/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
+++ b/solx-evm-assembly/src/ethereal_ir/function/block/element/mod.rs
@@ -183,6 +183,14 @@ impl solx_codegen_evm::WriteLLVM for Element {
             ),
             InstructionName::MEMORYGUARD => {
                 let arguments = self.pop_arguments_llvm(context)?;
+                let StackElement::Constant(guard) = &self.stack_input.elements[0] else {
+                    unreachable!("`MEMORYGUARD` is always preceded by a constant memory offset")
+                };
+                context.set_memory_guard(
+                    guard
+                        .to_u64()
+                        .expect("Memory guard offset always fits in 64 bits"),
+                );
                 let spill_area = context
                     .optimizer()
                     .settings()

--- a/solx-yul/src/parser/statement/expression/function_call/mod.rs
+++ b/solx-yul/src/parser/statement/expression/function_call/mod.rs
@@ -5,6 +5,7 @@
 pub mod name;
 
 use inkwell::values::BasicValue;
+use num::ToPrimitive;
 use solx_codegen_evm::IContext;
 use solx_codegen_evm::ISolidityData;
 
@@ -771,7 +772,15 @@ impl FunctionCall {
                 solx_codegen_evm::call::linker_symbol(context, path.as_str()).map(Some)
             }
             Name::MemoryGuard => {
-                let arguments = self.pop_arguments_llvm::<1>(context)?;
+                let arguments = self.pop_arguments::<1>(context)?;
+                let guard = arguments[0]
+                    .constant
+                    .as_ref()
+                    .and_then(|constant| constant.to_u64())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("{location} `memoryguard` argument must be a literal")
+                    })?;
+                context.set_memory_guard(guard);
                 let spill_area = context
                     .optimizer()
                     .settings()
@@ -779,7 +788,7 @@ impl FunctionCall {
                     .unwrap_or_default();
                 solx_codegen_evm::arithmetic::addition(
                     context,
-                    arguments[0].into_int_value(),
+                    arguments[0].value.into_int_value(),
                     context.field_const(spill_area),
                 )
                 .map(Some)

--- a/tests/solidity/simple/immutable/spill_area.sol
+++ b/tests/solidity/simple/immutable/spill_area.sol
@@ -1,0 +1,158 @@
+//! { "cases": [ {
+//!     "name": "default",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "1"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "0" ],
+//!             "expected": [ "0x1001" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "1" ],
+//!             "expected": [ "0x1003" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "2" ],
+//!             "expected": [ "0x1005" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "3" ],
+//!             "expected": [ "0x1007" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "4" ],
+//!             "expected": [ "0x1009" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "5" ],
+//!             "expected": [ "0x100b" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "6" ],
+//!             "expected": [ "0x100d" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "7" ],
+//!             "expected": [ "0x100f" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "8" ],
+//!             "expected": [ "0x1011" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "9" ],
+//!             "expected": [ "0x1013" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "10" ],
+//!             "expected": [ "0x1015" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "11" ],
+//!             "expected": [ "0x1017" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "12" ],
+//!             "expected": [ "0x1019" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "13" ],
+//!             "expected": [ "0x101b" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "14" ],
+//!             "expected": [ "0x101d" ]
+//!         },
+//!         {
+//!             "method": "raw",
+//!             "calldata": [ "15" ],
+//!             "expected": [ "0x101f" ]
+//!         }
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+// Report https://github.com/NomicFoundation/solx/issues/599
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 public immutable v0;
+    address public immutable v1;
+    uint256 public immutable v2;
+    uint256 public immutable v3;
+    uint256 public immutable v4;
+    address public immutable v5;
+    uint256 public immutable v6;
+    uint256 public immutable v7;
+    uint256 public immutable v8;
+    address public immutable v9;
+    uint256 public immutable v10;
+    uint256 public immutable v11;
+    uint256 public immutable v12;
+    address public immutable v13;
+    uint256 public immutable v14;
+    uint256 public immutable v15;
+
+    constructor(uint256 seed) { unchecked {
+        v0 = seed*1+0x1000+0;
+        v1 = address(uint160(seed*2+0x1000+1));
+        v2 = seed*3+0x1000+2;
+        v3 = seed*4+0x1000+3;
+        v4 = seed*5+0x1000+4;
+        v5 = address(uint160(seed*6+0x1000+5));
+        v6 = seed*7+0x1000+6;
+        v7 = seed*8+0x1000+7;
+        v8 = seed*9+0x1000+8;
+        v9 = address(uint160(seed*10+0x1000+9));
+        v10 = seed*11+0x1000+10;
+        v11 = seed*12+0x1000+11;
+        v12 = seed*13+0x1000+12;
+        v13 = address(uint160(seed*14+0x1000+13));
+        v14 = seed*15+0x1000+14;
+        v15 = seed*16+0x1000+15;
+    } }
+
+    function raw(uint256 i) public view returns (uint256) {
+        if (i == 0) return v0;
+        if (i == 1) return uint256(uint160(v1));
+        if (i == 2) return v2;
+        if (i == 3) return v3;
+        if (i == 4) return v4;
+        if (i == 5) return uint256(uint160(v5));
+        if (i == 6) return v6;
+        if (i == 7) return v7;
+        if (i == 8) return v8;
+        if (i == 9) return uint256(uint160(v9));
+        if (i == 10) return v10;
+        if (i == 11) return v11;
+        if (i == 12) return v12;
+        if (i == 13) return uint256(uint160(v13));
+        if (i == 14) return v14;
+        if (i == 15) return v15;
+        return 0;
+    }
+}


### PR DESCRIPTION
Fixes #599: with 16+ immutables and enough register pressure to spill, a deploy-code spill slot overlapped the memory where legacy codegen stages immutable values, so one immutable was initialized with another's value.

The stack-too-deep spill area was pinned to the constant user-memory offset `0x80`, which is only free when nothing is reserved below the memory guard. Deploy code that stages immutables reserves that region, so the spill aliased it.

- The `MEMORYGUARD` / `memoryguard` handlers record the unit's guard base on the codegen `Context`, and `TargetMachine` places `-evm-stack-region-offset` there instead of the hardcoded constant, keeping the spill area above solc's statically allocated memory; a unit with no guard falls back to `0x80`.
- Runtime code and immutable-free deploy code have a `0x80` guard base, so their bytecode is bit-identical; only reserved-memory deploy code moves. The via-IR path carried the same latent overlap and is fixed alongside EVMLA.
- The debug dump suffix drops the always-constant offset and keeps the spill size.

Regression test added at `tests/solidity/simple/immutable/spill_area.sol` (the issue's MRE); the full REVM corpus stays at 175095 passed.