### PR TITLE
feat(slang): complete enums and user-defined value types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -286,7 +286,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -303,7 +303,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -323,7 +323,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -344,7 +344,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -362,7 +362,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "zeroize",
 ]
@@ -413,7 +413,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -425,7 +425,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -438,7 +438,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -451,7 +451,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -484,7 +484,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "tracing",
@@ -520,7 +520,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -533,7 +533,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec 0.7.6",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ dependencies = [
  "ark-serialize-derive 0.6.0",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
  "serde_with",
 ]
 
@@ -1483,7 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2888,16 +2888,6 @@ name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2944,7 +2934,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3934,7 +3924,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -4533,7 +4523,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4546,10 +4536,10 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
  "itertools 0.15.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-rational",
  "paste",
  "ruint",
@@ -4563,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4577,12 +4567,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4591,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4605,9 +4595,9 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=0f2a4adf1bb709e57b00df9ad5c5b26181b75061#0f2a4adf1bb709e57b00df9ad5c5b26181b75061"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-rational",
  "num-traits",
@@ -4790,7 +4780,8 @@ name = "solx-slang"
 version = "0.1.6"
 dependencies = [
  "anyhow",
- "num-bigint 0.5.1",
+ "itertools 0.15.0",
+ "num",
  "num-traits",
  "ruint",
  "semver 1.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "6daec8fef8f0151ccac1413e0c882053b4e850d4"
+rev = "0f2a4adf1bb709e57b00df9ad5c5b26181b75061"

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -137,6 +137,14 @@ bool solxIsAddressType(MlirType ty) {
     return mlir::isa<mlir::sol::AddressType>(unwrap(ty));
 }
 
+bool solxIsEnumType(MlirType ty) {
+    return mlir::isa<mlir::sol::EnumType>(unwrap(ty));
+}
+
+uint32_t solxEnumTypeMax(MlirType ty) {
+    return mlir::cast<mlir::sol::EnumType>(unwrap(ty)).getMax();
+}
+
 bool solxIsStringType(MlirType ty) {
     return mlir::isa<mlir::sol::StringType>(unwrap(ty));
 }

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -162,6 +162,12 @@ unsafe extern "C" {
     /// Whether the type is a `sol::AddressType`, regardless of payability.
     pub fn solxIsAddressType(ty: mlir_sys::MlirType) -> bool;
 
+    /// Whether the type is a `sol::EnumType`.
+    pub fn solxIsEnumType(ty: mlir_sys::MlirType) -> bool;
+
+    /// Returns the largest ordinal a `sol::EnumType` admits.
+    pub fn solxEnumTypeMax(ty: mlir_sys::MlirType) -> u32;
+
     /// Whether the type is a `sol::StringType`, the shared representation of dynamic
     /// `bytes` and `string`.
     pub fn solxIsStringType(ty: mlir_sys::MlirType) -> bool;

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -36,6 +36,9 @@ sol_ops! {
     Value::address_cast(self, target_type: ty) -> value {
         AddressCastOperation.inp(self).out(target_type)
     }
+    Value::enum_cast(self, target_type: ty) -> value {
+        EnumCastOperation.inp(self).out(target_type)
+    }
     Value::dyn_bytes_to_fixedbytes(self, target_type: ty) -> value {
         DynBytesToFixedBytesOperation.inp(self).out(target_type)
     }

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -198,6 +198,17 @@ impl<'context> Type<'context> {
         unsafe { ffi::solxIsAddressType(self.inner.to_raw()) }
     }
 
+    /// Whether this is a `sol::EnumType`.
+    pub fn is_enum(self) -> bool {
+        unsafe { ffi::solxIsEnumType(self.inner.to_raw()) }
+    }
+
+    /// The largest ordinal this enum type admits; the classification is the caller's, via
+    /// `is_enum`.
+    pub fn enum_max(self) -> u32 {
+        unsafe { ffi::solxEnumTypeMax(self.inner.to_raw()) }
+    }
+
     /// Whether this is a `sol::StringType`, the shared representation of dynamic `bytes` and
     /// `string`.
     pub fn is_string(self) -> bool {

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -27,8 +27,9 @@ pub struct Value<'context> {
 
 impl<'context> Value<'context> {
     /// Materialises a `sol.constant` from an arbitrary-width [`BigInt`] at the type a constant can be
-    /// emitted at, then converts it to the target: `ui160` for an address, the width-matched unsigned
-    /// integer for a bytes-like target, the target type itself otherwise.
+    /// emitted at, then converts it to the target: `ui160` for an address, the EVM word for an enum
+    /// ordinal, the width-matched unsigned integer for a bytes-like target, the target type itself
+    /// otherwise.
     pub fn constant_from_bigint(
         value: &BigInt,
         result_type: Type<'context>,
@@ -36,6 +37,8 @@ impl<'context> Value<'context> {
     ) -> Self {
         let r#type = if result_type.is_address() {
             Type::unsigned(context.melior, solx_utils::BIT_LENGTH_ETH_ADDRESS)
+        } else if result_type.is_enum() {
+            Type::field(context.melior)
         } else if result_type.is_bytes_like() {
             let bits = result_type.bytes_like_width() as usize * solx_utils::BIT_LENGTH_BYTE;
             Type::unsigned(context.melior, bits)
@@ -105,11 +108,15 @@ impl<'context> Value<'context> {
     }
 
     /// Emits the cast reconciling `self` to `target_type`, be it a computed common type or an
-    /// explicit `T(x)`. The address and string-to-`bytesN` arms, reachable only under an explicit
-    /// cast, precede the bytes and scalar arms an address or string would otherwise fall into.
+    /// explicit `T(x)`. The enum, address, and string-to-`bytesN` arms, reachable only under an
+    /// explicit cast, precede the bytes and scalar arms an enum, address, or string would otherwise
+    /// fall into.
     pub fn convert(mut self, target_type: Type<'context>, context: &Context<'context>) -> Self {
         if self.r#type() == target_type {
             return self;
+        }
+        if self.r#type().is_enum() || target_type.is_enum() {
+            return self.enum_cast(target_type, context);
         }
         if self.r#type().is_address() {
             return self.address_cast(target_type, context);

--- a/solx-mlir/tests/lit/comparison.sol
+++ b/solx-mlir/tests/lit/comparison.sol
@@ -72,7 +72,27 @@
 // CHECK: sol.func @{{.*ge_fixed_bytes.*}}
 // CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : !sol.fixedbytes<8>
 
+// CHECK: sol.func @{{.*eq_enum.*}}
+// CHECK:   sol.cmp eq, %{{.*}}, %{{.*}} : !sol.enum<2>
+
+// CHECK: sol.func @{{.*ne_enum.*}}
+// CHECK:   sol.cmp ne, %{{.*}}, %{{.*}} : !sol.enum<2>
+
+// CHECK: sol.func @{{.*lt_enum.*}}
+// CHECK:   sol.cmp lt, %{{.*}}, %{{.*}} : !sol.enum<2>
+
+// CHECK: sol.func @{{.*le_enum.*}}
+// CHECK:   sol.cmp le, %{{.*}}, %{{.*}} : !sol.enum<2>
+
+// CHECK: sol.func @{{.*gt_enum.*}}
+// CHECK:   sol.cmp gt, %{{.*}}, %{{.*}} : !sol.enum<2>
+
+// CHECK: sol.func @{{.*ge_enum.*}}
+// CHECK:   sol.cmp ge, %{{.*}}, %{{.*}} : !sol.enum<2>
+
 contract C {
+    enum E { First, Second, Third }
+
     function eq(uint256 a, uint256 b) public pure returns (bool) {
         return a == b;
     }
@@ -162,6 +182,30 @@ contract C {
     }
 
     function ge_fixed_bytes(bytes4 a, bytes8 b) public pure returns (bool) {
+        return a >= b;
+    }
+
+    function eq_enum(E a, E b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function ne_enum(E a, E b) public pure returns (bool) {
+        return a != b;
+    }
+
+    function lt_enum(E a, E b) public pure returns (bool) {
+        return a < b;
+    }
+
+    function le_enum(E a, E b) public pure returns (bool) {
+        return a <= b;
+    }
+
+    function gt_enum(E a, E b) public pure returns (bool) {
+        return a > b;
+    }
+
+    function ge_enum(E a, E b) public pure returns (bool) {
         return a >= b;
     }
 }

--- a/solx-mlir/tests/lit/enum_storage_key_field.sol
+++ b/solx-mlir/tests/lit/enum_storage_key_field.sol
@@ -1,0 +1,65 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.state_var @{{.*}} slot 0 offset 0 : !sol.enum<2>
+// CHECK: sol.state_var @{{.*}} slot 1 offset 0 : !sol.mapping<!sol.enum<2>, ui256>
+// CHECK: sol.state_var @{{.*}} slot 2 offset 0 : !sol.struct<(!sol.enum<2>, ui256), Storage>
+
+// CHECK: sol.func @{{.*write.*}}
+// CHECK:   sol.addr_of @{{.*}} : !sol.ptr<!sol.enum<2>, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.enum<2>, !sol.ptr<!sol.enum<2>, Storage>
+
+// CHECK: sol.func @{{.*read.*}}-> !sol.enum<2>
+// CHECK:   sol.addr_of @{{.*}} : !sol.ptr<!sol.enum<2>, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<!sol.enum<2>, Storage>, !sol.enum<2>
+
+// CHECK: sol.func @{{.*entry.*}}-> ui256
+// CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<!sol.enum<2>, ui256>, !sol.enum<2>, !sol.ptr<ui256, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
+
+// CHECK: sol.func @{{.*write_entry.*}}
+// CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<!sol.enum<2>, ui256>, !sol.enum<2>, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*field.*}}-> !sol.enum<2>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(!sol.enum<2>, ui256), Storage>, ui64, !sol.ptr<!sol.enum<2>, Storage>
+// CHECK:   sol.load %{{.*}} : !sol.ptr<!sol.enum<2>, Storage>, !sol.enum<2>
+
+// CHECK: sol.func @{{.*clear.*}}
+// CHECK:   sol.constant 0 : ui256
+// CHECK:   sol.enum_cast %{{.*}} : ui256 to !sol.enum<2>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : !sol.enum<2>, !sol.ptr<!sol.enum<2>, Storage>
+
+contract C {
+    enum E { First, Second, Third }
+
+    struct S { E tag; uint256 amount; }
+
+    E state;
+    mapping(E => uint256) counts;
+    S item;
+
+    function write(E value) public {
+        state = value;
+    }
+
+    function read() public view returns (E) {
+        return state;
+    }
+
+    function entry(E key) public view returns (uint256) {
+        return counts[key];
+    }
+
+    function write_entry(E key, uint256 value) public {
+        counts[key] = value;
+    }
+
+    function field() public view returns (E) {
+        return item.tag;
+    }
+
+    function clear() public {
+        delete state;
+    }
+}

--- a/solx-mlir/tests/lit/enum_variant.sol
+++ b/solx-mlir/tests/lit/enum_variant.sol
@@ -1,0 +1,38 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*variant.*}}-> !sol.enum<2>
+// CHECK:   sol.constant 1 : ui256
+// CHECK:   sol.enum_cast %{{.*}} : ui256 to !sol.enum<2>
+
+// CHECK: sol.func @{{.*qualified_variant.*}}-> !sol.enum<2>
+// CHECK:   sol.constant 2 : ui256
+// CHECK:   sol.enum_cast %{{.*}} : ui256 to !sol.enum<2>
+
+// CHECK: sol.func @{{.*type_min.*}}-> !sol.enum<2>
+// CHECK:   sol.constant 0 : ui256
+// CHECK:   sol.enum_cast %{{.*}} : ui256 to !sol.enum<2>
+
+// CHECK: sol.func @{{.*type_max.*}}-> !sol.enum<2>
+// CHECK:   sol.constant 2 : ui256
+// CHECK:   sol.enum_cast %{{.*}} : ui256 to !sol.enum<2>
+
+contract C {
+    enum E { First, Second, Third }
+
+    function variant() public pure returns (E) {
+        return E.Second;
+    }
+
+    function qualified_variant() public pure returns (E) {
+        return C.E.Third;
+    }
+
+    function type_min() public pure returns (E) {
+        return type(E).min;
+    }
+
+    function type_max() public pure returns (E) {
+        return type(E).max;
+    }
+}

--- a/solx-mlir/tests/lit/named_returns.sol
+++ b/solx-mlir/tests/lit/named_returns.sol
@@ -16,7 +16,13 @@
 // CHECK:   %[[ZERO:.*]] = sol.constant 0 : ui32
 // CHECK:   sol.bytes_cast %[[ZERO]] : ui32 to !sol.fixedbytes<4>
 
+// CHECK: sol.func @{{.*named_enum.*}}
+// CHECK:   %[[ORDINAL:.*]] = sol.constant 0 : ui256
+// CHECK:   sol.enum_cast %[[ORDINAL]] : ui256 to !sol.enum<2>
+
 contract C {
+    enum E { First, Second, Third }
+
     function identity(bool _in) public pure returns (bool _out) {
         _out = _in;
     }
@@ -26,4 +32,6 @@ contract C {
     }
 
     function named_bytes() public pure returns (bytes4 result) {}
+
+    function named_enum() public pure returns (E result) {}
 }

--- a/solx-mlir/tests/lit/type_casts.sol
+++ b/solx-mlir/tests/lit/type_casts.sol
@@ -37,7 +37,19 @@
 // CHECK: sol.func @{{.*array_to_memory.*}}
 // CHECK:   sol.data_loc_cast %{{.*}} : !sol.array<? x ui256, CallData>, !sol.array<? x ui256, Memory>
 
+// CHECK: sol.func @{{.*uint8_to_enum.*}}
+// CHECK:   sol.enum_cast %{{.*}} : ui8 to !sol.enum<2>
+
+// CHECK: sol.func @{{.*enum_to_uint8.*}}
+// CHECK:   sol.enum_cast %{{.*}} : !sol.enum<2> to ui8
+
+// CHECK: sol.func @{{.*enum_to_uint256.*}}
+// CHECK:   sol.enum_cast %{{.*}} : !sol.enum<2> to ui8
+// CHECK:   sol.cast %{{.*}} : ui8 to ui256
+
 contract C {
+    enum E { First, Second, Third }
+
     function uint8_to_uint256(uint8 x) public pure returns (uint256) {
         return uint256(x);
     }
@@ -85,5 +97,17 @@ contract C {
 
     function array_to_memory(uint256[] calldata source) external pure returns (uint256[] memory) {
         return uint256[](source);
+    }
+
+    function uint8_to_enum(uint8 x) public pure returns (E) {
+        return E(x);
+    }
+
+    function enum_to_uint8(E x) public pure returns (uint8) {
+        return uint8(x);
+    }
+
+    function enum_to_uint256(E x) public pure returns (uint256) {
+        return uint256(uint8(x));
     }
 }

--- a/solx-mlir/tests/lit/user_defined_operator.sol
+++ b/solx-mlir/tests/lit/user_defined_operator.sol
@@ -1,0 +1,115 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+// solc's print-init emits the contract alone, so the CHECKs stop at the call sites.
+
+// CHECK: sol.func @{{.*plus.*}}-> ui256
+// CHECK:   sol.call @{{.*add.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*minus.*}}-> ui256
+// CHECK:   sol.call @{{.*sub.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*times.*}}-> ui256
+// CHECK:   sol.call @{{.*mul.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*divided.*}}-> ui256
+// CHECK:   sol.call @{{.*div.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*modulo.*}}-> ui256
+// CHECK:   sol.call @{{.*rem.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*conjunction.*}}-> ui256
+// CHECK:   sol.call @{{.*band.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*disjunction.*}}-> ui256
+// CHECK:   sol.call @{{.*bor.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*exclusive.*}}-> ui256
+// CHECK:   sol.call @{{.*bxor.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*negated.*}}-> ui256
+// CHECK:   sol.call @{{.*neg.*}}(%{{.*}}) : (ui256) -> ui256
+
+// CHECK: sol.func @{{.*inverted.*}}-> ui256
+// CHECK:   sol.call @{{.*bnot.*}}(%{{.*}}) : (ui256) -> ui256
+
+// CHECK: sol.func @{{.*equal.*}}-> i1
+// CHECK:   sol.call @{{.*eq.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*unequal.*}}-> i1
+// CHECK:   sol.call @{{.*ne.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*below.*}}-> i1
+// CHECK:   sol.call @{{.*lt.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*at_most.*}}-> i1
+// CHECK:   sol.call @{{.*le.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*above.*}}-> i1
+// CHECK:   sol.call @{{.*gt.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*at_least.*}}-> i1
+// CHECK:   sol.call @{{.*ge.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> i1
+
+// CHECK: sol.func @{{.*precedence.*}}-> ui256
+// CHECK:   sol.call @{{.*mul.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+// CHECK:   sol.call @{{.*add.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*signed_equal.*}}-> i1
+// CHECK:   sol.call @{{.*signed_eq.*}}(%{{.*}}, %{{.*}}) : (si256, si256) -> i1
+
+// CHECK: sol.func @{{.*signed_below.*}}-> i1
+// CHECK:   sol.call @{{.*signed_lt.*}}(%{{.*}}, %{{.*}}) : (si256, si256) -> i1
+
+type T is uint256;
+type Signed is int256;
+
+using {
+    add as +, sub as -, mul as *, div as /, rem as %,
+    band as &, bor as |, bxor as ^,
+    neg as -, bnot as ~,
+    eq as ==, ne as !=, lt as <, le as <=, gt as >, ge as >=
+} for T global;
+
+using {signed_eq as ==, signed_lt as <} for Signed global;
+
+function add(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) + T.unwrap(b)); }
+function sub(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) - T.unwrap(b)); }
+function mul(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) * T.unwrap(b)); }
+function div(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) / T.unwrap(b)); }
+function rem(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) % T.unwrap(b)); }
+function band(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) & T.unwrap(b)); }
+function bor(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) | T.unwrap(b)); }
+function bxor(T a, T b) pure returns (T) { return T.wrap(T.unwrap(a) ^ T.unwrap(b)); }
+function neg(T a) pure returns (T) { return T.wrap(0 - T.unwrap(a)); }
+function bnot(T a) pure returns (T) { return T.wrap(~T.unwrap(a)); }
+function eq(T a, T b) pure returns (bool) { return T.unwrap(a) == T.unwrap(b); }
+function ne(T a, T b) pure returns (bool) { return T.unwrap(a) != T.unwrap(b); }
+function lt(T a, T b) pure returns (bool) { return T.unwrap(a) < T.unwrap(b); }
+function le(T a, T b) pure returns (bool) { return T.unwrap(a) <= T.unwrap(b); }
+function gt(T a, T b) pure returns (bool) { return T.unwrap(a) > T.unwrap(b); }
+function ge(T a, T b) pure returns (bool) { return T.unwrap(a) >= T.unwrap(b); }
+
+function signed_eq(Signed a, Signed b) pure returns (bool) { return Signed.unwrap(a) == Signed.unwrap(b); }
+function signed_lt(Signed a, Signed b) pure returns (bool) { return Signed.unwrap(a) < Signed.unwrap(b); }
+
+contract C {
+    function plus(T a, T b) public pure returns (T) { return a + b; }
+    function minus(T a, T b) public pure returns (T) { return a - b; }
+    function times(T a, T b) public pure returns (T) { return a * b; }
+    function divided(T a, T b) public pure returns (T) { return a / b; }
+    function modulo(T a, T b) public pure returns (T) { return a % b; }
+    function conjunction(T a, T b) public pure returns (T) { return a & b; }
+    function disjunction(T a, T b) public pure returns (T) { return a | b; }
+    function exclusive(T a, T b) public pure returns (T) { return a ^ b; }
+    function negated(T a) public pure returns (T) { return -a; }
+    function inverted(T a) public pure returns (T) { return ~a; }
+    function equal(T a, T b) public pure returns (bool) { return a == b; }
+    function unequal(T a, T b) public pure returns (bool) { return a != b; }
+    function below(T a, T b) public pure returns (bool) { return a < b; }
+    function at_most(T a, T b) public pure returns (bool) { return a <= b; }
+    function above(T a, T b) public pure returns (bool) { return a > b; }
+    function at_least(T a, T b) public pure returns (bool) { return a >= b; }
+    function precedence(T a, T b, T c) public pure returns (T) { return a + b * c; }
+    function signed_equal(Signed a, Signed b) public pure returns (bool) { return a == b; }
+    function signed_below(Signed a, Signed b) public pure returns (bool) { return a < b; }
+}

