### PR TITLE
fix(slang): check the for-loop step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,7 +4533,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4546,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint 0.4.6",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4577,12 +4577,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=6daec8fef8f0151ccac1413e0c882053b4e850d4#6daec8fef8f0151ccac1413e0c882053b4e850d4"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=3b82850f6d525d42456135fea742ee556f56c298#3b82850f6d525d42456135fea742ee556f56c298"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "6daec8fef8f0151ccac1413e0c882053b4e850d4"
+rev = "3b82850f6d525d42456135fea742ee556f56c298"

--- a/solx-mlir/tests/lit/control_flow.sol
+++ b/solx-mlir/tests/lit/control_flow.sol
@@ -1,5 +1,5 @@
-// RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+// RUN: solx --emit-mlir=sol %s | FileCheck --check-prefixes=CHECK,CHECK-SOLX %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck --check-prefixes=CHECK,CHECK-SOLC %s
 
 // CHECK: sol.func @{{.*if_else.*}}
 // CHECK:   sol.if %{{.*}} {
@@ -27,7 +27,8 @@
 // CHECK:   } body {
 // CHECK:     sol.yield
 // CHECK:   } step {
-// CHECK:     sol.add %
+// CHECK-SOLX: sol.cadd %
+// CHECK-SOLC: sol.add %
 // CHECK:     sol.yield
 
 // CHECK: sol.func @{{.*do_while.*}}

--- a/solx-mlir/tests/lit/for_step.sol
+++ b/solx-mlir/tests/lit/for_step.sol
@@ -1,0 +1,28 @@
+// RUN: solx --emit-mlir=sol %for_loop/step_overflow.sol | FileCheck %s
+
+// solc's print-init emits every `for` step unchecked, so this is solx-only. The behavior is pinned
+// against legacy by tests/solidity/simple/loop/for/step_overflow.sol.
+
+// CHECK: sol.func @{{.*counter.*}}
+// CHECK:   } step {
+// CHECK:     sol.cadd %
+
+// CHECK: sol.func @{{.*inclusive.*}}
+// CHECK:   } step {
+// CHECK:     sol.cadd %
+
+// CHECK: sol.func @{{.*compound.*}}
+// CHECK:   } step {
+// CHECK:     sol.cadd %
+
+// CHECK: sol.func @{{.*decrement.*}}
+// CHECK:   } step {
+// CHECK:     sol.csub %
+
+// CHECK: sol.func @{{.*widened.*}}
+// CHECK:   } step {
+// CHECK:     sol.cadd %
+
+// CHECK: sol.func @{{.*bodyWrite.*}}
+// CHECK:   } step {
+// CHECK:     sol.cadd %

--- a/solx-mlir/tests/lit/lit.cfg.py
+++ b/solx-mlir/tests/lit/lit.cfg.py
@@ -17,6 +17,9 @@ config.environment["PATH"] = os.pathsep.join(
 config.substitutions.append(
     ("%evaluation_order", os.path.join(solx_root, "tests", "solidity", "simple", "evaluation_order").replace("\\", "/"))
 )
+config.substitutions.append(
+    ("%for_loop", os.path.join(solx_root, "tests", "solidity", "simple", "loop", "for").replace("\\", "/"))
+)
 
 config.test_source_root = config_dir
 config.test_exec_root = os.path.join(config_dir, "Output")

--- a/solx-slang/src/contract/function/statement/control_flow.rs
+++ b/solx-slang/src/contract/function/statement/control_flow.rs
@@ -46,8 +46,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         self.condition_region(condition_block, |scope| scope.expression(&node.condition()));
     }
 
