### PR TITLE
ci: fold benchmark mirror into build-{llvm,solc} composite actions

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -5,8 +5,11 @@ name: 'Build LLVM'
 description: 'Builds backend LLVM framework'
 outputs:
   cache-hit:
-    description: 'Whether the LLVM cache was hit'
-    value: ${{ steps.llvm-artifact-cache.outputs.cache-hit }}
+    description: 'Whether the LLVM artifacts were reused, from the cache or a sibling mirror, and no build ran'
+    value: ${{ steps.llvm-artifact-cache.outputs.cache-hit || steps.llvm-mirror.outputs.mirrored }}
+  cache-key:
+    description: 'Artifact cache key; a sibling invocation''s `mirror-key`'
+    value: ${{ steps.llvm-cache.outputs.key }}
   llvm-prefix:
     description: 'Path to the LLVM installation'
     value: 'target-llvm/target-final'
@@ -15,6 +18,13 @@ inputs:
     description: 'Working directory.'
     required: false
     default: '.'
+  mirror-key:
+    description: >-
+      Sibling invocation's `cache-key`: when equal to this invocation's own
+      key, the workspace-root artifacts are symlinked, skipping restore and
+      build. Empty disables mirroring.
+    required: false
+    default: ''
   enable-utils:
     description: "Build and install the LLVM utility binaries (FileCheck, llvm-lit, etc.). Implied by enable-tests."
     required: false
@@ -57,7 +67,7 @@ inputs:
       Disable it when the solx-llvm tree changes every run (e.g. solx-llvm's own
       regression CI) or when later steps need the build directory: an artifact hit
       skips the build entirely, so target-llvm/build-final would not exist.
-      When disabled, the `cache-hit` output is always empty.
+      When disabled, `cache-hit` reports a mirror hit or nothing at all.
     required: false
     default: 'true'
 
@@ -74,29 +84,23 @@ runs:
       run: echo "hash=$(pacman -Q | sha256sum | head -c 8)" >> "${GITHUB_OUTPUT}"
 
     - name: Compute LLVM cache key
-      if: inputs.enable-artifact-cache == 'true'
+      if: inputs.enable-artifact-cache == 'true' || inputs.mirror-key != ''
       id: llvm-cache
       shell: bash
       working-directory: ${{ inputs.working-dir }}
       run: |
         SHA=$(git -C solx-llvm rev-parse HEAD)
-        # solx-dev owns LLVM-build cmake args (shared.rs + platforms/*.rs).
-        # Hash that tree into the key so any Rust-side flag change invalidates
-        # stale artifact-cache entries automatically. Truncate for readability.
-        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir)) }}' | head -c 8)
+        # solx-dev composes cmake args and flag defaults outside `llvm/**` too;
+        # hash every module the LLVM build reads so flag changes re-key.
+        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir), format('{0}/solx-dev/src/arguments/llvm/**', inputs.working-dir), format('{0}/solx-dev/src/build_type.rs', inputs.working-dir), format('{0}/solx-dev/src/ccache_variant.rs', inputs.working-dir), format('{0}/solx-dev/src/utils.rs', inputs.working-dir)) }}' | head -c 8)
         KEY="v1-llvm-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
-        # `enable-utils` extends the install-distribution whitelist with
-        # FileCheck (see solx-dev's `build_opts_distribution`), so the install
-        # prefix actually differs by this flag. `enable-tests` is kept
-        # defensively even though no current workflow sets it; if one later
-        # does, LLVM_BUILD_TESTS=On could leak test artifacts into the prefix
-        # or change cmake-exports content.
-        # Normalize tests→utils because `--enable-tests` implies `--enable-utils`.
+        # `enable-utils` adds FileCheck to the install prefix; `enable-tests`
+        # implies it, so normalize before keying.
         UTILS='${{ inputs.enable-utils }}'
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
@@ -105,8 +109,22 @@ runs:
         [ -n '${{ steps.msys-toolchain.outputs.hash }}' ] && KEY="${KEY}-msys${{ steps.msys-toolchain.outputs.hash }}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    - name: Mirror LLVM from sibling checkout
+      if: inputs.mirror-key != ''
+      id: llvm-mirror
+      shell: bash
+      working-directory: ${{ inputs.working-dir }}
+      run: |
+        if [ '${{ steps.llvm-cache.outputs.key }}' = '${{ inputs.mirror-key }}' ]; then
+          mkdir -p target-llvm
+          ln -snf "${GITHUB_WORKSPACE}/target-llvm/target-final" target-llvm/target-final
+          echo "mirrored=true" | tee -a "${GITHUB_OUTPUT}"
+        else
+          echo "::notice::LLVM inputs differ (${{ steps.llvm-cache.outputs.key }} vs ${{ inputs.mirror-key }}), building separately"
+        fi
+
     - name: Restore LLVM artifact cache