--- a/solx-mlir/tests/lit/user_defined_value_type.sol
+++ b/solx-mlir/tests/lit/user_defined_value_type.sol
@@ -1,19 +1,46 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*id_u.*}}: ui256) -> ui256
-// CHECK: sol.func @{{.*id_s.*}}: si8) -> si8
-// CHECK: sol.func @{{.*id_a.*}}: !sol.address) -> !sol.address
-// CHECK: sol.func @{{.*id_b.*}}: i1) -> i1
+// CHECK: sol.func @{{.*identity_unsigned.*}}: ui256) -> ui256
+// CHECK: sol.func @{{.*identity_signed.*}}: si8) -> si8
+// CHECK: sol.func @{{.*identity_address.*}}: !sol.address) -> !sol.address
+// CHECK: sol.func @{{.*identity_boolean.*}}: i1) -> i1
+
+// CHECK: sol.func @{{.*wrap_unsigned.*}}: ui256) -> ui256
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*unwrap_unsigned.*}}: ui256) -> ui256
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*wrap_signed.*}}: si8) -> si8
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*unwrap_signed.*}}: si8) -> si8
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*wrap_address.*}}: !sol.address) -> !sol.address
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*unwrap_address.*}}: !sol.address) -> !sol.address
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*wrap_boolean.*}}: i1) -> i1
+// CHECK-NOT: _cast
+// CHECK: sol.func @{{.*unwrap_boolean.*}}: i1) -> i1
+// CHECK-NOT: _cast
+// CHECK: sol.return
 
 contract C {
-    type U is uint256;
-    type S is int8;
-    type A is address;
-    type B is bool;
+    type Unsigned is uint256;
+    type Signed is int8;
+    type Address is address;
+    type Boolean is bool;
 
-    function id_u(U x) public pure returns (U) { return x; }
-    function id_s(S x) public pure returns (S) { return x; }
-    function id_a(A x) public pure returns (A) { return x; }
-    function id_b(B x) public pure returns (B) { return x; }
+    function identity_unsigned(Unsigned x) public pure returns (Unsigned) { return x; }
+    function identity_signed(Signed x) public pure returns (Signed) { return x; }
+    function identity_address(Address x) public pure returns (Address) { return x; }
+    function identity_boolean(Boolean x) public pure returns (Boolean) { return x; }
+
+    function wrap_unsigned(uint256 x) public pure returns (Unsigned) { return Unsigned.wrap(x); }
+    function unwrap_unsigned(Unsigned x) public pure returns (uint256) { return Unsigned.unwrap(x); }
+    function wrap_signed(int8 x) public pure returns (Signed) { return Signed.wrap(x); }
+    function unwrap_signed(Signed x) public pure returns (int8) { return Signed.unwrap(x); }
+    function wrap_address(address x) public pure returns (Address) { return Address.wrap(x); }
+    function unwrap_address(Address x) public pure returns (address) { return Address.unwrap(x); }
+    function wrap_boolean(bool x) public pure returns (Boolean) { return Boolean.wrap(x); }
+    function unwrap_boolean(Boolean x) public pure returns (bool) { return Boolean.unwrap(x); }
 }

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -11,7 +11,8 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-num-bigint = "0.5"
+itertools.workspace = true
+num.workspace = true
 num-traits = "0.2"
 ruint.workspace = true
 serde_json.workspace = true