-    /// The `for` statement. The step expression emits unchecked, matching the solc lowering this
-    /// pipeline is verified against.
+    /// The `for` statement.
     pub fn for_statement(&mut self, node: &ForStatement) {
         self.nested(|scope| {
             scope.for_statement_initialization(&node.initialization());
@@ -61,7 +60,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             scope.region(body_block, |scope| scope.statement(&node.body()));
             scope.region(step_block, |scope| {
                 if let Some(iterator) = node.iterator() {
-                    scope.unchecked(|scope| scope.expression_effect(&iterator));
+                    scope.expression_effect(&iterator);
                 }
             });
         });

--- a/tests/solidity/simple/loop/for/step_overflow.sol
+++ b/tests/solidity/simple/loop/for/step_overflow.sol
@@ -1,0 +1,111 @@
+//! { "cases": [ {
+//!     "name": "counter",
+//!     "inputs": [ { "method": "counter", "calldata": [] } ],
+//!     "expected": [ "5" ]
+//! }, {
+//!     "name": "inclusive",
+//!     "inputs": [ { "method": "inclusive", "calldata": [ "255" ] } ],
+//!     "expected": {
+//!         "return_data": [
+//!             "0x4E487B7100000000000000000000000000000000000000000000000000000000",
+//!             "0x0000001100000000000000000000000000000000000000000000000000000000"
+//!         ],
+//!         "exception": true
+//!     }
+//! }, {
+//!     "name": "compound",
+//!     "inputs": [ { "method": "compound", "calldata": [] } ],
+//!     "expected": {
+//!         "return_data": [
+//!             "0x4E487B7100000000000000000000000000000000000000000000000000000000",
+//!             "0x0000001100000000000000000000000000000000000000000000000000000000"
+//!         ],
+//!         "exception": true
+//!     }
+//! }, {
+//!     "name": "decrement",
+//!     "inputs": [ { "method": "decrement", "calldata": [] } ],
+//!     "expected": {
+//!         "return_data": [
+//!             "0x4E487B7100000000000000000000000000000000000000000000000000000000",
+//!             "0x0000001100000000000000000000000000000000000000000000000000000000"
+//!         ],
+//!         "exception": true
+//!     }
+//! }, {
+//!     "name": "widened",
+//!     "inputs": [ { "method": "widened", "calldata": [] } ],
+//!     "expected": {
+//!         "return_data": [
+//!             "0x4E487B7100000000000000000000000000000000000000000000000000000000",
+//!             "0x0000001100000000000000000000000000000000000000000000000000000000"
+//!         ],
+//!         "exception": true
+//!     }
+//! }, {
+//!     "name": "body_write",
+//!     "inputs": [ { "method": "bodyWrite", "calldata": [] } ],
+//!     "expected": {
+//!         "return_data": [
+//!             "0x4E487B7100000000000000000000000000000000000000000000000000000000",
+//!             "0x0000001100000000000000000000000000000000000000000000000000000000"
+//!         ],
+//!         "exception": true
+//!     }
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    function counter() public pure returns (uint8) {
+        uint8 last = 0;
+        for (uint8 i = 0; i < 5; ++i) {
+            last = i + 1;
+        }
+        return last;
+    }
+
+    function inclusive(uint8 limit) public pure returns (uint8) {
+        uint8 last = 0;
+        for (uint8 i = 0; i <= limit; ++i) {
+            last = i;
+        }
+        return last;
+    }
+
+    function compound() public pure returns (uint8) {
+        uint8 last = 0;
+        for (uint8 i = 250; i < 255; i += 10) {
+            last = i;
+        }
+        return last;
+    }
+
+    function decrement() public pure returns (uint8) {
+        uint8 last = 0;
+        for (uint8 i = 0; i < 5; --i) {
+            last = i;
+        }
+        return last;
+    }
+
+    function widened() public pure returns (uint8) {
+        uint256 limit = 300;
+        uint8 last = 0;
+        for (uint8 i = 0; i < limit; ++i) {
+            last = i;
+        }
+        return last;
+    }
+
+    function bodyWrite() public pure returns (uint8) {
+        uint8 last = 0;
+        for (uint8 i = 0; i < 5; ++i) {
+            last = i;
+            i = 255;
+        }
+        return last;
+    }
+}


### PR DESCRIPTION
Corrects `for` iterator lowering, which previously emitted with unchecked arithmetic for every loop shape.

The iterator now inherits the ambient arithmetic context:

- In ordinary Solidity code, `++`, `--`, and compound arithmetic steps emit checked operations and revert with `Panic(0x11)` on overflow or underflow.
- Inside an explicit `unchecked` block, the same iterator operations remain unchecked.

The runtime matrix covers a safe counter and overflow or underflow through an inclusive bound, compound addition, decrement, a widened comparison, and a counter written in the loop body. The MLIR LIT fixture reuses the same Solidity source and pins each iterator operation in the loop step region.

Resolves #517.