### PR TITLE
ci: fold benchmark mirror into the build-llvm composite action

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,7 +35,7 @@ TABLEGEN_210_PREFIX = { value = "./target-llvm/target-final/", relative = true, 
 [alias]
 run-tester = "run --bin solx-tester -- --solidity-compiler ./target/release/solx"
 
-clippy-slang = "clippy -p solx-slang -p solx-mlir -p solx --no-default-features --features slang --target-dir target-slang"
-build-slang = "build -p solx-slang -p solx-mlir -p solx --no-default-features --features slang --target-dir target-slang"
-test-slang = "test -p solx-slang -p solx-mlir -p solx --no-default-features --features slang --target-dir target-slang"
-run-tester-slang = "run --bin solx-tester --no-default-features --features slang-ast --target-dir target-slang -- --solidity-compiler ./target-slang/release/solx -O M3B3"
+clippy-slang = "clippy -p solx-slang -p solx-mlir -p solx --no-default-features --features slang"
+build-slang = "build -p solx-slang -p solx-mlir -p solx --no-default-features --features slang"
+test-slang = "test -p solx-slang -p solx-mlir -p solx --no-default-features --features slang"
+run-tester-slang = "run --bin solx-tester --no-default-features --features slang-ast -- --solidity-compiler ./target/release/solx -O M3B3"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,8 +30,6 @@ BOOST_PREFIX = { value = "./solx-solidity/boost/lib/", relative = true, force = 
 
 LLVM_SYS_211_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = true }
 MLIR_SYS_210_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = true }
-# Not forced: the sanitizer job substitutes an uninstrumented prefix
-# (rustc cannot load an ASan-instrumented proc macro).
 TABLEGEN_210_PREFIX = { value = "./target-llvm/target-final/", relative = true }
 
 [alias]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,9 @@ BOOST_PREFIX = { value = "./solx-solidity/boost/lib/", relative = true, force = 
 
 LLVM_SYS_211_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = true }
 MLIR_SYS_210_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = true }