-      if: inputs.enable-artifact-cache == 'true'
+      if: inputs.enable-artifact-cache == 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       id: llvm-artifact-cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -116,12 +134,12 @@ runs:
     # Ninja build tool is not available on MacOS x64 runners by default. See:
     # https://github.com/actions/runner-images/issues/514
     - name: Install Ninja on MacOS x64
-      if: runner.os == 'macOS' && runner.arch == 'X64' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'macOS' && runner.arch == 'X64' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: 'bash'
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
 
     - name: Install LLVM builder
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       working-directory: ${{ inputs.working-dir }}
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -132,7 +150,7 @@ runs:
     # artifact-cache miss (i.e. submodule bump) and provides object-level reuse
     # across neighbouring solx-llvm commits.
     - name: Define ccache key
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       id: ccache-key
       run: |
@@ -157,7 +175,7 @@ runs:
     # The solx-ci-runner container doesn't ship sudo (steps run as root), so
     # we invoke apt-get directly. `-qq` silences routine output.
     - name: Prepare ccache installation
-      if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: 'bash'
       run: apt-get update -qq
 
@@ -167,7 +185,7 @@ runs:
     # KEEP-IN-SYNC with CCACHE_* env on Build LLVM and Show ccache stats steps
     # (GHA composite actions don't support YAML anchors).
     - name: Set up compiler cache
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       env:
         CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
@@ -183,7 +201,7 @@ runs:
         save: ${{ github.event_name != 'pull_request' }}
 
     - name: Build LLVM
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       working-directory: ${{ inputs.working-dir }}
       env:
@@ -229,7 +247,7 @@ runs:
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.
     - name: Show ccache stats
-      if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -240,7 +258,7 @@ runs:
       run: ccache --show-stats
 
     - name: Save LLVM artifact cache
-      if: inputs.enable-artifact-cache == 'true' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
+      if: inputs.enable-artifact-cache == 'true' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && steps.llvm-mirror.outputs.mirrored != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -4,11 +4,22 @@
 
 name: 'Build solc'
 description: 'Builds solc executable.'
+outputs:
+  cache-key:
+    description: 'Artifact cache key; a sibling invocation''s `mirror-key`'
+    value: ${{ steps.solc-cache.outputs.key }}
 inputs:
   working-dir:
     description: 'Working directory containing solx-solidity submodule.'
     required: false
     default: 'solx-solidity'
+  mirror-key:
+    description: >-
+      Sibling invocation's `cache-key`: when equal to this invocation's own
+      key, the root checkout's build and boost trees are symlinked, skipping
+      restore and build. Empty disables mirroring.
+    required: false
+    default: ''
   cmake-build-type:
     description: 'CMake build type (Release, Debug, or RelWithDebInfo).'
     required: false
@@ -31,14 +42,31 @@ runs:
       working-directory: ${{ inputs.working-dir }}/..
       run: |
         SHA=$(git -C solx-solidity rev-parse HEAD)
-        SCRIPT_HASH=$(find solx-dev/src/solc -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1)
+        # solx-dev composes cmake args and flag defaults outside `solc/` too;
+        # hash every module the solc build reads so flag changes re-key.
+        SCRIPT_HASH=$({ find solx-dev/src/solc solx-dev/src/arguments/solc -type f -print0; printf '%s\0' solx-dev/src/build_type.rs solx-dev/src/ccache_variant.rs solx-dev/src/utils.rs; } | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1)
         KEY="v2-solc-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.cmake-build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.cmake-build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         KEY="${KEY}-boost${{ inputs.boost-version }}-${SHA}-script${SCRIPT_HASH:0:8}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    - name: Mirror solc from sibling checkout
+      if: inputs.mirror-key != ''
+      id: solc-mirror
+      shell: bash
+      working-directory: ${{ inputs.working-dir }}
+      run: |
+        if [ '${{ steps.solc-cache.outputs.key }}' = '${{ inputs.mirror-key }}' ]; then
+          ln -snf "${GITHUB_WORKSPACE}/solx-solidity/build" build
+          ln -snf "${GITHUB_WORKSPACE}/solx-solidity/boost" boost
+          echo "mirrored=true" | tee -a "${GITHUB_OUTPUT}"
+        else
+          echo "::notice::solc inputs differ (${{ steps.solc-cache.outputs.key }} vs ${{ inputs.mirror-key }}), building separately"
+        fi
+
     - name: Restore solc artifact cache
+      if: steps.solc-mirror.outputs.mirrored != 'true'
       id: solc-artifact-cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -48,7 +76,7 @@ runs:
         key: ${{ steps.solc-cache.outputs.key }}
 
     - name: Build solx-dev
-      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       working-directory: ${{ inputs.working-dir }}/..
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -63,7 +91,7 @@ runs:
     # The solx-ci-runner container doesn't ship sudo (steps run as root), so
     # we invoke apt-get directly. `-qq` silences routine output.
     - name: Prepare ccache installation