--- a/solx-slang/src/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/contract/function/expression/arithmetic.rs
@@ -9,6 +9,7 @@ use slang_solidity_v2::ast::ExponentiationExpression;
 use slang_solidity_v2::ast::MultiplicativeExpression;
 use slang_solidity_v2::ast::MultiplicativeExpressionOperator;
 use slang_solidity_v2::ast::PositionalArguments;
+use slang_solidity_v2::ast::UserDefinedOperatorExpression;
 
 use solx_mlir::Context;
 use solx_mlir::Type as MlirType;
@@ -19,6 +20,9 @@ use crate::scope::function::FunctionScope;
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `a + b` and `a - b`, both operands converted to the binder's result type.
     pub fn additive(&mut self, node: &AdditiveExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let (lhs, rhs) =
             self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         match node.operator() {
@@ -29,6 +33,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// `a * b`, `a / b`, and `a % b`, both operands converted to the binder's result type.
     pub fn multiplicative(&mut self, node: &MultiplicativeExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let (lhs, rhs) =
             self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         match node.operator() {

--- a/solx-slang/src/contract/function/expression/bitwise.rs
+++ b/solx-slang/src/contract/function/expression/bitwise.rs
@@ -7,6 +7,7 @@ use slang_solidity_v2::ast::BitwiseOrExpression;
 use slang_solidity_v2::ast::BitwiseXorExpression;
 use slang_solidity_v2::ast::ShiftExpression;
 use slang_solidity_v2::ast::ShiftExpressionOperator;
+use slang_solidity_v2::ast::UserDefinedOperatorExpression;
 
 use solx_mlir::Value;
 
@@ -15,6 +16,9 @@ use crate::scope::function::FunctionScope;
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `a & b`, both operands converted to the binder's result type.
     pub fn bitwise_and(&mut self, node: &BitwiseAndExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let (lhs, rhs) =
             self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitand(rhs, self)
@@ -22,6 +26,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// `a | b`, both operands converted to the binder's result type.
     pub fn bitwise_or(&mut self, node: &BitwiseOrExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let (lhs, rhs) =
             self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitor(rhs, self)
@@ -29,6 +36,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// `a ^ b`, both operands converted to the binder's result type.
     pub fn bitwise_xor(&mut self, node: &BitwiseXorExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let (lhs, rhs) =
             self.converted_operands(node.get_type(), &node.left_operand(), &node.right_operand());
         lhs.bitxor(rhs, self)

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -58,7 +58,7 @@ impl Call {
             Self::StructConstruction(struct_definition) => {
                 Self::struct_construction(&struct_definition, node, arguments, scope)
             }
-            Self::TypeConversion => Self::type_conversion(node, arguments, scope),
+            Self::TypeConversion => vec![Self::type_conversion(node, arguments, scope)],
             Self::Builtin(built_in) => Self::builtin(built_in, arguments, scope)
                 .into_iter()
                 .collect(),
@@ -66,7 +66,7 @@ impl Call {
                 .into_iter()
                 .collect(),
             Self::Function(function_definition) => {
-                Self::function(&function_definition, arguments, scope)
+                scope.call(&function_definition, arguments.iter())
             }
         }
     }
@@ -142,13 +142,13 @@ impl Call {
         call: &FunctionCallExpression,
         arguments: &PositionalArguments,
         scope: &mut FunctionScope<'_, '_, 'context>,
-    ) -> Vec<Value<'context>> {
+    ) -> Value<'context> {
         let operand = arguments
             .iter()
             .next()
             .expect("classification admits exactly one argument");
         let target_type = scope.typing(call.get_type());
-        vec![scope.converted(&operand, target_type)]
+        scope.converted(&operand, target_type)
     }
 
     /// Statement-style built-ins (`assert`, `require`, `revert`) produce no value.
@@ -402,33 +402,11 @@ impl Call {
             Some(BuiltIn::BytesConcat | BuiltIn::StringConcat) => {
                 Some(Value::concat(&scope.positional_arguments(arguments), scope))
             }
+            Some(BuiltIn::Wrap | BuiltIn::Unwrap) => {
+                Some(Self::type_conversion(call, arguments, scope))
+            }
             _ => unimplemented!("unsupported member call: {}", access.member().name()),
         }
-    }
-
-    /// Resolves the callee's pre-registered MLIR signature by node id and converts each argument to
-    /// its declared parameter type before `sol.call`.
-    fn function<'context>(
-        function_definition: &FunctionDefinition,
-        arguments: &PositionalArguments,
-        scope: &mut FunctionScope<'_, '_, 'context>,
-    ) -> Vec<Value<'context>> {
-        let signature = scope
-            .contract
-            .source_unit
-            .function_signature(function_definition.node_id());
-        let converted: Vec<Value<'context>> = arguments
-            .iter()
-            .zip(&signature.parameter_types)
-            .map(|(argument, &parameter_type)| scope.converted(&argument, parameter_type))
-            .collect();
-        Function::call(
-            &signature.mlir_name,
-            &converted,
-            &signature.return_types,
-            scope,
-        )
-        .expect("sol.call yields its declared results")
     }
 }
 
@@ -444,5 +422,43 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .next()
             .expect("an array push in place position yields the new element's slot");
         (Place::from(slot), slot.r#type().element_type(0))
+    }
+
+    /// Calls the function a `using {f as op} for T global;` directive binds an operator to. Being a
+    /// call, its operands evaluate left-first, not in a built-in operator's right-first order.
+    pub fn bound_operator(
+        &mut self,
+        function_definition: &FunctionDefinition,
+        operands: impl IntoIterator<Item = Expression>,
+    ) -> Value<'context> {
+        self.call(function_definition, operands)
+            .into_iter()
+            .next()
+            .expect("a user-defined operator's function returns one value")
+    }
+
+    /// Resolves the callee's pre-registered MLIR signature by node id and converts each argument to
+    /// its declared parameter type before `sol.call`.
+    fn call(
+        &mut self,
+        function_definition: &FunctionDefinition,
+        arguments: impl IntoIterator<Item = Expression>,
+    ) -> Vec<Value<'context>> {
+        let signature = self
+            .contract
+            .source_unit
+            .function_signature(function_definition.node_id());
+        let converted: Vec<Value<'context>> = arguments
+            .into_iter()
+            .zip(&signature.parameter_types)
+            .map(|(argument, &parameter_type)| self.converted(&argument, parameter_type))
+            .collect();
+        Function::call(
+            &signature.mlir_name,
+            &converted,
+            &signature.return_types,
+            self,
+        )
+        .expect("sol.call yields its declared results")
     }
 }

