### PR TITLE
fix(slang): qualify function symbols with the node id

### DIFF
--- a/solx-mlir/tests/lit/evaluation_order/nested_assignment.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_assignment.sol
@@ -4,53 +4,53 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*ternary.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 4 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*call.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*indexPlace.*}}
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*compound.*}}
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*tuple.*}}
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 4 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/evaluation_order/nested_binary.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_binary.sol
@@ -4,39 +4,39 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*ternary.*}}
 // CHECK:   sol.constant 4 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*assignment.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*call.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*index.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/evaluation_order/nested_call.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_call.sol
@@ -4,25 +4,25 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*ternary.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 4 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*assignment.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/evaluation_order/nested_index.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_index.sol
@@ -4,27 +4,27 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*ternary.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 4 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*call.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 3 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/evaluation_order/nested_logical.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_logical.sol
@@ -4,36 +4,36 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 2 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*ternary.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.if
 // CHECK:       sol.constant 3 : ui8
-// CHECK:       sol.call @"t(uint256)"
+// CHECK:       sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*assignment.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*logical.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.if
 // CHECK:       sol.constant 3 : ui8
-// CHECK:       sol.call @"t(uint256)"
+// CHECK:       sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/evaluation_order/nested_ternary.sol
+++ b/solx-mlir/tests/lit/evaluation_order/nested_ternary.sol
@@ -4,43 +4,43 @@
 
 // CHECK: sol.func @{{.*binary.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 4 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*logical.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 4 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*call.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 4 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 
 // CHECK: sol.func @{{.*assignment.*}}
 // CHECK:   sol.constant 1 : ui8
-// CHECK:   sol.call @"t(uint256)"
+// CHECK:   sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:   sol.if
 // CHECK:     sol.constant 2 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"
 // CHECK:     sol.constant 3 : ui8
-// CHECK:     sol.call @"t(uint256)"
+// CHECK:     sol.call @"t(uint256)_{{[0-9]+}}"

--- a/solx-mlir/tests/lit/function_overloads.sol
+++ b/solx-mlir/tests/lit/function_overloads.sol
@@ -1,0 +1,77 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*pick.*}}(%{{.*}}: ui256) -> ui256
+// CHECK: sol.func @{{.*pick.*}}(%{{.*}}: i1) -> i1
+
+// CHECK: sol.func @{{.*sum.*}}(%{{.*}}: ui256) -> ui256
+// CHECK: sol.func @{{.*sum.*}}(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+
+// CHECK: sol.func @{{.*run_nested.*}}
+// CHECK:   %[[INNER:.*]] = sol.call @{{.*sum.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK:   sol.call @{{.*sum.*}}(%[[INNER]], %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*get.*}}(%{{.*}}: ui256) -> ui256 attributes {{.*}}selector = -1794649190
+// CHECK: sol.func @{{.*get.*}}(%{{.*}}: i1) -> i1 attributes {{.*}}selector = -1044471942
+
+// CHECK: sol.func @{{.*apply_pointer.*}}(%{{.*}}: !sol.func_ref<(ui256) -> ui256>) -> ui256
+// CHECK:   sol.icall %{{[0-9]+}}(%{{.*}}) : !sol.func_ref<(ui256) -> ui256>, (ui256) -> ui256
+// CHECK: sol.func @{{.*apply_pointer.*}}(%{{.*}}: !sol.func_ref<(i1) -> i1>) -> i1
+// CHECK:   sol.icall %{{[0-9]+}}(%{{.*}}) : !sol.func_ref<(i1) -> i1>, (i1) -> i1
+
+// CHECK: sol.func @{{.*run.*}}
+// CHECK:   sol.call @{{.*apply_pointer.*}}(%{{.*}}) : (!sol.func_ref<(i1) -> i1>) -> i1
+// CHECK:     sol.call @{{.*pick.*}}(%{{.*}}) : (i1) -> i1
+
+contract C {
+    function pick(uint256 x) internal pure returns (uint256) {
+        return x;
+    }
+
+    function pick(bool b) internal pure returns (bool) {
+        return b;
+    }
+
+    function sum(uint256 x) internal pure returns (uint256) {
+        return x;
+    }
+
+    function sum(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x + y;
+    }
+
+    function run_nested() public pure returns (uint256) {
+        return sum(sum(10), 20);
+    }
+
+    function get(uint256 x) public pure returns (uint256) {
+        return x;
+    }
+
+    function get(bool b) public pure returns (bool) {
+        return b;
+    }
+
+    function apply_pointer(function(uint256) internal pure returns (uint256) f) internal pure returns (uint256) {
+        return f(1);
+    }
+
+    function apply_pointer(function(bool) internal pure returns (bool) f) internal pure returns (bool) {
+        return f(true);
+    }
+
+    function first(uint256 x) internal pure returns (uint256) {
+        return x + 1;
+    }
+
+    function second(bool b) internal pure returns (bool) {
+        return !b;
+    }
+
+    function run() public pure returns (uint256) {
+        if (apply_pointer(second) || pick(true)) {
+            return apply_pointer(first) + pick(1);
+        }
+        return 0;
+    }
+}