-      if: runner.os == 'Linux' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       shell: 'bash'
       run: apt-get update -qq
 
@@ -75,7 +103,7 @@ runs:
     # KEEP-IN-SYNC with CCACHE_* env on Build solc and Show ccache stats steps
     # (GHA composite actions don't support YAML anchors).
     - name: Set up compiler cache for solc
-      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       env:
         CCACHE_DIR: ${{ runner.temp }}/ccache-solc
@@ -99,7 +127,7 @@ runs:
     # deps submodules need the same setting or they surface as modified
     # content in the parent diff.
     - name: Align solc eol config with the checkout (Windows)
-      if: runner.os == 'Windows' && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Windows' && steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       shell: bash
       working-directory: ${{ inputs.working-dir }}
       run: |
@@ -107,7 +135,7 @@ runs:
         git submodule foreach --recursive git config core.autocrlf true
 
     - name: Build solc
-      if: steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       # Run from the checkout root that owns solx-solidity
       working-directory: ${{ inputs.working-dir }}/..
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
@@ -129,7 +157,7 @@ runs:
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build solc failure in the step summary.
     - name: Show ccache stats
-      if: always() && steps.solc-artifact-cache.outputs.cache-hit != 'true'
+      if: always() && steps.solc-artifact-cache.outputs.cache-hit != 'true' && steps.solc-mirror.outputs.mirrored != 'true'
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -140,7 +168,7 @@ runs:
       run: ccache --show-stats
 
     - name: Save solc artifact cache
-      if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
+      if: steps.solc-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && steps.solc-mirror.outputs.mirrored != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |

--- a/.github/workflows/compile-benchmark.yaml
+++ b/.github/workflows/compile-benchmark.yaml
@@ -97,87 +97,33 @@ jobs:
       # Release build without assertions: matches the released binary's
       # configuration so the three-way comparison is apples-to-apples.
       - name: Build LLVM
+        id: build-llvm-pr
         uses: ./.github/actions/build-llvm
         with:
           build-type: Release
           enable-assertions: 'false'
 
-      # Submodule SHA alone is not sufficient: `solx-dev llvm build` is
-      # driven by `solx-dev/src/llvm/*`, so a PR that edits those scripts
-      # without bumping the solx-llvm submodule would silently share its
-      # own LLVM as the "main" baseline. Mirror the SHA + script-hash
-      # check used by integration-tests.yaml.
-      - name: Share LLVM with main checkout
-        id: share-llvm
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-llvm rev-parse HEAD)
-          PR_SHA=$(git -C solx-llvm rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/llvm)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/llvm)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "LLVM SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            mkdir -p temp-solx-main/target-llvm
-            rm -rf temp-solx-main/target-llvm/target-final
-            ln -snf "$GITHUB_WORKSPACE/target-llvm/target-final" \
-                    temp-solx-main/target-llvm/target-final
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::LLVM inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
       - name: Build LLVM (main)
-        if: steps.share-llvm.outputs.shared != 'true'
-        run: |
-          pushd temp-solx-main
-          ${SFW_PREFIX:-} cargo fetch --locked
-          ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-          ./target/release/solx-dev llvm build --build-type Release --install-distribution
-          popd
+        uses: ./.github/actions/build-llvm
+        with:
+          working-dir: temp-solx-main
+          mirror-key: ${{ steps.build-llvm-pr.outputs.cache-key }}
+          build-type: Release
+          enable-assertions: 'false'
 
       - name: Build solc (PR)
+        id: build-solc-pr
         uses: ./.github/actions/build-solc
         with:
           cmake-build-type: Release
           working-dir: 'solx-solidity'
 
-      # Match the cache key composition in build-solc/action.yml: SHA alone
-      # is not sufficient because a PR can change `solx-dev/src/solc/*`
-      # without bumping the submodule pin. Without the script-hash check,
-      # the PR's solc binary would be shared as the "main" baseline and
-      # silently skew benchmarks.
-      - name: Share solc with main checkout
-        id: share-solc
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-solidity rev-parse HEAD)
-          PR_SHA=$(git -C solx-solidity rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/solc)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/solc)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "solc SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            rm -rf temp-solx-main/solx-solidity/build temp-solx-main/solx-solidity/boost
-            ln -snf "$GITHUB_WORKSPACE/solx-solidity/build" \
-                    temp-solx-main/solx-solidity/build
-            ln -snf "$GITHUB_WORKSPACE/solx-solidity/boost" \
-                    temp-solx-main/solx-solidity/boost
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::solc inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
       - name: Build solc (main)
-        if: steps.share-solc.outputs.shared != 'true'
         uses: ./.github/actions/build-solc
         with:
           cmake-build-type: 'Release'
           working-dir: 'temp-solx-main/solx-solidity'
