### PR TITLE
ci(slang-tests): skip doc-only changes via paths filter

### DIFF
--- a/.github/actions/code-changes/action.yml
+++ b/.github/actions/code-changes/action.yml
@@ -1,0 +1,33 @@
+name: Code changes filter
+description: >-
+  Detects whether any changed file is code rather than documentation.
+  The repository must already be checked out with full history
+  (fetch-depth 0) before calling this action.
+
+outputs:
+  code:
+    description: Whether any non-documentation file changed (true/false)
+    value: ${{ steps.filter.outputs.code }}
+
+runs:
+  using: composite
+  steps:
+    # token '' forces git-diff mode: the PR files API caps at 3,000 files, and
+    # a truncated list can fail open (matrix skipped despite a code change).
+    # 'every': a file counts as code only if no negation pattern excludes it.
+    # Not every .md is documentation — solx-benchmark-converter compiles
+    # templates/summary.md into the binary and asserts golden .md fixtures.
+    - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      id: filter
+      with:
+        token: ''
+        predicate-quantifier: 'every'
+        filters: |
+          code:
+            - '**'
+            - '!docs/**'
+            - '!*.md'
+            - '!**/README.md'
+            - '!.github/**/*.md'
+            - '!**/LICENSE-APACHE'
+            - '!**/LICENSE-MIT'

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -16,18 +16,39 @@ concurrency:
 jobs:
 
   label-check:
+    # Checks the PR's current label set, not the triggering action: keying on
+    # github.event.label.name would skip this run (and cancel a real one in
+    # flight) when an unrelated label is added to a PR carrying ci:sanitizer.
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ci:sanitizer'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:sanitizer'))
+      contains(github.event.pull_request.labels.*.name, 'ci:sanitizer')
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-24.04
     steps:
       - run: 'true'
 
+  changes:
+    needs: label-check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history for the filter's git-diff mode.
+          fetch-depth: 0
+      - uses: ./.github/actions/code-changes
+        id: filter
+
   cooldown-check:
     name: Cargo cooldown check
     runs-on: ubuntu-24.04
-    needs: label-check
+    needs: [label-check, changes]
+    # A custom if: overrides the implicit skip cascade from needs
+    # (actions/runner#491), so the label gate must be restated here.
+    if: needs.label-check.result == 'success' && needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -92,6 +113,7 @@ jobs:
     if: always()
     needs:
       - label-check
+      - changes
       - cooldown-check
       - sanitizer
     steps:
@@ -100,4 +122,6 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, sanitizer' || '' }}
+            ${{ needs.label-check.result == 'skipped' && 'label-check, changes, cooldown-check, sanitizer'
+            || needs.changes.outputs.code != 'true' && 'cooldown-check, sanitizer'
+            || '' }}

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -19,44 +19,40 @@ concurrency:
 jobs:
 
   label-check:
+    # Checks the PR's current label set, not the triggering action: keying on
+    # github.event.label.name would skip this run (and cancel a real one in
+    # flight) when an unrelated label is added to a PR carrying ci:slang.
     if: >-
       github.event_name == 'push'
-      || ((github.event.action == 'labeled' && github.event.label.name == 'ci:slang'
-      || github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ci:slang'))
+      || (contains(github.event.pull_request.labels.*.name, 'ci:slang')
       && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-24.04
     steps:
       - run: 'true'
 
-  # Detect whether code (non-doc) files changed; mirrors the filter in test.yaml.
   changes:
+    needs: label-check
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+          # Full history for the filter's git-diff mode.
+          fetch-depth: 0
+      - uses: ./.github/actions/code-changes
         id: filter
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            code:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
-              - '!**/LICENSE*'
 
   cooldown-check:
     name: Cargo cooldown check
     runs-on: ubuntu-24.04
     needs: [label-check, changes]
-    if: needs.changes.outputs.code == 'true'
+    # A custom if: overrides the implicit skip cascade from needs
+    # (actions/runner#491), so the label gate must be restated here.
+    if: needs.label-check.result == 'success' && needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -206,6 +202,6 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, slang-tests'
+            ${{ needs.label-check.result == 'skipped' && 'label-check, changes, cooldown-check, slang-tests'
             || needs.changes.outputs.code != 'true' && 'cooldown-check, slang-tests'
             || '' }}

--- a/.github/workflows/slang-tests.yaml
+++ b/.github/workflows/slang-tests.yaml
@@ -28,10 +28,35 @@ jobs:
     steps:
       - run: 'true'
 
+  # Detect whether code (non-doc) files changed; mirrors the filter in test.yaml.
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!**/LICENSE*'
+
   cooldown-check:
     name: Cargo cooldown check
     runs-on: ubuntu-24.04
-    needs: label-check
+    needs: [label-check, changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -172,6 +197,7 @@ jobs:
     if: always()
     needs:
       - label-check
+      - changes
       - cooldown-check
       - slang-tests
     steps:
@@ -180,4 +206,6 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-
-            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, slang-tests' || '' }}
+            ${{ needs.label-check.result == 'skipped' && 'label-check, cooldown-check, slang-tests'
+            || needs.changes.outputs.code != 'true' && 'cooldown-check, slang-tests'
+            || '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
       devcontainer: ${{ steps.filter-devcontainer.outputs.devcontainer }}
@@ -33,19 +32,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+          # Full history for the filters' git-diff mode.
+          fetch-depth: 0
+      - uses: ./.github/actions/code-changes
         id: filter
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            code:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
-              - '!**/LICENSE*'
       # Separate step: the OR-list below needs the default 'some' quantifier,
-      # while the negation-style filter above needs 'every'. The docker dir is
+      # while the negation-style code filter needs 'every'. The docker dir is
       # included because the devcontainer builds its `base` stage locally;
       # rust-toolchain.toml because the container resolves it lazily on first
       # use; this workflow itself so edits to the validation harness (the
@@ -53,6 +45,7 @@ jobs:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter-devcontainer
         with:
+          token: ''
           filters: |
             devcontainer:
               - '.devcontainer/**'


### PR DESCRIPTION
# ci(slang-tests): skip doc-only changes via paths filter

Mirrors `test.yaml`'s `changes` job in `slang-tests.yaml`: PRs and pushes that only touch `docs/`, `*.md`, `*.mdx`, or `LICENSE*` no longer run the 5-platform toolchain matrix.

Wiring:

- New `changes` job (same `dorny/paths-filter` pin and filter list as `test.yaml`) runs in parallel with `label-check`.
- `cooldown-check` gains `needs: changes` + `if: needs.changes.outputs.code == 'true'`; the skip propagates to `slang-tests` through the existing `needs` chain.
- `pr-checks` (alls-green) gets a second `allowed-skips` branch so the required check passes when the matrix was skipped for a doc-only change, while a failed `changes` job still fails it.

Behavior is unchanged for the existing `ci:slang` label gating and `push`/`merge_group` events — this only adds the doc-only skip, as groundwork for eventually enabling Slang tests by default.

`actionlint` clean.