--- a/solx-mlir/tests/lit/function_shadowing.sol
+++ b/solx-mlir/tests/lit/function_shadowing.sol
@@ -1,0 +1,43 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*add.*}}(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+
+// CHECK: sol.func @{{.*plus.*}}(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+// CHECK:   sol.call @{{.*add.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*sum.*}}(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
+// CHECK:   sol.call @{{.*add.*}}(%{{.*}}, %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*f.*}}() -> ui256
+// CHECK:   sol.call @{{.*f.*}}() : () -> ui256
+
+type T is uint256;
+
+using {add as +} for T global;
+
+function add(T a, T b) pure returns (T) {
+    return T.wrap(T.unwrap(a) + T.unwrap(b));
+}
+
+function f() pure returns (uint256) {
+    return 1337;
+}
+
+contract C {
+    function add(T a, T b) internal pure returns (T) {
+        return T.wrap(T.unwrap(a) + T.unwrap(b) + 1);
+    }
+
+    function plus(T a, T b) public pure returns (T) {
+        return a + b;
+    }
+
+    function sum(T a, T b) public pure returns (T) {
+        return add(a, b);
+    }
+
+    function f() public pure returns (uint256) {
+        return f();
+    }
+}

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -18,6 +18,7 @@ use solx_mlir::StateMutability;
 use solx_mlir::Value;
 
 use crate::scope::contract::ContractScope;
+use crate::scope::source_unit::SourceUnitScope;
 
 impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
     /// Emits `function`'s `sol.func` into the contract body from its pre-registered signature,
@@ -110,5 +111,19 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             scope.state_variable_initializers();
             scope.current_block().r#return(&[], scope);
         });
+    }
+}
+
+impl<'context> SourceUnitScope<'context> {
+    /// The function's symbol: its internal signature qualified by the node id, since internal
+    /// signatures alone collide.
+    pub fn symbol(function: &FunctionDefinition) -> String {
+        format!(
+            "{}_{}",
+            function
+                .compute_internal_signature()
+                .expect("every emitted function has an internal signature"),
+            function.node_id(),
+        )
     }
 }

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -47,12 +47,7 @@ impl<'context> SourceUnitScope<'context> {
             };
             self.function_signatures.insert(
                 function.node_id(),
-                Function::new(
-                    function
-                        .compute_internal_signature()
-                        .expect("every emitted function has an internal signature"),
-                    self.function_type(&function_type),
-                ),
+                Function::new(Self::symbol(&function), self.function_type(&function_type)),
             );
         }
 


### PR DESCRIPTION
Fixes #560 by qualifying every registered function symbol with its node id:

- Overloads differing only in a function-typed parameter, `apply_pointer(function(uint256) ...)` next to `apply_pointer(function(bool) ...)`, both mangled to `apply_pointer(function)` and died on symbol redefinition; they now emit distinct `{signature}_{node id}` symbols, the qualification the C++ frontend's mangling applies, which also covers same-signature overrides once inheritance lands.