+          mirror-key: ${{ steps.build-solc-pr.outputs.cache-key }}
 
       # Env and target mirror .github/actions/build-rust so the pr/main
       # binaries share the released binary's build configuration: the

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -92,93 +92,35 @@ jobs:
           optional: 'true'
 
       - name: Build LLVM
+        id: build-llvm-pr
         uses: ./.github/actions/build-llvm
         with:
           build-type: Release
           enable-assertions: 'false'
 
-      # Submodule SHA alone is not sufficient: `solx-dev llvm build` is
-      # driven by `solx-dev/src/llvm/*`, so a PR that edits those scripts
-      # without bumping the solx-llvm submodule would silently share its
-      # own LLVM as the "main" baseline. Mirror the SHA + script-hash
-      # check used by share-solc.
-      - name: Share LLVM with main checkout
-        id: share-llvm
-        continue-on-error: true
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-llvm rev-parse HEAD)
-          PR_SHA=$(git -C solx-llvm rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/llvm)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/llvm)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "LLVM SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            mkdir -p temp-solx-main/target-llvm
-            rm -rf temp-solx-main/target-llvm/target-final
-            ln -snf "$GITHUB_WORKSPACE/target-llvm/target-final" \
-                    temp-solx-main/target-llvm/target-final
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::LLVM inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
-      # If share-llvm failed entirely (output empty), fall through and build.
       - name: Build LLVM (main)
-        if: steps.share-llvm.outputs.shared != 'true'
+        uses: ./.github/actions/build-llvm
         continue-on-error: true
-        run: |
-          pushd temp-solx-main
-          ${SFW_PREFIX:-} cargo fetch --locked
-          ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-          ./target/release/solx-dev llvm build --build-type Release --install-distribution
-          popd
+        with:
+          working-dir: temp-solx-main
+          mirror-key: ${{ steps.build-llvm-pr.outputs.cache-key }}
+          build-type: Release
+          enable-assertions: 'false'
 
       - name: Build solc (PR)
+        id: build-solc-pr
         uses: ./.github/actions/build-solc
         with:
           cmake-build-type: Release
           working-dir: 'solx-solidity'
 
-      # Match the cache key composition in build-solc/action.yml: SHA alone
-      # is not sufficient because a PR can change `solx-dev/src/solc/*`
-      # without bumping the submodule pin. Without the script-hash check,
-      # the PR's solc binary would be shared as the "main" baseline and
-      # silently skew benchmarks.
-      - name: Share solc with main checkout
-        id: share-solc
-        continue-on-error: true
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-solidity rev-parse HEAD)
-          PR_SHA=$(git -C solx-solidity rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/solc)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/solc)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "solc SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            rm -rf temp-solx-main/solx-solidity/build temp-solx-main/solx-solidity/boost
-            ln -snf "$GITHUB_WORKSPACE/solx-solidity/build" \
-                    temp-solx-main/solx-solidity/build
-            ln -snf "$GITHUB_WORKSPACE/solx-solidity/boost" \
-                    temp-solx-main/solx-solidity/boost
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::solc inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
-      # If share-solc failed entirely (output empty), fall through and build.
       - name: Build solc (main)
-        if: steps.share-solc.outputs.shared != 'true'
         uses: ./.github/actions/build-solc
         continue-on-error: true
         with:
           cmake-build-type: 'Release'
           working-dir: 'temp-solx-main/solx-solidity'
+          mirror-key: ${{ steps.build-solc-pr.outputs.cache-key }}
 
       - name: Fetch dependencies (PR)
         run: ${SFW_PREFIX:-} cargo fetch --locked


### PR DESCRIPTION
Folds the SHA-keyed artifact mirror from workflow bash into the composite actions, as proposed in #375's review:

- `build-{llvm,solc}` gain a `cache-key` output and a `mirror-key` input: the main-side call receives the PR-side invocation's key and symlinks the workspace-root artifacts when its own key is equal, skipping restore and build. The predicate is the full cache key of both invocations, so it cannot drift into a subset as key dimensions grow and cannot false-match when the paired callsites diverge in build parameters.
- `integration-tests.yaml` and `compile-benchmark.yaml` (which cloned the share steps after the issue was filed) collapse to plain `uses:` calls per artifact.
- On a mirror miss, the main-side LLVM build now goes through the composite chain — artifact-cache restore (cache-warmup saves the exact Release/no-assertions key on main) and ccache — instead of the raw cold rebuild.
- The dev-script hashes widen to the modules the builds read from outside `src/llvm`/`src/solc`: `arguments/{llvm,solc}` (flag defaults), `build_type`, `ccache_variant`, and `utils` (cmake-flag composition). This re-keys every artifact cache once; cache-warmup gets dispatched right after merge so open PRs stop cold-building.

Closes #448.