--- a/solx-slang/src/contract/function/expression/comparison.rs
+++ b/solx-slang/src/contract/function/expression/comparison.rs
@@ -7,6 +7,7 @@ use slang_solidity_v2::ast::EqualityExpression;
 use slang_solidity_v2::ast::EqualityExpressionOperator;
 use slang_solidity_v2::ast::InequalityExpression;
 use slang_solidity_v2::ast::InequalityExpressionOperator;
+use slang_solidity_v2::ast::UserDefinedOperatorExpression;
 
 use solx_mlir::CmpPredicate;
 use solx_mlir::Value;
@@ -16,6 +17,9 @@ use crate::scope::function::FunctionScope;
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `a == b` and `a != b`, the operands converted to the type the binder reconciles them to.
     pub fn equality(&mut self, node: &EqualityExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let predicate = match node.operator() {
             EqualityExpressionOperator::EqualEqual(_) => CmpPredicate::Eq,
             EqualityExpressionOperator::BangEqual(_) => CmpPredicate::Ne,
@@ -31,6 +35,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// `a < b`, `a <= b`, `a > b`, and `a >= b`, the operands converted to the type the binder
     /// reconciles them to.
     pub fn inequality(&mut self, node: &InequalityExpression) -> Value<'context> {
+        if let Some(function) = node.resolve_operator() {
+            return self.bound_operator(&function, [node.left_operand(), node.right_operand()]);
+        }
         let predicate = match node.operator() {
             InequalityExpressionOperator::LessThan(_) => CmpPredicate::Lt,
             InequalityExpressionOperator::LessThanEqual(_) => CmpPredicate::Le,

--- a/solx-slang/src/contract/function/expression/member.rs
+++ b/solx-slang/src/contract/function/expression/member.rs
@@ -2,6 +2,7 @@
 //! Member access expressions: struct fields and the environment intrinsics.
 //!
 
+use num::BigInt;
 use slang_solidity_v2::ast::BuiltIn;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::MemberAccessExpression;
@@ -14,12 +15,24 @@ use solx_mlir::Value;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// A struct field loads from its place; every other member access is an environment or EVM
-    /// intrinsic.
+    /// A struct field loads from its place; an enum member is its ordinal; every other member access
+    /// is an environment or EVM intrinsic.
     pub fn member_access(&mut self, node: &MemberAccessExpression) -> Value<'context> {
         if matches!(node.operand().get_type(), Some(Type::Struct(_))) {
             let (place, element_type) = self.member_access_place(node);
             return place.load(element_type, self);
+        }
+        if let Some(Definition::EnumMember(member)) = node.member().resolve_to_definition() {
+            let Some(Definition::Enum(enum_definition)) = member.enclosing_definition() else {
+                unreachable!("an enum member is declared by an enum");
+            };
+            let ordinal = enum_definition
+                .members()
+                .iter()
+                .position(|candidate| candidate.node_id() == member.node_id())
+                .expect("an enum lists the members it declares");
+            let enum_type = self.typing(node.get_type());
+            return Value::constant_from_bigint(&BigInt::from(ordinal), enum_type, self);
         }
         match node.member().resolve_to_built_in() {
             Some(BuiltIn::AddressBalance) => Value::balance(self.expression(&node.operand()), self),
@@ -43,6 +56,11 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             Some(BuiltIn::BlockBlobbasefee) => Value::block_blob_base_fee(self),
             Some(BuiltIn::BlockDifficulty) => Value::block_difficulty(self),
             Some(BuiltIn::BlockPrevrandao) => Value::block_prev_randao(self),
+            Some(BuiltIn::TypeEnumMin) => Value::zero(self.typing(node.get_type()), self),
+            Some(BuiltIn::TypeEnumMax) => {
+                let enum_type = self.typing(node.get_type());
+                Value::constant_from_bigint(&BigInt::from(enum_type.enum_max()), enum_type, self)
+            }
             _ => unimplemented!("unsupported member access: {}", node.member().name()),
         }
     }

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -7,6 +7,7 @@ use slang_solidity_v2::ast::PostfixExpression;
 use slang_solidity_v2::ast::PostfixExpressionOperator;
 use slang_solidity_v2::ast::PrefixExpression;
 use slang_solidity_v2::ast::PrefixExpressionOperator;
+use slang_solidity_v2::ast::UserDefinedOperatorExpression;
 
 use solx_mlir::CmpPredicate;
 use solx_mlir::Context;
@@ -18,6 +19,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// The prefix `++`, `--`, `~`, `!`, and `-` operators, each yielding a value; and `delete`, which
     /// resets its operand and yields nothing, `delete` being value-less in Solidity.
     pub fn prefix(&mut self, node: &PrefixExpression) -> Option<Value<'context>> {
+        if let Some(function) = node.resolve_operator() {
+            return Some(self.bound_operator(&function, [node.operand()]));
+        }
         match node.operator() {
             PrefixExpressionOperator::PlusPlus(_) => Some(self.step(&node.operand(), Value::add).1),
             PrefixExpressionOperator::MinusMinus(_) => {

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 
 use slang_solidity_v2::ast::ContractDefinition;
 use slang_solidity_v2::ast::ContractMember;
+use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::FunctionKind;
 
 use solx_mlir::Block;
@@ -26,12 +27,21 @@ impl<'context> SourceUnitScope<'context> {
     /// `method_identifiers` map (externally-dispatchable signature to 4-byte selector, lower-case
     /// hex); `convert-sol-to-yul` builds the entry-point dispatcher from the function selectors.
     /// Function signatures are pre-registered for call resolution before any body is emitted.
-    /// Inherited state variables are not yet declared: derived contracts do not compile through
-    /// this path.
-    pub fn contract_definition(&mut self, node: &ContractDefinition) -> BTreeMap<String, String> {
+    /// `operator_functions` land in the contract body because MLIR has no file scope. Inherited
+    /// state variables are not yet declared: derived contracts do not compile through this path.
+    pub fn contract_definition(
+        &mut self,
+        node: &ContractDefinition,
+        operator_functions: &[FunctionDefinition],
+    ) -> BTreeMap<String, String> {
         let contract_identifier = node.name();
 
-        for function in node.functions().into_iter().chain(node.constructor()) {
+        for function in node
+            .functions()
+            .into_iter()
+            .chain(node.constructor())
+            .chain(operator_functions.iter().cloned())
+        {
             let parameter_types = function
                 .parameters()
                 .iter()
@@ -108,8 +118,8 @@ impl<'context> SourceUnitScope<'context> {
                     );
                 }
                 scope.constructor(node);
-                for function in node.functions() {
-                    scope.function_definition(&function);
+                for function in node.functions().iter().chain(operator_functions) {
+                    scope.function_definition(function);
                 }
             },
         );

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -4,7 +4,12 @@
 
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
+use slang_solidity_v2::ast::Definition;
+use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::SourceUnit;
+use slang_solidity_v2::ast::SourceUnitMember;
+use slang_solidity_v2::ast::UsingClause;
 
 use solx_mlir::Context;
 use solx_standard_json::output::contract::Contract;
@@ -31,7 +36,8 @@ impl<'context> SourceUnitScope<'context> {
         };
         let melior = Context::create_melior_context();
         let mut scope = SourceUnitScope::new(Context::new(&melior, evm_version));
-        let method_identifiers = scope.contract_definition(contract);
+        let method_identifiers =
+            scope.contract_definition(contract, &Self::operator_bound_functions(unit));
 
         let name = contract.name().name().to_owned();
         let mlir = Context::from(scope).finalize_module(
@@ -43,5 +49,30 @@ impl<'context> SourceUnitScope<'context> {
             name,
             Contract::new_mlir(mlir, method_identifiers),
         )]))
+    }
+
+    /// The functions `unit`'s `using {f as op} for T global;` directives bind operators to, in
+    /// source order and without repeats. A binding reaches the whole compilation unit, so a
+    /// function bound from another file is missing here.
+    fn operator_bound_functions(unit: &SourceUnit) -> Vec<FunctionDefinition> {
+        unit.members()
+            .iter()
+            .filter_map(|member| match member {
+                SourceUnitMember::UsingDirective(directive) if directive.is_global() => {
+                    match directive.clause() {
+                        UsingClause::UsingDeconstruction(deconstruction) => Some(deconstruction),
+                        UsingClause::IdentifierPath(_) => None,
+                    }
+                }
+                _ => None,
+            })
+            .flat_map(|deconstruction| deconstruction.symbols().iter().collect::<Vec<_>>())
+            .filter(|symbol| symbol.alias().is_some())
+            .filter_map(|symbol| match symbol.name().resolve_to_definition()? {
+                Definition::Function(function) => Some(function),
+                _ => None,
+            })
+            .unique_by(|function| function.node_id())
+            .collect()
     }
 }

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -54,6 +54,7 @@ impl<'context> SourceUnitScope<'context> {
     /// The functions `unit`'s `using {f as op} for T global;` directives bind operators to, in
     /// source order and without repeats. A binding reaches the whole compilation unit, so a
     /// function bound from another file is missing here.
+    // TODO: add support for cross-file binding of operator functions
     fn operator_bound_functions(unit: &SourceUnit) -> Vec<FunctionDefinition> {
         unit.members()
             .iter()


### PR DESCRIPTION
Completes enums and user-defined value types on the Slang frontend:

- An enum member `E.Variant`, its qualified form `C.E.Variant`, and `type(E).min` / `type(E).max` materialize as the member's ordinal: a `sol.constant` at the EVM word, cast by `sol.enum_cast` to `!sol.enum<N>`; the ordinal is a member's position among the enum's declarations, and the maximum is read back off the dialect type that already bounds it.
- `E(v)` and `uint8(e)` lower to `sol.enum_cast` in either direction, a wider target chaining `sol.cast` behind it; the range check on an integer narrowed into an enum belongs to the lowering pass, not the frontend.
- An enum comparison emits `sol.cmp` at `!sol.enum<N>` with no widening in front of it, the dialect admitting an enum wherever it admits an integer.
- An enum-typed state variable, mapping key, struct field, or array element carries `!sol.enum<N>` through `sol.state_var`, `sol.mapping`, `sol.gep`, and `sol.load`; an uninitialized local, a named return, and `delete` all default-initialize to ordinal zero through the same constant-and-cast pair solc emits.
- `T.wrap(x)` and `T.unwrap(v)` emit nothing, a user-defined value type lowering to the type it wraps, so both are the identity case of an explicit conversion.
- A user-defined operator — the fourteen binary forms, `~`, and unary `-` — lowers to `sol.call` of the function a `using {f as op} for T global;` directive binds it to, which the binder resolves and the AST reads back; being a call, its operands evaluate left-first rather than in a built-in operator's right-first order.
- The operator-bound free functions emit into the contract body alongside the contract's own, MLIR having no file scope for them to land in.

