### PR TITLE
chore(deps): resolve Dependabot alerts and fix the slang-ast tester build

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -324,7 +324,7 @@ jobs:
           node-version: 24
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
 
       # Some projects might use hardcoded ssh URLs: force git to use https instead.
       - name: Git https settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Build the `solx-dev` tool first, then use it to build LLVM and solc:
 cargo build --release --bin solx-dev
 
 # Build LLVM (outputs to target-llvm/target-final/)
-./target/release/solx-dev llvm build --enable-mlir --enable-tests --build-type RelWithDebInfo
+./target/release/solx-dev llvm build --enable-mlir --enable-utils --build-type RelWithDebInfo
 
 # Build solc libraries (outputs to solx-solidity/build/)
 ./target/release/solx-dev solc build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -608,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -972,6 +972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1074,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1188,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1408,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1418,11 +1438,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1432,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1695,7 +1714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1776,7 +1795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1936,11 +1955,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1950,8 +1967,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3340,15 +3360,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3371,7 +3392,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3403,9 +3424,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3421,6 +3442,17 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3460,6 +3492,21 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3893,7 +3940,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand 0.9.3",
  "rlp 0.5.2",
  "ruint-macro",
@@ -3957,7 +4004,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4014,7 +4061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4283,11 +4330,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4302,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5018,10 +5066,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5629,7 +5677,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -144,16 +144,18 @@ impl<'context> Context<'context> {
     /// Run the Sol-to-LLVM conversion pass pipeline on a module in-place.
     ///
     /// The pass pipeline is:
-    /// 1. `convert-sol-to-yul`: Sol → Yul
-    /// 2. `convert-yul-to-std`: Yul → func/arith/scf/cf/LLVM
-    /// 3. `convert-scf-to-cf`
-    /// 4. `convert-func-to-llvm`
-    /// 5. `convert-arith-to-llvm`
-    /// 6. `convert-cf-to-llvm`
-    /// 7. `reconcile-unrealized-casts`
+    /// 1. `canonicalize`
+    /// 2. `sol-inline-modifiers`
+    /// 3. `convert-sol-to-yul`: Sol → Yul
+    /// 4. `convert-yul-to-std`: Yul → func/arith/scf/cf/LLVM
+    /// 5. `canonicalize`
+    /// 6. `convert-scf-to-cf`
+    /// 7. `convert-func-to-llvm`
+    /// 8. `convert-arith-to-llvm`
+    /// 9. `convert-cf-to-llvm`
+    /// 10. `reconcile-unrealized-casts`
     ///
-    /// Modifier lowering and LICM are skipped: they operate on `sol.modifier`
-    /// and `sol.while`/`sol.for` ops which are not yet emitted.
+    /// `sol-licm` is not yet in the pipeline.
     ///
     /// # Errors
     ///
@@ -167,7 +169,7 @@ impl<'context> Context<'context> {
                 crate::ffi::mlirCreateTransformsCanonicalizer(),
             ));
             pass_manager.add_pass(melior::pass::Pass::from_raw(
-                crate::ffi::mlirCreateSolModifierOpLoweringPass(),
+                crate::ffi::mlirCreateSolModifierInliningPass(),
             ));
             pass_manager.add_pass(melior::pass::Pass::from_raw(
                 crate::ffi::mlirCreateConversionConvertSolToYulPass(),

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -32,8 +32,8 @@ unsafe extern "C" {
     /// Creates the `canonicalize` pass.
     pub fn mlirCreateTransformsCanonicalizer() -> MlirPass;
 
-    /// Creates the `sol-modifier-op-lowering` pass.
-    pub fn mlirCreateSolModifierOpLoweringPass() -> MlirPass;
+    /// Creates the `sol-inline-modifiers` pass.
+    pub fn mlirCreateSolModifierInliningPass() -> MlirPass;
 
     // ---- Sol-to-Yul conversion ----
 

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -221,8 +221,8 @@ sol_ops! {
     Block::assert(self, condition: value) {
         AssertOperation.cond(condition)
     }
-    Block::revert | revert_custom (self, signature: str, arguments: values) {
-        RevertOperation.signature(str_attr(signature)).args(many(arguments))
+    Block::revert | revert_custom (self, signature: optional_str, arguments: values) {
+        RevertOperation.signature(optional_str(signature)).args(many(arguments))
     } flagged .call;
     Block::r#return(self, operands: values) {
         ReturnOperation.operands(many(operands))

--- a/solx-mlir/tests/lit/revert.sol
+++ b/solx-mlir/tests/lit/revert.sol
@@ -2,10 +2,13 @@
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
 // CHECK: sol.func @{{.*plain_revert.*}}
-// CHECK:   sol.revert ""
+// CHECK:   sol.revert{{$}}
 
 // CHECK: sol.func @{{.*message_revert.*}}
 // CHECK:   sol.revert "oops"
+
+// CHECK: sol.func @{{.*empty_message_revert.*}}
+// CHECK:   sol.revert ""
 
 // CHECK: sol.func @{{.*custom_error.*}}
 // CHECK:   sol.revert "TooLow(uint256,uint256)" %{{.*}}, %{{.*}} : ui256, ui256 {call}
@@ -24,6 +27,10 @@ contract C {
 
     function message_revert() public pure {
         revert("oops");
+    }
+
+    function empty_message_revert() public pure {
+        revert("");
     }
 
     function custom_error(uint256 x) public pure {

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -211,21 +211,15 @@ impl Call {
                 None
             }
             BuiltIn::Revert => {
-                let signature: String = match arguments.iter().next() {
-                    Some(Expression::StringExpression(string_expression)) => {
-                        let message = String::from_utf8(string_expression.value())
-                            .expect("slang validates string lals are UTF-8");
-                        if message.is_empty() {
-                            unimplemented!(
-                                "revert with an empty reason is not yet supported; use revert() for a no-data revert"
-                            );
-                        }
-                        message
-                    }
+                let message = match arguments.iter().next() {
+                    Some(Expression::StringExpression(string_expression)) => Some(
+                        String::from_utf8(string_expression.value())
+                            .expect("slang validates string lals are UTF-8"),
+                    ),
                     Some(_) => unreachable!("revert message is a string lal"),
-                    None => String::new(),
+                    None => None,
                 };
-                scope.current_block().revert(&signature, &[], scope);
+                scope.current_block().revert(message.as_deref(), &[], scope);
                 None
             }
             BuiltIn::Gasleft => Some(Value::gas_left(scope)),

--- a/solx-slang/src/contract/function/statement/revert.rs
+++ b/solx-slang/src/contract/function/statement/revert.rs
@@ -12,7 +12,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     pub fn revert_statement(&mut self, node: &RevertStatement) {
         let error = match node.error().resolve_to_definition() {
             None => {
-                self.current_block().revert("", &[], self);
+                self.current_block().revert(None, &[], self);
                 return;
             }
             Some(Definition::Error(error)) => error,
@@ -27,6 +27,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .map(|(_, value)| value)
             .collect();
         self.current_block()
-            .revert_custom(&signature, &values, self);
+            .revert_custom(Some(signature.as_str()), &values, self);
     }
 }

--- a/solx-tester/src/compilers/solidity/slang_ast.rs
+++ b/solx-tester/src/compilers/solidity/slang_ast.rs
@@ -104,14 +104,15 @@ impl SlangAst {
                 .iter()
                 .collect();
             for member in members.iter().rev() {
-                let name = match member {
-                    SourceUnitMember::ContractDefinition(definition) => definition.name().name(),
-                    SourceUnitMember::InterfaceDefinition(definition) => definition.name().name(),
-                    SourceUnitMember::LibraryDefinition(definition) => definition.name().name(),
+                let identifier = match member {
+                    SourceUnitMember::ContractDefinition(definition) => definition.name(),
+                    SourceUnitMember::InterfaceDefinition(definition) => definition.name(),
+                    SourceUnitMember::LibraryDefinition(definition) => definition.name(),
                     _ => continue,
                 };
-                if compiled.contains_key(name.as_str()) {
-                    return Some(ContractName::full_path(file_id.as_str(), name.as_str()));
+                let name = identifier.name();
+                if compiled.contains_key(name) {
+                    return Some(ContractName::full_path(file_id.as_str(), name));
                 }
             }
         }


### PR DESCRIPTION
- Bump `quinn-proto` 0.11.14 → 0.11.16: fixes GHSA-4w2j-m93h-cj5j (high) — remote memory exhaustion from unbounded out-of-order stream reassembly. Lockfile-only: the crate has no active path in any workspace member (it enters the lockfile via reqwest's unused `http3` feature).
- Bump `serde_with` 3.16.1 → 3.21.0: fixes GHSA-7gcf-g7xr-8hxj (medium) — `KeyValueMap` serialization panic on empty entries. Also lockfile-only (unused alloy/ark-serialize features); drags `serde_with_macros` and `darling` 0.21.3 → 0.23.0 along.
- Bump `rand` 0.8.5 → 0.8.7: fixes GHSA-cq8v-f236-94qc (low) — unsoundness with a custom logger. The only alert in compiled code, reaching `solx-tester` via `revm-precompile → ark-std`; 0.8.7 is a semver-trick shim over `rand` 0.10, which joins the lockfile with `rand_core`/`rand_pcg`/`chacha20`/`bs58`.
- Fix `--features slang-ast` compile errors in `solx-tester`: `SlangAst::last_deployable` chained `definition.name().name()`, borrowing from a temporary `Identifier` (E0716 ×3) and then calling the unstable `str::as_str` on the resulting `&str` (E0658 ×2); the identifier is now bound before its name is borrowed. `cargo run-tester-slang` builds and runs the suite again (7240 passed / 547 failed / 1038 invalid, matching the WIP Slang pipeline state).
- Re-pin `foundry-rs/foundry-toolchain` to v1.9.1 (`908c5403`) in `integration-tests.yaml`: upstream moved the floating `v1` tag to v1.9.1 on 2026-07-28, so zizmor's online audit flagged the old `b00af27e # v1` pin as a mismatched version comment and failed the `pr-checks` gate for every branch.

- Bump the `solx-llvm` submodule `a2a60323` → `7d0702e1` (current upstream main, 12 commits): MLIR Sol-dialect work, notably the new `ModifierInlining` pass replacing `SolModifierOpLowering`, plus new `Sol/Utils` and SolOps/YulOps extensions.

- Rename the `solx-mlir` pass binding to `mlirCreateSolModifierInliningPass`: the solx-llvm bump replaced `SolModifierOpLowering` with `ModifierInlining`, so the stale extern left an undefined symbol that failed linking on every slang-tests platform.