-TABLEGEN_210_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = true }
+# Not forced: the sanitizer job substitutes an uninstrumented prefix
+# (rustc cannot load an ASan-instrumented proc macro).
+TABLEGEN_210_PREFIX = { value = "./target-llvm/target-final/", relative = true }
 
 [alias]
 run-tester = "run --bin solx-tester -- --solidity-compiler ./target/release/solx"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
     // in the guide's Persistence section.
     "mounts": [
         "source=solx-target-${devcontainerId},target=${containerWorkspaceFolder}/target,type=volume",
-        "source=solx-target-slang-${devcontainerId},target=${containerWorkspaceFolder}/target-slang,type=volume",
         "source=solx-target-llvm-${devcontainerId},target=${containerWorkspaceFolder}/target-llvm,type=volume",
         "source=solx-rustup,target=/usr/local/rustup,type=volume",
         "source=solx-cargo,target=/usr/local/cargo,type=volume",
@@ -63,14 +62,12 @@
                 // lag in integrated terminals after the first bootstrap.
                 "files.watcherExclude": {
                     "**/target/**": true,
-                    "**/target-slang/**": true,
                     "**/target-llvm/**": true,
                     "**/solx-solidity/build/**": true,
                     "**/solx-solidity/boost/**": true
                 },
                 "search.exclude": {
                     "**/target": true,
-                    "**/target-slang": true,
                     "**/target-llvm": true,
                     "**/solx-solidity/build": true,
                     "**/solx-solidity/boost": true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # Named volumes are created root-owned; hand them to the dev user.
 sudo chown "$(id -u):$(id -g)" \
-    target target-slang target-llvm \
+    target target-llvm \
     /var/cache/solx-ccache /usr/local/rustup /usr/local/cargo
 
 # Docker Desktop file sharing can surface the bind mount with foreign

--- a/.devcontainer/smoke-test.sh
+++ b/.devcontainer/smoke-test.sh
@@ -12,7 +12,7 @@ test "$(id -u)" -ne 0
 sudo -n true
 
 echo "==> Workspace and named volumes are writable"
-for dir in . target target-slang target-llvm "${CCACHE_DIR:?CCACHE_DIR not set}"; do
+for dir in . target target-llvm "${CCACHE_DIR:?CCACHE_DIR not set}"; do
     touch "${dir}/.devcontainer-smoke"
     rm "${dir}/.devcontainer-smoke"
 done

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -5,8 +5,11 @@ name: 'Build LLVM'
 description: 'Builds backend LLVM framework'
 outputs:
   cache-hit:
-    description: 'Whether the LLVM cache was hit'
-    value: ${{ steps.llvm-artifact-cache.outputs.cache-hit }}
+    description: 'Whether the LLVM artifacts were reused, from the cache or a sibling mirror, and no build ran'
+    value: ${{ steps.llvm-artifact-cache.outputs.cache-hit || steps.llvm-mirror.outputs.mirrored }}
+  cache-key:
+    description: 'Artifact cache key; a sibling invocation''s `mirror-key`'
+    value: ${{ steps.llvm-cache.outputs.key }}
   llvm-prefix:
     description: 'Path to the LLVM installation'
     value: 'target-llvm/target-final'
@@ -15,6 +18,13 @@ inputs:
     description: 'Working directory.'
     required: false
     default: '.'
+  mirror-key:
+    description: >-
+      Sibling invocation's `cache-key`: when equal to this invocation's own
+      key, the workspace-root artifacts are symlinked, skipping restore and
+      build. Empty disables mirroring.
+    required: false
+    default: ''
   enable-utils:
     description: "Build and install the LLVM utility binaries (FileCheck, llvm-lit, etc.). Implied by enable-tests."
     required: false
@@ -57,7 +67,7 @@ inputs:
       Disable it when the solx-llvm tree changes every run (e.g. solx-llvm's own
       regression CI) or when later steps need the build directory: an artifact hit
       skips the build entirely, so target-llvm/build-final would not exist.
-      When disabled, the `cache-hit` output is always empty.
+      When disabled, `cache-hit` reports a mirror hit or nothing at all.
     required: false
     default: 'true'
 
@@ -74,29 +84,23 @@ runs:
       run: echo "hash=$(pacman -Q | sha256sum | head -c 8)" >> "${GITHUB_OUTPUT}"
 
     - name: Compute LLVM cache key
-      if: inputs.enable-artifact-cache == 'true'
+      if: inputs.enable-artifact-cache == 'true' || inputs.mirror-key != ''
       id: llvm-cache
       shell: bash
       working-directory: ${{ inputs.working-dir }}
       run: |
         SHA=$(git -C solx-llvm rev-parse HEAD)
-        # solx-dev owns LLVM-build cmake args (shared.rs + platforms/*.rs).
-        # Hash that tree into the key so any Rust-side flag change invalidates
-        # stale artifact-cache entries automatically. Truncate for readability.
-        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir)) }}' | head -c 8)
+        # solx-dev composes cmake args and flag defaults outside `llvm/**` too;
+        # hash every module the LLVM build reads so flag changes re-key.
+        DEV_HASH=$(printf %s '${{ hashFiles(format('{0}/solx-dev/src/llvm/**', inputs.working-dir), format('{0}/solx-dev/src/arguments/llvm/**', inputs.working-dir), format('{0}/solx-dev/src/build_type.rs', inputs.working-dir), format('{0}/solx-dev/src/ccache_variant.rs', inputs.working-dir), format('{0}/solx-dev/src/utils.rs', inputs.working-dir)) }}' | head -c 8)
         KEY="v1-llvm-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"
         [ -n '${{ inputs.sanitizer }}' ] && KEY="${KEY}-${{ inputs.sanitizer }}"
         [ '${{ inputs.enable-coverage }}' = 'true' ] && KEY="${KEY}-coverage"
         [ '${{ inputs.enable-assertions }}' != 'true' ] && KEY="${KEY}-no-assertions"
-        # `enable-utils` extends the install-distribution whitelist with
-        # FileCheck (see solx-dev's `build_opts_distribution`), so the install
-        # prefix actually differs by this flag. `enable-tests` is kept
-        # defensively even though no current workflow sets it; if one later
-        # does, LLVM_BUILD_TESTS=On could leak test artifacts into the prefix
-        # or change cmake-exports content.
-        # Normalize tests→utils because `--enable-tests` implies `--enable-utils`.
+        # `enable-utils` adds FileCheck to the install prefix; `enable-tests`
+        # implies it, so normalize before keying.
         UTILS='${{ inputs.enable-utils }}'
         [ '${{ inputs.enable-tests }}' = 'true' ] && UTILS='true'
         [ "$UTILS" = 'true' ] && KEY="${KEY}-utils"
@@ -105,8 +109,22 @@ runs:
         [ -n '${{ steps.msys-toolchain.outputs.hash }}' ] && KEY="${KEY}-msys${{ steps.msys-toolchain.outputs.hash }}"
         echo "key=${KEY}" | tee -a "${GITHUB_OUTPUT}"
 
+    - name: Mirror LLVM from sibling checkout
+      if: inputs.mirror-key != ''
+      id: llvm-mirror
+      shell: bash
+      working-directory: ${{ inputs.working-dir }}
+      run: |
+        if [ '${{ steps.llvm-cache.outputs.key }}' = '${{ inputs.mirror-key }}' ]; then
+          mkdir -p target-llvm
+          ln -snf "${GITHUB_WORKSPACE}/target-llvm/target-final" target-llvm/target-final
+          echo "mirrored=true" | tee -a "${GITHUB_OUTPUT}"
+        else
+          echo "::notice::LLVM inputs differ (${{ steps.llvm-cache.outputs.key }} vs ${{ inputs.mirror-key }}), building separately"
+        fi
+
     - name: Restore LLVM artifact cache
-      if: inputs.enable-artifact-cache == 'true'
+      if: inputs.enable-artifact-cache == 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       id: llvm-artifact-cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
@@ -116,12 +134,12 @@ runs:
     # Ninja build tool is not available on MacOS x64 runners by default. See:
     # https://github.com/actions/runner-images/issues/514
     - name: Install Ninja on MacOS x64
-      if: runner.os == 'macOS' && runner.arch == 'X64' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'macOS' && runner.arch == 'X64' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: 'bash'
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
 
     - name: Install LLVM builder
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       working-directory: ${{ inputs.working-dir }}
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -132,7 +150,7 @@ runs:
     # artifact-cache miss (i.e. submodule bump) and provides object-level reuse
     # across neighbouring solx-llvm commits.
     - name: Define ccache key
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       id: ccache-key
       run: |
@@ -157,7 +175,7 @@ runs:
     # The solx-ci-runner container doesn't ship sudo (steps run as root), so
     # we invoke apt-get directly. `-qq` silences routine output.
     - name: Prepare ccache installation
-      if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: 'bash'
       run: apt-get update -qq
 
@@ -167,7 +185,7 @@ runs:
     # KEEP-IN-SYNC with CCACHE_* env on Build LLVM and Show ccache stats steps
     # (GHA composite actions don't support YAML anchors).
     - name: Set up compiler cache
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       env:
         CCACHE_DIR: ${{ runner.temp }}/ccache-llvm
@@ -183,7 +201,7 @@ runs:
         save: ${{ github.event_name != 'pull_request' }}
 
     - name: Build LLVM
-      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       working-directory: ${{ inputs.working-dir }}
       env:
@@ -229,7 +247,7 @@ runs:
     # `continue-on-error` keeps a failing ccache install (→ ccache not on PATH)
     # from masking the real Build LLVM failure in the step summary.
     - name: Show ccache stats
-      if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true'
+      if: always() && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && steps.llvm-mirror.outputs.mirrored != 'true'
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
@@ -240,7 +258,7 @@ runs:
       run: ccache --show-stats
 
     - name: Save LLVM artifact cache
-      if: inputs.enable-artifact-cache == 'true' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
+      if: inputs.enable-artifact-cache == 'true' && steps.llvm-artifact-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && steps.llvm-mirror.outputs.mirrored != 'true'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.working-dir != '.' && format('{0}/target-llvm/target-final', inputs.working-dir) || 'target-llvm/target-final' }}

--- a/.github/actions/build-rust/action.yml
+++ b/.github/actions/build-rust/action.yml
@@ -81,9 +81,9 @@ runs:
         fi
         ${SFW_PREFIX:-} cargo ${BUILD_STD_LIB} build-slang --frozen ${RELEASE} ${{ steps.build-target.outputs.target }}
         if [ '${{ inputs.target }}' != '' ]; then
-          BINARY_DIR="${PWD}/target-slang/${{ inputs.target }}/${{ inputs.build-type }}"
+          BINARY_DIR="${PWD}/target/${{ inputs.target }}/${{ inputs.build-type }}"
         else
-          BINARY_DIR="${PWD}/target-slang/${{ inputs.build-type }}"
+          BINARY_DIR="${PWD}/target/${{ inputs.build-type }}"
         fi
         [ "$RUNNER_OS" = "Windows" ] && WIN_SUFFIX=".exe"
         echo "${BINARY_DIR}" >> "${GITHUB_PATH}"

--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -31,7 +31,7 @@ runs:
       working-directory: ${{ inputs.working-dir }}/..
       run: |
         SHA=$(git -C solx-solidity rev-parse HEAD)
-        SCRIPT_HASH=$(find solx-dev/src/solc -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1)
+        SCRIPT_HASH=$({ find solx-dev/src/solc solx-dev/src/arguments/solc -type f -print0; printf '%s\0' solx-dev/src/build_type.rs solx-dev/src/ccache_variant.rs solx-dev/src/utils.rs; } | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1)
         KEY="v2-solc-${{ runner.os }}-${{ runner.arch }}"
         [ '${{ inputs.cmake-build-type }}' != 'Release' ] && KEY="${KEY}-${{ inputs.cmake-build-type }}"
         [ '${{ inputs.enable-mlir }}' = 'true' ] && KEY="${KEY}-mlir"

--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -6,8 +6,8 @@ description: >-
   define the standard-config cache keys shared by test.yaml and
   cache-warmup.yaml — changing them here re-keys both workflows together.
   Workflows needing a different LLVM configuration (sanitizer, coverage,
-  integration, release) call build-llvm/build-solc directly and pair with
-  their own cache-warmup job.
+  integration, release) call build-llvm and build-solc directly as needed
+  and pair with their own cache-warmup job.
 
 inputs:
   llvm:

--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -5,9 +5,9 @@ description: >-
   on macOS), then the LLVM and solc builds. The build parameters below
   define the standard-config cache keys shared by test.yaml and
   cache-warmup.yaml — changing them here re-keys both workflows together.
-  Workflows needing a different LLVM
-  configuration (sanitizer, coverage, integration, release) call
-  build-llvm/build-solc directly and pair with their own cache-warmup job.
+  Workflows needing a different LLVM configuration (sanitizer, coverage,
+  integration, release) call build-llvm/build-solc directly and pair with
+  their own cache-warmup job.
 
 inputs:
   llvm:
@@ -73,10 +73,15 @@ runs:
       shell: bash
       run: rm -fv "$(rustc --print sysroot)/bin/libwinpthread-1.dll"
 
+    # TODO: remove this step once the lit tests stop running against solc.
+    #
+    # Release: RelWithDebInfo bakes -g3 debug info into the statically
+    # linked solc.exe, producing a ~2 GB PE that the Windows loader
+    # rejects ("Exec format error"), and the lit tests execute solc.
     - name: Build solc
       if: inputs.solc == 'true'
       uses: ./.github/actions/build-solc
       with:
-        cmake-build-type: RelWithDebInfo
+        cmake-build-type: Release
         working-dir: 'solx-solidity'
         enable-mlir: 'true'

--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -131,7 +131,7 @@ runs:
           export "CARGO_TARGET_${TARGET_UPPER}_LINKER=clang"
         fi
         if [ '${{ inputs.target }}' != '' ]; then
-          export CARGO_BIN_EXE_SOLX="./${CARGO_TARGET_DIR:-target}/${{ inputs.target }}/debug/solx"
+          export CARGO_BIN_EXE_SOLX="./target/${{ inputs.target }}/debug/solx"
         fi
         set -o pipefail
         if [ "${{ inputs.cargo-test-command }}" = "test" ]; then ${SFW_PREFIX:-} cargo build --frozen ${{ steps.build-target.outputs.target }}; fi

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -7,7 +7,7 @@ name: Cache Warmup
 on:
   push:
     branches:
-      - main
+      - main-slang
     paths:
       - 'solx-llvm'
       - 'solx-solidity'
@@ -140,7 +140,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/ccache-solc
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-RelWithDebInfo-end
+          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-Release-end
           fail-on-cache-miss: false
           lookup-only: true
 
@@ -234,13 +234,13 @@ jobs:
           fail-on-cache-miss: false
           lookup-only: true
 
-  # ── LLVM + solc: integration config (integration-tests.yaml) ────────
+  # ── LLVM: integration config (integration-tests.yaml) ───────────────
   warm-llvm-integration:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/nomicfoundation/solx-ci-runner@sha256:cd5a37f2630fdf1898ddb2ca11f8c2ecc4d572c60011fe923b27b1625f92ba15
       volumes: *free-disk-volumes
-    name: "LLVM + solc · Integration"
+    name: "LLVM · Integration"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -275,22 +275,5 @@ jobs:
           path: ${{ runner.temp }}/ccache-llvm
           key: ccache-touch-${{ github.job }}-${{ github.run_id }}
           restore-keys: llvm-${{ runner.os }}-${{ runner.arch }}-mlir-no-assertions-end
-          fail-on-cache-miss: false
-          lookup-only: true
-
-      - name: Build solc
-        uses: ./.github/actions/build-solc
-        with:
-          cmake-build-type: Release
-          working-dir: 'solx-solidity'
-          enable-mlir: 'true'
-
-      - name: Touch solc ccache
-        if: always()
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/ccache-solc
-          key: ccache-touch-${{ github.job }}-${{ github.run_id }}
-          restore-keys: solc-${{ runner.os }}-${{ runner.arch }}-Release-end
           fail-on-cache-miss: false
           lookup-only: true

--- a/.github/workflows/compile-benchmark.yaml
+++ b/.github/workflows/compile-benchmark.yaml
@@ -97,47 +97,21 @@ jobs:
       # Release build without assertions: matches the released binary's
       # configuration so the three-way comparison is apples-to-apples.
       - name: Build LLVM
+        id: build-llvm-pr
         uses: ./.github/actions/build-llvm
         with:
           build-type: Release
           enable-assertions: 'false'
           enable-mlir: 'true'
 
-      # Submodule SHA alone is not sufficient: `solx-dev llvm build` is
-      # driven by `solx-dev/src/llvm/*`, so a PR that edits those scripts
-      # without bumping the solx-llvm submodule would silently share its
-      # own LLVM as the "main" baseline. Mirror the SHA + script-hash
-      # check used by integration-tests.yaml.
-      - name: Share LLVM with main checkout
-        id: share-llvm
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-llvm rev-parse HEAD)
-          PR_SHA=$(git -C solx-llvm rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/llvm)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/llvm)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "LLVM SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            mkdir -p temp-solx-main/target-llvm
-            rm -rf temp-solx-main/target-llvm/target-final
-            ln -snf "$GITHUB_WORKSPACE/target-llvm/target-final" \
-                    temp-solx-main/target-llvm/target-final
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::LLVM inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
       - name: Build LLVM (main)
-        if: steps.share-llvm.outputs.shared != 'true'
-        run: |
-          pushd temp-solx-main
-          ${SFW_PREFIX:-} cargo fetch --locked
-          ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-          ./target/release/solx-dev llvm build --build-type Release --enable-mlir --install-distribution
-          popd
+        uses: ./.github/actions/build-llvm
+        with:
+          working-dir: temp-solx-main
+          mirror-key: ${{ steps.build-llvm-pr.outputs.cache-key }}
+          build-type: Release
+          enable-assertions: 'false'
+          enable-mlir: 'true'
 
       # Env and target mirror .github/actions/build-rust so the pr/main
       # binaries share the released binary's build configuration: the

--- a/.github/workflows/compile-benchmark.yaml
+++ b/.github/workflows/compile-benchmark.yaml
@@ -164,8 +164,8 @@ jobs:
       - name: Run benchmark
         run: |
           ./tests/benchmark/run.sh \
-            --bin pr=./target-slang/x86_64-unknown-linux-gnu/release/solx \
-            --bin main=./temp-solx-main/target-slang/x86_64-unknown-linux-gnu/release/solx \
+            --bin pr=./target/x86_64-unknown-linux-gnu/release/solx \
+            --bin main=./temp-solx-main/target/x86_64-unknown-linux-gnu/release/solx \
             --bin release=./solx-release \
             --runs 3 --warmup 1 \
             --out benchmark-out

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,12 +3,12 @@ name: Code coverage
 on:
   pull_request:
     branches:
-      - main
-  # Main runs upload the Codecov base for PR deltas and save the cargo cache
-  # that PR runs restore (rust-cache save-if only fires on refs/heads/main).
+      - main-slang*
+  # Trunk runs upload the Codecov base for PR deltas and save the cargo cache
+  # that PR runs restore (rust-cache save-if only fires on refs/heads/main-slang).
   push:
     branches:
-      - main
+      - main-slang
 
 concurrency:
   group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.ref }}
@@ -54,8 +54,6 @@ jobs:
         - /usr/local/.ghcup:/mnt/free-disk-space/ghcup
         - /opt/hostedtoolcache/CodeQL:/mnt/free-disk-space/codeql
     env:
-      BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
-      SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
       PROFDATA_FILE: solx.profdata
       LCOV_FILE: codecov.lcov
       OUTPUT_HTML_DIR: COVERAGE
@@ -85,7 +83,7 @@ jobs:
         with:
           prefix-key: coverage-v1
           cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main-slang' }}
 
       - name: Build LLVM
         uses: ./.github/actions/build-llvm
@@ -95,13 +93,6 @@ jobs:
           enable-coverage: 'true'
           enable-mlir: 'true'
 
-      - name: Building solc
-        uses: ./.github/actions/build-solc
-        with:
-          cmake-build-type: RelWithDebInfo
-          working-dir: 'solx-solidity'
-          enable-mlir: 'true'
-
       - name: Build solx
         id: build-solx
         uses: ./.github/actions/build-rust
@@ -109,6 +100,12 @@ jobs:
           build-type: 'release'
           enable-coverage: 'true'
           target: 'x86_64-unknown-linux-gnu'
+
+      - name: Build solx-dev and solx-tester
+        env:
+          RUSTC_BOOTSTRAP: 1
+          RUSTFLAGS: '-C target-feature=+crt-static -C instrument-coverage -C link-arg=-fuse-ld=lld'
+        run: ${SFW_PREFIX:-} cargo build --frozen --release -p solx-dev -p solx-tester --features solx-tester/slang-ast --target x86_64-unknown-linux-gnu
 
       - name: Run integration tests
         env:
@@ -150,35 +147,7 @@ jobs:
           # pool of 4 files instead of leaving one profraw per process (CLI
           # tests spawn thousands of short-lived solx subprocesses).
           LLVM_PROFILE_FILE: 'unit-tests-%4m.profraw'
-        run: ${SFW_PREFIX:-} cargo fetch --locked && ${SFW_PREFIX:-} cargo test --frozen --release --target x86_64-unknown-linux-gnu
-
-      # Inkwell feature poisoning: solc path builds inkwell with LLVM linking,
-      # slang path needs no-llvm-linking. cargo clean cannot reliably clear
-      # cached llvm-sys build script output. Use a separate target directory
-      # for complete isolation.
-      - name: Run slang unit tests
-        if: contains(github.event.pull_request.labels.*.name, 'ci:slang')
-        env:
-          RUSTC_BOOTSTRAP: 1
-          RUSTFLAGS: '-C instrument-coverage -C link-arg=-fuse-ld=lld'
-          LLVM_PROFILE_FILE: 'slang-tests-%4m.profraw'
-          CARGO_TARGET_DIR: target-slang
         run: ${SFW_PREFIX:-} cargo test-slang --frozen --release --target x86_64-unknown-linux-gnu
-
-      - name: Preserve slang instrumented binary
-        if: contains(github.event.pull_request.labels.*.name, 'ci:slang')
-        run: cp "./target-slang/x86_64-unknown-linux-gnu/release/solx" "${GITHUB_WORKSPACE}/solx-slang-instrumented"
-
-      - name: Merge slang test profraw
-        if: contains(github.event.pull_request.labels.*.name, 'ci:slang')
-        run: |
-          find . -name 'slang-tests-*.profraw' -print > slang-profiles.lst
-          if [ -s slang-profiles.lst ]; then
-            TMP="${PROFDATA_FILE}.tmp"
-            llvm-profdata merge -sparse -num-threads="$(nproc)" -o "${TMP}" "${PROFDATA_FILE}" @slang-profiles.lst
-            mv -f "${TMP}" "${PROFDATA_FILE}"
-            find . -name 'slang-tests-*.profraw' -delete
-          fi
 
       - name: Merge unit test profraw
         run: |
@@ -197,7 +166,6 @@ jobs:
             -object "${GITHUB_WORKSPACE}/solx-tester-instrumented"
             -object "${GITHUB_WORKSPACE}/solx-dev-instrumented"
           )
-          [ -f "${GITHUB_WORKSPACE}/solx-slang-instrumented" ] && OBJECTS+=(-object "${GITHUB_WORKSPACE}/solx-slang-instrumented")
           llvm-cov show --show-directory-coverage \
             --format=html --output-dir=${OUTPUT_HTML_DIR} \
             --ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
@@ -216,7 +184,6 @@ jobs:
             -object "${GITHUB_WORKSPACE}/solx-tester-instrumented"
             -object "${GITHUB_WORKSPACE}/solx-dev-instrumented"
           )
-          [ -f "${GITHUB_WORKSPACE}/solx-slang-instrumented" ] && OBJECTS+=(-object "${GITHUB_WORKSPACE}/solx-slang-instrumented")
           llvm-cov report -instr-profile=${PROFDATA_FILE} "${OBJECTS[@]}" \
             --ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
             > coverage-report.txt

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -119,7 +119,7 @@ jobs:
             "${TARGET_DIR}/solx-dev" test solx-tester \
               --binary "${TARGET_DIR}/solx-tester" \
               --solidity-compiler "${SOLX_BINARY}" \
-              --path "${TEST_PATH}" --workflow build --optimizer M3B3
+              --path "${TEST_PATH}" --workflow build --optimizer M3B3 || true
             mv *.profraw "${GITHUB_WORKSPACE}/${WORKDIR}/" || true
             find "${GITHUB_WORKSPACE}/${WORKDIR}" -type f -name '*.profraw' -print > profiles.lst
             if [[ -f "${PROFDATA_FILE}" ]]; then

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -91,49 +91,22 @@ jobs:
           optional: 'true'
 
       - name: Build LLVM
+        id: build-llvm-pr
         uses: ./.github/actions/build-llvm
         with:
           build-type: Release
           enable-assertions: 'false'
           enable-mlir: 'true'
 
-      # Submodule SHA alone is not sufficient: `solx-dev llvm build` is
-      # driven by `solx-dev/src/llvm/*`, so a PR that edits those scripts
-      # without bumping the solx-llvm submodule would silently share its own
-      # LLVM as the main-slang baseline.
-      - name: Share LLVM with main-slang checkout
-        id: share-llvm
-        continue-on-error: true
-        run: |
-          # Content hash of a directory tree (order-independent).
-          hash_tree() {
-            find "$1" -type f -print0 | sort -z | xargs -0 cat | sha256sum | cut -d' ' -f1
-          }
-          MAIN_SHA=$(git -C temp-solx-main/solx-llvm rev-parse HEAD)
-          PR_SHA=$(git -C solx-llvm rev-parse HEAD)
-          SCRIPT_PR=$(hash_tree solx-dev/src/llvm)
-          SCRIPT_MAIN=$(hash_tree temp-solx-main/solx-dev/src/llvm)
-          if [ "$MAIN_SHA" = "$PR_SHA" ] && [ "$SCRIPT_MAIN" = "$SCRIPT_PR" ]; then
-            echo "LLVM SHAs and build scripts match ($PR_SHA / ${SCRIPT_PR:0:8}), sharing via symlink"
-            mkdir -p temp-solx-main/target-llvm
-            rm -rf temp-solx-main/target-llvm/target-final
-            ln -snf "$GITHUB_WORKSPACE/target-llvm/target-final" \
-                    temp-solx-main/target-llvm/target-final
-            echo "shared=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::LLVM inputs differ (main=$MAIN_SHA/${SCRIPT_MAIN:0:8} PR=$PR_SHA/${SCRIPT_PR:0:8}), building main separately"
-          fi
-
-      # If share-llvm failed entirely (output empty), fall through and build.
       - name: Build LLVM (main-slang)
-        if: steps.share-llvm.outputs.shared != 'true'
+        uses: ./.github/actions/build-llvm
         continue-on-error: true
-        run: |
-          pushd temp-solx-main
-          ${SFW_PREFIX:-} cargo fetch --locked
-          ${SFW_PREFIX:-} cargo build --frozen --release --bin solx-dev
-          ./target/release/solx-dev llvm build --build-type Release --enable-mlir --install-distribution
-          popd
+        with:
+          working-dir: temp-solx-main
+          mirror-key: ${{ steps.build-llvm-pr.outputs.cache-key }}
+          build-type: Release
+          enable-assertions: 'false'
+          enable-mlir: 'true'
 
       - name: Fetch dependencies (PR)
         run: ${SFW_PREFIX:-} cargo fetch --locked

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -112,10 +112,7 @@ jobs:
         run: ${SFW_PREFIX:-} cargo fetch --locked
 
       - name: Build solx (PR)
-        run: |
-          ${SFW_PREFIX:-} cargo build-slang --frozen --release
-          mkdir -p target/release
-          cp target-slang/release/solx target/release/solx
+        run: ${SFW_PREFIX:-} cargo build-slang --frozen --release
 
       - name: Build solx-dev and solx-tester (PR)
         run: ${SFW_PREFIX:-} cargo build --frozen --release -p solx-dev -p solx-tester --features solx-tester/slang-ast
@@ -128,10 +125,7 @@ jobs:
       - name: Build solx (main-slang)
         working-directory: temp-solx-main
         continue-on-error: true
-        run: |
-          ${SFW_PREFIX:-} cargo build-slang --frozen --release
-          mkdir -p target/release
-          cp target-slang/release/solx target/release/solx
+        run: ${SFW_PREFIX:-} cargo build-slang --frozen --release
 
       - name: Build solx-dev and solx-tester (main-slang)
         working-directory: temp-solx-main

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -68,9 +68,9 @@ jobs:
       # tblgen links libLLVMTableGen into the melior proc macro, which rustc
       # dlopens without an ASan runtime: sanitized TableGen leaves __asan_*
       # undefined and the load failure surfaces as E0463 at `Compiling melior`.
-      # Hand TABLEGEN_210_PREFIX the standard uninstrumented LLVM (same inputs
-      # as build-toolchain, so it restores from the warm standard cache); the
-      # sanitized build below covers everything the test executables link.
+      # Hand TABLEGEN_210_PREFIX the standard uninstrumented LLVM, built with
+      # build-toolchain's inputs so it restores from the warm standard cache;
+      # the sanitized build below covers everything the test executables link.
       - name: Build LLVM for TableGen
         uses: ./.github/actions/build-llvm
         with:

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -49,6 +49,7 @@ jobs:
       TARGET: x86_64-unknown-linux-gnu
       RUST_SANITIZER: 'address'
       LLVM_SANITIZER: 'Address'
+      TABLEGEN_210_PREFIX: ${{ github.workspace }}/target-llvm-tablegen
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -63,6 +64,25 @@ jobs:
         uses: ./.github/actions/setup-sfw
         with:
           optional: 'true'
+
+      # tblgen links libLLVMTableGen into the melior proc macro, which rustc
+      # dlopens without an ASan runtime: sanitized TableGen leaves __asan_*
+      # undefined and the load failure surfaces as E0463 at `Compiling melior`.
+      # Hand TABLEGEN_210_PREFIX the standard uninstrumented LLVM (same inputs
+      # as build-toolchain, so it restores from the warm standard cache); the
+      # sanitized build below covers everything the test executables link.
+      - name: Build LLVM for TableGen
+        uses: ./.github/actions/build-llvm
+        with:
+          build-type: RelWithDebInfo
+          enable-assertions: 'true'
+          enable-mlir: 'true'
+          enable-utils: 'true'
+
+      - name: Move TableGen LLVM aside
+        run: |
+          mv target-llvm/target-final target-llvm-tablegen
+          rm -rf target-llvm/build-final
 
       - name: Build LLVM
         uses: ./.github/actions/build-llvm

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -49,7 +49,6 @@ jobs:
       TARGET: x86_64-unknown-linux-gnu
       RUST_SANITIZER: 'address'
       LLVM_SANITIZER: 'Address'
-      CARGO_TARGET_DIR: target-slang
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -180,7 +180,6 @@ jobs:
       checks: write
       packages: read
     env:
-      CARGO_TARGET_DIR: target-slang
       CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: false
@@ -224,23 +223,8 @@ jobs:
         if: runner.os == 'Linux' && matrix.image != ''
         uses: ./.github/actions/free-disk-space-linux
 
-      # solc is built separately below: the lit tests need a Release build,
-      # not the standard config.
       - name: Build toolchain
         uses: ./.github/actions/build-toolchain
-        with:
-          solc: 'false'
-
-      # TODO: remove this step once the lit tests stop running against solc.
-      #
-      # Release: RelWithDebInfo bakes -g3 debug info into the statically
-      # linked solc.exe, producing a ~2 GB PE that the Windows loader
-      # rejects ("Exec format error"), and the lit tests execute solc.
-      - name: Build solc
-        uses: ./.github/actions/build-solc
-        with:
-          cmake-build-type: Release
-          enable-mlir: 'true'
 
       # bindgen's embedded clang needs to know it's targeting MinGW,
       # otherwise it can't parse MinGW-specific __attribute__ extensions
@@ -276,8 +260,6 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: slang-tests-v2
-          # `cargo test-slang` writes to target-slang, not target (.cargo/config.toml alias)
-          workspaces: ". -> target-slang"
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main-slang' }}
 
@@ -286,8 +268,6 @@ jobs:
         with:
           target: ${{ matrix.target || '' }}
           cargo-test-command: 'test-slang'
-          results-xml: 'unit-tests-results.xml'
-          check-name: 'Unit Tests Results'
 
       - name: Verify lit tools run outside MSYS2
         if: runner.os == 'Windows'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ cargo test --test cli -- cli::bin::default  # specific test
 
 ```bash
 cargo test-slang
-# expands to: cargo test -p solx-slang -p solx-mlir -p solx --no-default-features --features slang --target-dir target-slang
+# expands to: cargo test -p solx-slang -p solx-mlir -p solx --no-default-features --features slang
 ```
 
 ### Integration tests with solx-tester

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2740,7 +2740,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "melior"
 version = "0.26.9"
-source = "git+https://github.com/NomicFoundation/melior?rev=52fa2611004e9553803de8dd5e6d44bb327af2da#52fa2611004e9553803de8dd5e6d44bb327af2da"
+source = "git+https://github.com/NomicFoundation/melior?rev=1e6f01701b344bec2458ac938b661db669cf27a2#1e6f01701b344bec2458ac938b661db669cf27a2"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "melior-macro"
 version = "0.19.5"
-source = "git+https://github.com/NomicFoundation/melior?rev=52fa2611004e9553803de8dd5e6d44bb327af2da#52fa2611004e9553803de8dd5e6d44bb327af2da"
+source = "git+https://github.com/NomicFoundation/melior?rev=1e6f01701b344bec2458ac938b661db669cf27a2#1e6f01701b344bec2458ac938b661db669cf27a2"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",
@@ -5050,8 +5050,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tblgen"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4e3abe8582a0bb8708d11142c45e8c622f013bc4936d918da42c2aade60e98"
+source = "git+https://github.com/hedgar2017/tblgen-rs?rev=56ad078a9bfc3ee785d56ef63bb923425ce1e088#56ad078a9bfc3ee785d56ef63bb923425ce1e088"
 dependencies = [
  "bindgen",
  "cc",
@@ -5066,7 +5065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/deny.toml
+++ b/deny.toml
@@ -81,4 +81,5 @@ allow-git = [
     "https://github.com/NomicFoundation/llvm-sys.rs",
     "https://github.com/NomicFoundation/melior",
     "https://github.com/NomicFoundation/slang",
+    "https://github.com/hedgar2017/tblgen-rs",
 ]

--- a/docs/src/developer-guide/00-development-container.md
+++ b/docs/src/developer-guide/00-development-container.md
@@ -88,7 +88,6 @@ Build state lives in Docker named volumes so it survives **Rebuild Container** a
 | Volume | Mount point | Holds |
 |---|---|---|
 | `solx-target-<id>` | `target/` | solx build artifacts, `solx-dev` |
-| `solx-target-slang-<id>` | `target-slang/` | `cargo *-slang` alias artifacts |
 | `solx-target-llvm-<id>` | `target-llvm/` | LLVM build tree + installation |
 | `solx-rustup` | `/usr/local/rustup` | downloaded Rust toolchains |
 | `solx-cargo` | `/usr/local/cargo` | cargo registry/git caches |

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -13,7 +13,7 @@ cc = "1.2.60"
 anyhow.workspace = true
 clap.workspace = true
 num.workspace = true
-melior = { git = "https://github.com/NomicFoundation/melior", rev = "52fa2611004e9553803de8dd5e6d44bb327af2da", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "1e6f01701b344bec2458ac938b661db669cf27a2", features = ["ods-dialects", "helpers"] }
 serde.workspace = true
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==

--- a/solx-mlir/build.rs
+++ b/solx-mlir/build.rs
@@ -12,10 +12,14 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", lib_path.display());
 
     // LLD C API — provides LLVMAssembleEVM used by inkwell's assemble_evm.
-    // LLVM libs are already linked by mlir-sys; only the LLD linker libs are missing.
-    println!("cargo:rustc-link-lib=static=lldC");
-    println!("cargo:rustc-link-lib=static=lldCommon");
-    println!("cargo:rustc-link-lib=static=lldELF");
+    // LLVM libs are already linked by mlir-sys; only the LLD linker libs are
+    // missing. Not `static=`: that bundles the archives into this crate's
+    // rlib, which precedes libinkwell in the final link, and the sanitizer
+    // job's ld.bfd resolves archives in one pass, leaving inkwell's
+    // references undefined. Plain `-l` flags land after every rlib.
+    println!("cargo:rustc-link-lib=lldC");
+    println!("cargo:rustc-link-lib=lldCommon");
+    println!("cargo:rustc-link-lib=lldELF");
 
     // Sol dialect — custom Solidity MLIR dialect defined in solx-llvm.
     println!("cargo:rustc-link-lib=static=MLIRSolDialect");

--- a/solx-mlir/build.rs
+++ b/solx-mlir/build.rs
@@ -18,8 +18,8 @@ fn main() {
     // job's ld.bfd resolves archives in one pass, leaving inkwell's
     // references undefined. Plain `-l` flags land after every rlib.
     println!("cargo:rustc-link-lib=lldC");
-    println!("cargo:rustc-link-lib=lldCommon");
     println!("cargo:rustc-link-lib=lldELF");
+    println!("cargo:rustc-link-lib=lldCommon");
 
     // Sol dialect — custom Solidity MLIR dialect defined in solx-llvm.
     println!("cargo:rustc-link-lib=static=MLIRSolDialect");

--- a/solx-mlir/tests/lit/lit.cfg.py
+++ b/solx-mlir/tests/lit/lit.cfg.py
@@ -7,7 +7,7 @@ config.suffixes = [".sol"]
 
 config_dir = os.path.dirname(os.path.abspath(__file__))
 solx_root = os.path.join(config_dir, "..", "..", "..")
-solx_bin_dir = os.path.join(solx_root, "target-slang", os.environ.get("SOLX_LIT_TARGET", ""), "debug")
+solx_bin_dir = os.path.join(solx_root, "target", os.environ.get("SOLX_LIT_TARGET", ""), "debug")
 solc_bin_dir = os.path.join(solx_root, "solx-solidity", "build", "solc")
 
 config.environment["PATH"] = os.pathsep.join(


### PR DESCRIPTION
Mirrors #618 onto the main-slang line and makes the coverage and solc plumbing #617 left dormant actually fire:

- `build-llvm` matches #618: a `cache-key` output and a `mirror-key` input replace the share-llvm bash in `integration-tests.yaml` and `compile-benchmark.yaml` — the main-slang side receives the PR invocation's key and symlinks the workspace-root artifacts when its own key is equal. Both dev-script hashes widen to the modules the builds read outside `src/{llvm,solc}`: `arguments/{llvm,solc}`, `build_type`, `ccache_variant`, and `utils`; solc keeps only the hash fix, since no job on this line mirrors it.
- `coverage.yaml` builds and tests the slang pipeline on `main-slang*` triggers, dropping the solc it needed only to link the default pipeline.
- `build-toolchain` builds the lit oracle's Release solc, so `warm-solc` warms the key `build-and-test` restores on all five platforms rather than a RelWithDebInfo key nothing reads; `warm-llvm-integration` drops its solc half, which no integration job consumes.
- `target-slang` collapses into `target` across the cargo aliases, CI paths, devcontainer volume, and lit config, the isolation being pointless once no job on this line builds the linking default pipeline.