### PR TITLE
feat(slang): named arguments

### DIFF
--- a/solx-mlir/build.rs
+++ b/solx-mlir/build.rs
@@ -64,7 +64,7 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .file("sol_attr_stubs.cpp")
-        .include(&include_path)
+        .flag(format!("-isystem{}", include_path.display()))
         .flag("-std=c++17")
         .compile("sol_attr_stubs");
 }

--- a/solx-mlir/src/context/contract.rs
+++ b/solx-mlir/src/context/contract.rs
@@ -49,7 +49,7 @@ impl<'context> Contract<'context> {
         byte_offset: u32,
         context: &Context<'context>,
     ) {
-        mlir_op_void!(
+        mlir_op!(
             context,
             self.body,
             StateVarOperation
@@ -62,7 +62,8 @@ impl<'context> Contract<'context> {
                 .byte_offset(IntegerAttribute::new(
                     IntegerType::new(context.melior, solx_utils::BIT_LENGTH_X32 as u32).into(),
                     byte_offset.into(),
-                ))
+                ));
+            ()
         );
     }
 }

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -70,23 +70,23 @@ sol_ops! {
         CmpOperation.predicate(predicate_attr(predicate)).lhs(self).rhs(other).result(boolean())
     }
 
-    Value::add(self, rhs: value) -> value {
-        checked(CAddOperation, AddOperation).lhs(self).rhs(rhs)
+    Value::add(self, rhs: value) -> value checked(CAddOperation) {
+        AddOperation.lhs(self).rhs(rhs)
     }
-    Value::subtract(self, rhs: value) -> value {
-        checked(CSubOperation, SubOperation).lhs(self).rhs(rhs)
+    Value::subtract(self, rhs: value) -> value checked(CSubOperation) {
+        SubOperation.lhs(self).rhs(rhs)
     }
-    Value::multiply(self, rhs: value) -> value {
-        checked(CMulOperation, MulOperation).lhs(self).rhs(rhs)
+    Value::multiply(self, rhs: value) -> value checked(CMulOperation) {
+        MulOperation.lhs(self).rhs(rhs)
     }
-    Value::divide(self, rhs: value) -> value {
-        checked(CDivOperation, DivOperation).lhs(self).rhs(rhs)
+    Value::divide(self, rhs: value) -> value checked(CDivOperation) {
+        DivOperation.lhs(self).rhs(rhs)
     }
     Value::remainder(self, rhs: value) -> value {
         ModOperation.lhs(self).rhs(rhs)
     }
-    Value::exponentiate(self, rhs: value) -> value {
-        checked(CExpOperation, ExpOperation).lhs(self).rhs(rhs).result(self_ty)
+    Value::exponentiate(self, rhs: value) -> value checked(CExpOperation) {
+        ExpOperation.lhs(self).rhs(rhs).result(self_ty)
     }
     Value::bitand(self, rhs: value) -> value {
         AndOperation.lhs(self).rhs(rhs)

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -69,7 +69,7 @@ impl<'context> Value<'context> {
         Self::constant(i64::from(value), Type::boolean(context.melior), context)
     }
 
-    /// Materialises the default-initialized value of `target_type`, matching solc's default-init.
+    /// Materialises the default-initialized value of `target_type`.
     /// A function reference cannot route through `zero`, since `sol.constant` is illegal at a
     /// `!sol.func_ref`, and a reference type's default is its location's designator rather than a
     /// value.

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -1,12 +1,7 @@
 //!
 //! ODS op-construction macros.
 //!
-//! `mlir_op_build!` / `mlir_op!` / `mlir_op_void!` / `mlir_region_op!` collapse the ceremony of an
-//! ODS-generated op builder (the `(context, unknown_location)` head and `.build().into()` tail) so a
-//! site states only the op name and its setters.
-//!
 
-/// Builds an inlined dialect op and yields it as an `Operation`, without appending.
 macro_rules! mlir_op_build {
     ($context:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
         $operation::builder($context.melior, $context.location())
@@ -16,12 +11,12 @@ macro_rules! mlir_op_build {
     };
 }
 
-/// Builds an inlined dialect op ([`mlir_op_build!`]), appends it to `$block`, and
-/// returns its single result value. The `expect` message is derived from the op.
-/// Omitting `$block` appends at the `current_block()` cursor.
 macro_rules! mlir_op {
     ($context:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
         mlir_op!($context, $context.current_block(), $operation $(.$method($($argument),*))*)
+    };
+    ($context:expr, $block:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))* ; ()) => {
+        $block.append_operation(mlir_op_build!($context, $operation $(.$method($($argument),*))*));
     };
     ($context:expr, $block:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
         $block
@@ -31,21 +26,6 @@ macro_rules! mlir_op {
     };
 }
 
-/// [`mlir_op!`] for a value-less op: a statement or effect such as `sol.store`
-/// or `sol.return`: appends the op ([`mlir_op_build!`]) and yields `()`.
-macro_rules! mlir_op_void {
-    ($context:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
-        mlir_op_void!($context, $context.current_block(), $operation $(.$method($($argument),*))*)
-    };
-    ($context:expr, $block:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
-        $block.append_operation(mlir_op_build!($context, $operation $(.$method($($argument),*))*));
-    };
-}
-
-/// Appends a region-bearing control-flow op (`sol.if`/`for`/`while`/`do`) and hands back each
-/// region's fresh entry block for the caller to emit into and terminate. A trailing `; empty name…`
-/// clause sets a region the op's shape requires but this method leaves bodiless — an `if` with no
-/// `else` — and it is not handed back.
 macro_rules! mlir_region_op {
     (
         $context:expr, $block:expr, $operation:ident
@@ -90,8 +70,6 @@ macro_rules! mlir_region_op {
     }};
 }
 
-/// A Sol dialect attribute enum built by a `solxCreate*Attr` FFI constructor: the `#[repr(u32)]`
-/// enum plus its `attribute()` builder. `From`/other impls, where present, live alongside the call.
 macro_rules! sol_dialect_attribute {
     (
         $(#[$enum_meta:meta])*
@@ -115,8 +93,6 @@ macro_rules! sol_dialect_attribute {
     };
 }
 
-/// A Sol comparison-predicate enum encoded as an `i64` `IntegerAttribute`: the `#[repr(i64)]` enum
-/// plus its `attribute()` builder. `From`/other impls, where present, live alongside the call.
 macro_rules! sol_predicate_attribute {
     (
         $(#[$enum_meta:meta])*
@@ -169,25 +145,6 @@ impl<'slice, T, const N: usize> IntoOds<&'slice [T]> for &'slice [T; N] {
     }
 }
 
-/// Declares Sol dialect op-wrapper methods on their entity homes as pure data: one ODS operation
-/// per declaration.
-///
-/// A declaration names the receiver, the method and its typed parameters, the disposition, the
-/// operation, and the builder setter chain. Every setter argument is a parameter, the receiver
-/// `self`, or a closed keyword from the `@arg` rules; keywords are call-shaped, so a bare
-/// identifier is always a parameter. The operation slot may be `checked(CheckedOp, UncheckedOp)`,
-/// which threads a `checked: bool` selector.
-///
-/// A `base | flagged (…) … { … } flagged .setter ;` declaration stamps a pair of methods off one
-/// chain: `base` omits the unit-flag setter and `flagged` appends `.setter(unit_flag)`, so a binary
-/// mode is two named methods rather than one method taking a `bool`.
-///
-/// Dispositions: `-> value` / `-> place` append at the `current_block()` cursor and wrap the single
-/// result; `-> value nop_if_same(param)` short-circuits when the receiver already has that type; an
-/// arrowless declaration is value-less and appends to the receiver block for a `Block` method, or at
-/// the `current_block()` cursor for a `Value` / `Place`. A `Block` declaration listing region names
-/// after `;` opens a region-bearing op and returns each region's entry block, or the sole block when
-/// one region is named. Every argument is routed through [`IntoOds`] to the setter's type.
 macro_rules! sol_ops {
     () => {};
 
@@ -314,6 +271,18 @@ macro_rules! sol_ops {
         .into()
     };
 
+    (@flag_ty $checked_op:ident) => { bool };
+    (@op [$context:ident] [$receiver:tt] [$flag:ident] checked($checked_op:ident) $operation:ident $($chain:tt)*) => {
+        if $flag {
+            sol_ops!(@build [$context] [$receiver] $checked_op $($chain)*)
+        } else {
+            sol_ops!(@build [$context] [$receiver] $operation $($chain)*)
+        }
+    };
+    (@op [$context:ident] [$receiver:tt] [$flag:ident] $operation:ident $($chain:tt)*) => {
+        sol_ops!(@build [$context] [$receiver] $operation $($chain)*)
+    };
+
     (@disp_ty value) => { $crate::Value<'context> };
     (@disp_ty place) => { $crate::Place<'context> };
     (@disp_ty values) => { ::std::vec::Vec<$crate::Value<'context>> };
@@ -381,37 +350,15 @@ macro_rules! sol_ops {
 
     (
         $receiver:ident :: $method:ident (self $(, $argument:ident : $kind:ident)* $(,)?)
-        -> value { checked($checked_op:ident, $unchecked_op:ident) $($chain:tt)* }
+        -> $disposition:ident $(nop_if_same($same:ident))? $(checked($checked_op:ident))?
+        { $operation:ident $($chain:tt)* }
         $($rest:tt)*
     ) => {
         impl<'context> $receiver<'context> {
             pub fn $method(
                 self,
                 $($argument: sol_ops!(@ty $kind),)*
-                checked: bool,
-                context: &$crate::Context<'context>,
-            ) -> $crate::Value<'context> {
-                let receiver = self;
-                let operation = if checked {
-                    sol_ops!(@build [context] [receiver] $checked_op $($chain)*)
-                } else {
-                    sol_ops!(@build [context] [receiver] $unchecked_op $($chain)*)
-                };
-                sol_ops!(@emit value [context] operation, "checked arithmetic op produces one result")
-            }
-        }
-        sol_ops!($($rest)*);
-    };
-
-    (
-        $receiver:ident :: $method:ident (self $(, $argument:ident : $kind:ident)* $(,)?)
-        -> $disposition:ident $(nop_if_same($same:ident))? { $operation:ident $($chain:tt)* }
-        $($rest:tt)*
-    ) => {
-        impl<'context> $receiver<'context> {
-            pub fn $method(
-                self,
-                $($argument: sol_ops!(@ty $kind),)*
+                $(checked: sol_ops!(@flag_ty $checked_op),)?
                 context: &$crate::Context<'context>,
             ) -> sol_ops!(@disp_ty $disposition) {
                 let receiver = self;
@@ -419,7 +366,8 @@ macro_rules! sol_ops {
                     return receiver.into();
                 })?
                 sol_ops!(@emit $disposition [context]
-                    sol_ops!(@build [context] [receiver] $operation $($chain)*),
+                    sol_ops!(@op [context] [receiver] [checked]
+                        $(checked($checked_op))? $operation $($chain)*),
                     concat!(stringify!($operation), " produces one result"))
             }
         }

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -1,7 +1,12 @@
 //!
 //! ODS op-construction macros.
 //!
+//! `mlir_op_build!` / `mlir_op!` / `mlir_region_op!` collapse the ceremony of an ODS-generated op
+//! builder (the `(context, unknown_location)` head and `.build().into()` tail) so a site states only
+//! the op name and its setters.
+//!
 
+/// Builds an inlined dialect op and yields it as an `Operation`, without appending.
 macro_rules! mlir_op_build {
     ($context:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
         $operation::builder($context.melior, $context.location())
@@ -11,6 +16,10 @@ macro_rules! mlir_op_build {
     };
 }
 
+/// Builds an inlined dialect op ([`mlir_op_build!`]), appends it to `$block`, and
+/// returns its single result value. The `expect` message is derived from the op.
+/// Omitting `$block` appends at the `current_block()` cursor. A `; ()` tail marks the value-less
+/// form of a `$block` site: the op is appended for its effect and yields `()`.
 macro_rules! mlir_op {
     ($context:expr, $operation:ident $(.$method:ident($($argument:expr),* $(,)?))*) => {
         mlir_op!($context, $context.current_block(), $operation $(.$method($($argument),*))*)
@@ -26,6 +35,10 @@ macro_rules! mlir_op {
     };
 }
 
+/// Appends a region-bearing control-flow op (`sol.if`/`for`/`while`/`do`) and hands back each
+/// region's fresh entry block for the caller to emit into and terminate. A trailing `; empty name…`
+/// clause sets a region the op's shape requires but this method leaves bodiless — an `if` with no
+/// `else` — and it is not handed back.
 macro_rules! mlir_region_op {
     (
         $context:expr, $block:expr, $operation:ident
@@ -70,6 +83,8 @@ macro_rules! mlir_region_op {
     }};
 }
 
+/// A Sol dialect attribute enum built by a `solxCreate*Attr` FFI constructor: the `#[repr(u32)]`
+/// enum plus its `attribute()` builder. `From`/other impls, where present, live alongside the call.
 macro_rules! sol_dialect_attribute {
     (
         $(#[$enum_meta:meta])*
@@ -93,6 +108,8 @@ macro_rules! sol_dialect_attribute {
     };
 }
 
+/// A Sol comparison-predicate enum encoded as an `i64` `IntegerAttribute`: the `#[repr(i64)]` enum
+/// plus its `attribute()` builder. `From`/other impls, where present, live alongside the call.
 macro_rules! sol_predicate_attribute {
     (
         $(#[$enum_meta:meta])*
@@ -145,6 +162,26 @@ impl<'slice, T, const N: usize> IntoOds<&'slice [T]> for &'slice [T; N] {
     }
 }
 
+/// Declares Sol dialect op-wrapper methods on their entity homes as pure data: one ODS operation
+/// per declaration.
+///
+/// A declaration names the receiver, the method and its typed parameters, the disposition, the
+/// operation, and the builder setter chain. Every setter argument is a parameter, the receiver
+/// `self`, or a closed keyword from the `@arg` rules; keywords are call-shaped, so a bare
+/// identifier is always a parameter.
+///
+/// A `base | flagged (…) … { … } flagged .setter ;` declaration stamps a pair of methods off one
+/// chain: `base` omits the unit-flag setter and `flagged` appends `.setter(unit_flag)`, so a binary
+/// mode is two named methods rather than one method taking a `bool`.
+///
+/// Dispositions: `-> value` / `-> place` append at the `current_block()` cursor and wrap the single
+/// result; `-> value nop_if_same(param)` short-circuits when the receiver already has that type;
+/// `-> value checked(CheckedOp)` threads a `checked: bool` selector that builds `CheckedOp` in place
+/// of the declared operation off the same chain; an arrowless declaration is value-less and appends
+/// to the receiver block for a `Block` method, or at the `current_block()` cursor for a `Value` /
+/// `Place`. A `Block` declaration listing region names after `;` opens a region-bearing op and
+/// returns each region's entry block, or the sole block when one region is named. Every argument is
+/// routed through [`IntoOds`] to the setter's type.
 macro_rules! sol_ops {
     () => {};
 

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -9,6 +9,10 @@
 // CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
 // CHECK-NOT: sol.store
 
+// CHECK: sol.func {{.*}}pushEmptyBraces
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK-NOT: sol.store
+
 // CHECK: sol.func {{.*}}pushAssign
 // CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
@@ -26,6 +30,9 @@
 // CHECK:   sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
 
 // CHECK: sol.func {{.*}}popLast
+// CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>
+
+// CHECK: sol.func {{.*}}popEmptyBraces
 // CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>
 
 // CHECK: sol.func {{.*}}popByte
@@ -46,6 +53,10 @@ contract C {
         arr.push();
     }
 
+    function pushEmptyBraces() public {
+        arr.push({});
+    }
+
     function pushAssign(uint256 x) public {
         arr.push() = x;
     }
@@ -64,6 +75,10 @@ contract C {
 
     function popLast() public {
         arr.pop();
+    }
+
+    function popEmptyBraces() public {
+        arr.pop({});
     }
 
     function popByte() public {

--- a/solx-mlir/tests/lit/evaluation_order/named_arguments.sol
+++ b/solx-mlir/tests/lit/evaluation_order/named_arguments.sol
@@ -1,0 +1,25 @@
+// RUN: solx --emit-mlir=sol %evaluation_order/named_arguments.sol | FileCheck %s
+
+// solc print-init spells an internal callee `@t_28` rather than `@"t(uint256)_28"`, so the symbol
+// CHECKs are solx-only. The behavior is pinned against legacy by
+// tests/solidity/simple/evaluation_order/named_arguments.sol.
+
+// CHECK: sol.func @{{.*call.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   %[[A:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   %[[B:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   %[[C:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.call @{{.*triple.*}}(%[[A]], %[[B]], %[[C]])
+
+// CHECK: sol.func @{{.*struct_constructor.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   %[[FIELD_A:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.store %[[FIELD_A]]
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   %[[FIELD_B:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.store %[[FIELD_B]]
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   %[[FIELD_C:.*]] = sol.call @"t(uint256)_{{[0-9]+}}"
+// CHECK:   sol.store %[[FIELD_C]]

--- a/solx-mlir/tests/lit/events.sol
+++ b/solx-mlir/tests/lit/events.sol
@@ -7,6 +7,12 @@
 // CHECK:   %[[AMT:.*]] = sol.load
 // CHECK:   sol.emit "Transfer(address,address,uint256)" indexed = [%[[CALLER]], %[[TO]]] non_indexed = [%[[AMT]]] : !sol.address, !sol.address, ui256
 
+// CHECK: sol.func @{{.*}}fireNamed
+// CHECK:   %[[CALLER:.*]] = sol.caller
+// CHECK:   %[[TO:.*]] = sol.load
+// CHECK:   %[[AMT:.*]] = sol.load
+// CHECK:   sol.emit "Transfer(address,address,uint256)" indexed = [%[[CALLER]], %[[TO]]] non_indexed = [%[[AMT]]] : !sol.address, !sol.address, ui256
+
 // CHECK: sol.func @{{.*}}fireAnon
 // CHECK:   sol.emit non_indexed = [%{{.*}}] : ui256
 
@@ -16,6 +22,10 @@ contract C {
 
     function fire(address to, uint256 amount) public {
         emit Transfer(msg.sender, to, amount);
+    }
+
+    function fireNamed(address to, uint256 amount) public {
+        emit Transfer({value: amount, to: to, from: msg.sender});
     }
 
     function fireAnon(uint256 v) public {

--- a/solx-mlir/tests/lit/function_calls.sol
+++ b/solx-mlir/tests/lit/function_calls.sol
@@ -28,6 +28,11 @@
 // CHECK:   sol.constant 1 : ui8
 // CHECK:   sol.call @{{.*add.*}}
 
+// CHECK: sol.func @{{.*paren_named_argument.*}}
+// CHECK:   %[[X:.*]] = sol.load
+// CHECK:   %[[ONE:.*]] = sol.cast
+// CHECK:   sol.icall %{{.*}}(%[[X]], %[[ONE]])
+
 // CHECK: sol.func @{{.*empty_braces.*}}
 // CHECK:   sol.call @{{.*literal_argument.*}}() : () -> ()
 
@@ -60,6 +65,10 @@ contract C {
 
     function named_argument(uint256 x) public pure returns (uint256) {
         return add({b: 1, a: x});
+    }
+
+    function paren_named_argument(uint256 x) public pure returns (uint256) {
+        return (add)({b: 1, a: x});
     }
 
     function empty_braces() public pure {

--- a/solx-mlir/tests/lit/function_calls.sol
+++ b/solx-mlir/tests/lit/function_calls.sol
@@ -23,6 +23,14 @@
 // CHECK:   sol.cast %{{.*}} : ui8 to ui256
 // CHECK:   sol.call @{{.*add.*}}
 
+// CHECK: sol.func @{{.*named_argument.*}}
+// CHECK:   sol.load %{{.*}}
+// CHECK:   sol.constant 1 : ui8
+// CHECK:   sol.call @{{.*add.*}}
+
+// CHECK: sol.func @{{.*empty_braces.*}}
+// CHECK:   sol.call @{{.*literal_argument.*}}() : () -> ()
+
 // CHECK: sol.func @{{.*tuple_statement.*}}
 // CHECK:   sol.call @{{.*add.*}}
 // CHECK:   sol.call @{{.*double.*}}
@@ -48,6 +56,14 @@ contract C {
 
     function widening_argument(uint8 a, uint8 b) public pure returns (uint256) {
         return add(a, b);
+    }
+
+    function named_argument(uint256 x) public pure returns (uint256) {
+        return add({b: 1, a: x});
+    }
+
+    function empty_braces() public pure {
+        literal_argument({});
     }
 
     function tuple_statement(uint256 x) public pure {

--- a/solx-mlir/tests/lit/function_overloads.sol
+++ b/solx-mlir/tests/lit/function_overloads.sol
@@ -4,6 +4,11 @@
 // CHECK: sol.func @{{.*pick.*}}(%{{.*}}: ui256) -> ui256
 // CHECK: sol.func @{{.*pick.*}}(%{{.*}}: i1) -> i1
 
+// CHECK: sol.func @{{.*pick_named.*}}
+// CHECK:   sol.call @{{.*pick.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*pick_named_bool.*}}
+// CHECK:   sol.call @{{.*pick.*}}(%{{.*}}) : (i1) -> i1
+
 // CHECK: sol.func @{{.*sum.*}}(%{{.*}}: ui256) -> ui256
 // CHECK: sol.func @{{.*sum.*}}(%{{.*}}: ui256, %{{.*}}: ui256) -> ui256
 
@@ -30,6 +35,14 @@ contract C {
 
     function pick(bool b) internal pure returns (bool) {
         return b;
+    }
+
+    function pick_named() public pure returns (uint256) {
+        return pick({x: 1});
+    }
+
+    function pick_named_bool() public pure returns (bool) {
+        return pick({b: true});
     }
 
     function sum(uint256 x) internal pure returns (uint256) {

--- a/solx-mlir/tests/lit/internal_function_pointer.sol
+++ b/solx-mlir/tests/lit/internal_function_pointer.sol
@@ -12,6 +12,10 @@
 // CHECK:   %[[POINTER:.*]] = sol.load %[[SLOT]] : !sol.ptr<!sol.func_ref<() -> ui256>, Stack>, !sol.func_ref<() -> ui256>
 // CHECK:   sol.icall %[[POINTER]]() : !sol.func_ref<() -> ui256>, () -> ui256
 
+// CHECK: sol.func @{{.*run_empty_braces.*}}
+// CHECK:   sol.func_constant @{{.*g.*}} : !sol.func_ref<() -> ui256>
+// CHECK:   sol.icall %{{[0-9]+}}() : !sol.func_ref<() -> ui256>, () -> ui256
+
 // CHECK: sol.func @{{.*invoke.*}}(%[[ARGUMENT:.*]]: !sol.func_ref<() -> ui256>) -> ui256
 // CHECK:   sol.store %[[ARGUMENT]], %[[SLOT:.*]] : !sol.func_ref<() -> ui256>, !sol.ptr<!sol.func_ref<() -> ui256>, Stack>
 // CHECK:   %[[POINTER:.*]] = sol.load %[[SLOT]] : !sol.ptr<!sol.func_ref<() -> ui256>, Stack>, !sol.func_ref<() -> ui256>
@@ -74,6 +78,11 @@ contract C {
     function run() public returns (uint256) {
         function () internal returns (uint256) functionPointer = g;
         return functionPointer();
+    }
+
+    function run_empty_braces() public returns (uint256) {
+        function () internal returns (uint256) functionPointer = g;
+        return functionPointer({});
     }
 
     function invoke(function () internal returns (uint256) f) internal returns (uint256) {

--- a/solx-mlir/tests/lit/revert.sol
+++ b/solx-mlir/tests/lit/revert.sol
@@ -13,6 +13,10 @@
 // CHECK: sol.func @{{.*empty_message_revert.*}}
 // CHECK:   sol.revert ""
 
+// CHECK: sol.func @{{.*runtime_message_revert.*}}
+// CHECK:   %[[MESSAGE:.*]] = sol.data_loc_cast %{{.*}} : !sol.string<CallData>, !sol.string<Memory>
+// CHECK:   sol.revert "Error(string)" %[[MESSAGE]] : !sol.string<Memory> {call}
+
 // CHECK: sol.func @{{.*custom_error.*}}
 // CHECK:   sol.revert "TooLow(uint256,uint256)" %{{.*}}, %{{.*}} : ui256, ui256 {call}
 
@@ -38,6 +42,10 @@ contract C {
 
     function empty_message_revert() public pure {
         revert("");
+    }
+
+    function runtime_message_revert(string calldata message) public pure {
+        revert(message);
     }
 
     function custom_error(uint256 x) public pure {

--- a/solx-mlir/tests/lit/revert.sol
+++ b/solx-mlir/tests/lit/revert.sol
@@ -4,6 +4,9 @@
 // CHECK: sol.func @{{.*plain_revert.*}}
 // CHECK:   sol.revert{{$}}
 
+// CHECK: sol.func @{{.*empty_named_revert.*}}
+// CHECK:   sol.revert{{$}}
+
 // CHECK: sol.func @{{.*message_revert.*}}
 // CHECK:   sol.revert "oops"
 
@@ -23,6 +26,10 @@ contract C {
 
     function plain_revert() public pure {
         revert();
+    }
+
+    function empty_named_revert() public pure {
+        revert({});
     }
 
     function message_revert() public pure {

--- a/solx-mlir/tests/lit/struct_constructor.sol
+++ b/solx-mlir/tests/lit/struct_constructor.sol
@@ -10,6 +10,19 @@
 // CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Memory>
 
+// CHECK: sol.func {{.*}}build_named{{.*}}-> !sol.struct<(ui256, ui256), Memory>
+// CHECK:   %[[STRUCT:.*]] = sol.malloc :{{ +}}!sol.struct<(ui256, ui256), Memory>
+// CHECK:   %[[FIRST:.*]] = sol.constant 0 : ui64
+// CHECK:   %[[A:.*]] = sol.gep %[[STRUCT]], %[[FIRST]] : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
+// CHECK:   %[[ONE:.*]] = sol.constant 1 : ui8
+// CHECK:   %[[A_VALUE:.*]] = sol.cast %[[ONE]] : ui8 to ui256
+// CHECK:   sol.store %[[A_VALUE]], %[[A]] : ui256, !sol.ptr<ui256, Memory>
+// CHECK:   %[[SECOND:.*]] = sol.constant 1 : ui64
+// CHECK:   %[[B:.*]] = sol.gep %[[STRUCT]], %[[SECOND]] : !sol.struct<(ui256, ui256), Memory>, ui64, !sol.ptr<ui256, Memory>
+// CHECK:   %[[TWO:.*]] = sol.constant 2 : ui8
+// CHECK:   %[[B_VALUE:.*]] = sol.cast %[[TWO]] : ui8 to ui256
+// CHECK:   sol.store %[[B_VALUE]], %[[B]] : ui256, !sol.ptr<ui256, Memory>
+
 // CHECK: sol.func {{.*}}build_tagged{{.*}}-> !sol.struct<(!sol.fixedbytes<4>, ui256), Memory>
 // CHECK:   sol.constant {{.*}} : ui32
 // CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
@@ -21,6 +34,10 @@ contract C {
 
     function build(uint256 x, uint256 y) public pure returns (S memory) {
         return S(x, y);
+    }
+
+    function build_named() public pure returns (S memory) {
+        return S({b: 2, a: 1});
     }
 
     function build_tagged() public pure returns (T memory) {

--- a/solx-slang/src/contract/function/expression/arithmetic.rs
+++ b/solx-slang/src/contract/function/expression/arithmetic.rs
@@ -6,9 +6,9 @@
 use slang_solidity_v2::ast::AdditiveExpression;
 use slang_solidity_v2::ast::AdditiveExpressionOperator;
 use slang_solidity_v2::ast::ExponentiationExpression;
+use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::MultiplicativeExpression;
 use slang_solidity_v2::ast::MultiplicativeExpressionOperator;
-use slang_solidity_v2::ast::PositionalArguments;
 use slang_solidity_v2::ast::UserDefinedOperatorExpression;
 
 use solx_mlir::Context;
@@ -58,7 +58,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// legacy, then combined by `operator`.
     pub fn modular(
         &mut self,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         operator: impl FnOnce(
             Value<'context>,
             Value<'context>,
@@ -67,7 +67,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         ) -> Value<'context>,
     ) -> Value<'context> {
         let field = MlirType::field(self.melior);
-        let arguments: Vec<_> = arguments.iter().collect();
         let modulus = self.converted(&arguments[2], field);
         let right = self.converted(&arguments[1], field);
         let left = self.converted(&arguments[0], field);

--- a/solx-slang/src/contract/function/expression/call/arguments.rs
+++ b/solx-slang/src/contract/function/expression/call/arguments.rs
@@ -7,9 +7,9 @@ use std::collections::HashMap;
 use slang_solidity_v2::ast::ArgumentsDeclaration;
 use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::NamedArguments;
+use slang_solidity_v2::ast::NodeId;
 use slang_solidity_v2::ast::Parameter;
 use slang_solidity_v2::ast::Parameters;
-use slang_solidity_v2::ast::PositionalArguments;
 
 use solx_mlir::Value;
 
@@ -25,7 +25,10 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     ) -> Vec<(Parameter, Value<'context>)> {
         let ordered: Vec<Expression> = match arguments {
             ArgumentsDeclaration::PositionalArguments(positional) => positional.iter().collect(),
-            ArgumentsDeclaration::NamedArguments(named) => Self::named_arguments(named, parameters),
+            ArgumentsDeclaration::NamedArguments(named) => Self::named_arguments(
+                named,
+                parameters.iter().map(|parameter| parameter.node_id()),
+            ),
         };
         parameters
             .iter()
@@ -39,27 +42,36 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     }
 
     /// The positional argument list of a call, each argument evaluated in order.
-    pub fn positional_arguments(&mut self, node: &PositionalArguments) -> Vec<Value<'context>> {
-        node.iter()
-            .map(|argument| self.expression(&argument))
+    pub fn positional_arguments(&mut self, arguments: &[Expression]) -> Vec<Value<'context>> {
+        arguments
+            .iter()
+            .map(|argument| self.expression(argument))
             .collect()
     }
 
-    /// The named argument list of a call, reordered into the definition's parameter order by the
-    /// name matching slang has validated is total and unambiguous.
-    fn named_arguments(named: &NamedArguments, parameters: &Parameters) -> Vec<Expression> {
-        let mut by_name: HashMap<String, Expression> = named
+    /// The named argument list of a call, reordered into the targets' declaration order through
+    /// the label bindings slang resolves.
+    pub fn named_arguments(
+        named: &NamedArguments,
+        targets: impl Iterator<Item = NodeId>,
+    ) -> Vec<Expression> {
+        let mut by_target: HashMap<NodeId, Expression> = named
             .iter()
-            .map(|argument| (argument.name().name().to_owned(), argument.value()))
+            .map(|argument| {
+                (
+                    argument
+                        .name()
+                        .resolve_to_definition()
+                        .expect("slang binds every named-argument label")
+                        .node_id(),
+                    argument.value(),
+                )
+            })
             .collect();
-        parameters
-            .iter()
-            .map(|parameter| {
-                let identifier = parameter
-                    .name()
-                    .expect("slang validates a named argument targets a named parameter");
-                by_name
-                    .remove(identifier.name())
+        targets
+            .map(|target| {
+                by_target
+                    .remove(&target)
                     .expect("slang validates every parameter receives a named argument")
             })
             .collect()

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -11,6 +11,7 @@ use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::FunctionCallExpression;
 use slang_solidity_v2::ast::FunctionDefinition;
+use slang_solidity_v2::ast::FunctionType;
 use slang_solidity_v2::ast::MemberAccessExpression;
 use slang_solidity_v2::ast::StructDefinition;
 use slang_solidity_v2::ast::Type;
@@ -39,11 +40,11 @@ pub enum Call {
     /// A direct call to a named function.
     Function(FunctionDefinition),
     /// A call through a function-typed value, dispatched by `sol.icall`.
-    FunctionPointer,
+    FunctionPointer(FunctionType),
 }
 
 impl Call {
-    /// The canonical signature ABI-encoding a runtime `require` message.
+    /// The canonical signature ABI-encoding a runtime `require` or `revert` message.
     const ERROR_STRING_SIGNATURE: &'static str = "Error(string)";
 
     /// Classifies and emits `node`, routing each kind to its emission and returning its results in
@@ -66,7 +67,9 @@ impl Call {
                 .into_iter()
                 .collect(),
             Self::Function(function_definition) => scope.call(&function_definition, arguments),
-            Self::FunctionPointer => Self::function_pointer(node, &arguments, scope),
+            Self::FunctionPointer(function_type) => {
+                Self::function_pointer(&function_type, &node.operand(), &arguments, scope)
+            }
         }
     }
 
@@ -97,8 +100,8 @@ impl Call {
                 {
                     return Self::Function(function_definition);
                 }
-                if matches!(identifier.get_type(), Some(Type::Function(_))) {
-                    return Self::FunctionPointer;
+                if let Some(Type::Function(function_type)) = identifier.get_type() {
+                    return Self::FunctionPointer(function_type);
                 }
                 unimplemented!("unsupported callee '{}'", identifier.name())
             }
@@ -106,17 +109,19 @@ impl Call {
                 if matches!(
                     access.member().resolve_to_definition(),
                     Some(Definition::StructMember(_))
-                ) && matches!(access.get_type(), Some(Type::Function(_)))
+                ) && let Some(Type::Function(function_type)) = access.get_type()
                 {
-                    return Self::FunctionPointer;
+                    return Self::FunctionPointer(function_type);
                 }
                 Self::Member(access)
             }
-            callee if matches!(callee.get_type(), Some(Type::Function(_))) => Self::FunctionPointer,
-            callee => unimplemented!(
-                "unsupported callee expression: {:?}",
-                std::mem::discriminant(&callee)
-            ),
+            callee => match callee.get_type() {
+                Some(Type::Function(function_type)) => Self::FunctionPointer(function_type),
+                _ => unimplemented!(
+                    "unsupported callee expression: {:?}",
+                    std::mem::discriminant(&callee)
+                ),
+            },
         }
     }
 
@@ -141,10 +146,26 @@ impl Call {
                         .iter()
                         .map(|parameter| parameter.node_id()),
                 ),
-                Self::TypeConversion
-                | Self::Builtin(_)
-                | Self::Member(_)
-                | Self::FunctionPointer => Vec::new(),
+                Self::FunctionPointer(function_type) => match function_type.associated_definition()
+                {
+                    Some(Definition::Function(function_definition)) => {
+                        FunctionScope::named_arguments(
+                            &named,
+                            function_definition
+                                .parameters()
+                                .iter()
+                                .map(|parameter| parameter.node_id()),
+                        )
+                    }
+                    _ if named.is_empty() => Vec::new(),
+                    _ => unreachable!("a function value declares no labeled parameter"),
+                },
+                Self::Member(_) | Self::Builtin(_) if named.is_empty() => Vec::new(),
+                Self::Member(_) => unimplemented!("named arguments on a member callee"),
+                Self::Builtin(_) => unreachable!("a built-in declares no labeled parameter"),
+                Self::TypeConversion => {
+                    unreachable!("a type conversion classifies only positional arguments")
+                }
             },
         }
     }
@@ -247,15 +268,24 @@ impl Call {
                 None
             }
             BuiltIn::Revert => {
-                let message = match arguments.first() {
-                    Some(Expression::StringExpression(string_expression)) => Some(
-                        String::from_utf8(string_expression.value())
-                            .expect("slang validates string lals are UTF-8"),
-                    ),
-                    Some(_) => unreachable!("revert message is a string lal"),
-                    None => None,
-                };
-                scope.current_block().revert(message.as_deref(), &[], scope);
+                match arguments.first() {
+                    Some(Expression::StringExpression(string_expression)) => {
+                        let message = String::from_utf8(string_expression.value())
+                            .expect("slang validates string literals are UTF-8");
+                        scope.current_block().revert(Some(&message), &[], scope);
+                    }
+                    Some(expression) => {
+                        let string_type =
+                            MlirType::string(scope.melior, solx_utils::DataLocation::Memory);
+                        let message = scope.converted(expression, string_type);
+                        scope.current_block().revert_custom(
+                            Some(Self::ERROR_STRING_SIGNATURE),
+                            &[message],
+                            scope,
+                        );
+                    }
+                    None => scope.current_block().revert(None, &[], scope),
+                }
                 None
             }
             BuiltIn::Gasleft => Some(Value::gas_left(scope)),
@@ -449,16 +479,13 @@ impl Call {
     /// The signature comes from the callee's binder type: a pointer callee names no definition to
     /// look a registered signature up by.
     fn function_pointer<'context>(
-        call: &FunctionCallExpression,
+        function_type: &FunctionType,
+        callee: &Expression,
         arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
-        let callee = call.operand();
-        let Some(Type::Function(function_type)) = callee.get_type() else {
-            unreachable!("classification admits only function-typed callees");
-        };
-        let function_type = scope.contract.source_unit.function_type(&function_type);
-        let pointer = scope.expression(&callee);
+        let function_type = scope.contract.source_unit.function_type(function_type);
+        let pointer = scope.expression(callee);
         let converted: Vec<Value<'context>> = arguments
             .iter()
             .zip(&function_type.parameters)

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -12,7 +12,6 @@ use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::FunctionCallExpression;
 use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::MemberAccessExpression;
-use slang_solidity_v2::ast::PositionalArguments;
 use slang_solidity_v2::ast::StructDefinition;
 use slang_solidity_v2::ast::Type;
 
@@ -53,24 +52,21 @@ impl Call {
         node: &FunctionCallExpression,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
-        let ArgumentsDeclaration::PositionalArguments(arguments) = &node.arguments() else {
-            unreachable!("only positional arguments supported");
-        };
-        match Self::from_call(node) {
+        let kind = Self::from_call(node);
+        let arguments = kind.arguments(node);
+        match kind {
             Self::StructConstruction(struct_definition) => {
-                Self::struct_construction(&struct_definition, node, arguments, scope)
+                Self::struct_construction(&struct_definition, node, &arguments, scope)
             }
-            Self::TypeConversion => vec![Self::type_conversion(node, arguments, scope)],
-            Self::Builtin(built_in) => Self::builtin(built_in, arguments, scope)
+            Self::TypeConversion => vec![Self::type_conversion(node, &arguments, scope)],
+            Self::Builtin(built_in) => Self::builtin(built_in, &arguments, scope)
                 .into_iter()
                 .collect(),
-            Self::Member(access) => Self::member(&access, node, arguments, scope)
+            Self::Member(access) => Self::member(&access, node, &arguments, scope)
                 .into_iter()
                 .collect(),
-            Self::Function(function_definition) => {
-                scope.call(&function_definition, arguments.iter())
-            }
-            Self::FunctionPointer => Self::function_pointer(node, arguments, scope),
+            Self::Function(function_definition) => scope.call(&function_definition, arguments),
+            Self::FunctionPointer => Self::function_pointer(node, &arguments, scope),
         }
     }
 
@@ -124,19 +120,48 @@ impl Call {
         }
     }
 
+    /// The call's arguments in the callee's declaration order, which is the order the named form
+    /// evaluates in. A kind that declares no parameters orders against nothing, so the empty
+    /// braces of `f({})` are its only named form.
+    fn arguments(&self, call: &FunctionCallExpression) -> Vec<Expression> {
+        match call.arguments() {
+            ArgumentsDeclaration::PositionalArguments(positional) => positional.iter().collect(),
+            ArgumentsDeclaration::NamedArguments(named) => match self {
+                Self::StructConstruction(struct_definition) => FunctionScope::named_arguments(
+                    &named,
+                    struct_definition
+                        .members()
+                        .iter()
+                        .map(|member| member.node_id()),
+                ),
+                Self::Function(function_definition) => FunctionScope::named_arguments(
+                    &named,
+                    function_definition
+                        .parameters()
+                        .iter()
+                        .map(|parameter| parameter.node_id()),
+                ),
+                Self::TypeConversion
+                | Self::Builtin(_)
+                | Self::Member(_)
+                | Self::FunctionPointer => Vec::new(),
+            },
+        }
+    }
+
     /// Builds the struct value in memory: allocates the call's result type and stores each
     /// argument, converted to its field type, through the field's address.
     fn struct_construction<'context>(
         struct_definition: &StructDefinition,
         call: &FunctionCallExpression,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
         let struct_address = Place::malloc(scope.typing(call.get_type()), scope);
         for (index, (member, argument)) in struct_definition
             .members()
             .iter()
-            .zip(arguments.iter())
+            .zip(arguments)
             .enumerate()
         {
             let field_type = scope.resolve_type(
@@ -144,7 +169,7 @@ impl Call {
                 Some(solx_utils::DataLocation::Memory),
             );
             let field_address = struct_address.gep_field(index, field_type, scope);
-            field_address.store(scope.converted(&argument, field_type), scope);
+            field_address.store(scope.converted(argument, field_type), scope);
         }
         vec![struct_address.into()]
     }
@@ -153,15 +178,14 @@ impl Call {
     /// cast.
     fn type_conversion<'context>(
         call: &FunctionCallExpression,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Value<'context> {
         let operand = arguments
-            .iter()
-            .next()
+            .first()
             .expect("classification admits exactly one argument");
         let target_type = scope.typing(call.get_type());
-        scope.converted(&operand, target_type)
+        scope.converted(operand, target_type)
     }
 
     /// Statement-style built-ins (`assert`, `require`, `revert`) produce no value.
@@ -170,16 +194,15 @@ impl Call {
     /// evaluates at runtime and is ABI-encoded under the `Error(string)` selector via its call form.
     fn builtin<'context>(
         built_in: BuiltIn,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Option<Value<'context>> {
         match built_in {
             BuiltIn::Assert => {
                 let condition_expression = arguments
-                    .iter()
-                    .next()
+                    .first()
                     .expect("slang validates the arity of assert");
-                let condition = scope.expression(&condition_expression).is_nonzero(scope);
+                let condition = scope.expression(condition_expression).is_nonzero(scope);
                 scope.current_block().assert(condition, scope);
                 None
             }
@@ -187,7 +210,7 @@ impl Call {
                 let mut iter = arguments.iter();
                 let condition_expression =
                     iter.next().expect("slang validates the arity of require");
-                let condition = scope.expression(&condition_expression).is_nonzero(scope);
+                let condition = scope.expression(condition_expression).is_nonzero(scope);
                 let (values, message, custom) = match iter.next() {
                     Some(Expression::StringExpression(string_expression)) => (
                         Vec::new(),
@@ -200,7 +223,7 @@ impl Call {
                     Some(expression) => {
                         let string_memory_type =
                             MlirType::string(scope.melior, solx_utils::DataLocation::Memory);
-                        let message_value = scope.converted(&expression, string_memory_type);
+                        let message_value = scope.converted(expression, string_memory_type);
                         (
                             vec![message_value],
                             Some(Self::ERROR_STRING_SIGNATURE.to_owned()),
@@ -224,7 +247,7 @@ impl Call {
                 None
             }
             BuiltIn::Revert => {
-                let message = match arguments.iter().next() {
+                let message = match arguments.first() {
                     Some(Expression::StringExpression(string_expression)) => Some(
                         String::from_utf8(string_expression.value())
                             .expect("slang validates string lals are UTF-8"),
@@ -284,7 +307,7 @@ impl Call {
     fn member<'context>(
         access: &MemberAccessExpression,
         call: &FunctionCallExpression,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Option<Value<'context>> {
         match access.member().resolve_to_built_in() {
@@ -342,14 +365,13 @@ impl Call {
                     scope,
                 );
                 let values = iter
-                    .map(|argument| scope.expression(&argument))
+                    .map(|argument| scope.expression(argument))
                     .collect::<Vec<_>>();
                 Some(Value::encode(&values, Some(selector), scope))
             }
             Some(BuiltIn::AbiDecode) => {
                 let payload_expression = arguments
-                    .iter()
-                    .next()
+                    .first()
                     .expect("slang validates the payload argument");
                 let return_slang_type = call
                     .get_type()
@@ -358,7 +380,7 @@ impl Call {
                     unimplemented!("abi.decode returning multiple values is not yet supported");
                 }
                 Some(Value::decode(
-                    scope.expression(&payload_expression),
+                    scope.expression(payload_expression),
                     scope.resolve_type(&return_slang_type, None),
                     scope,
                 ))
@@ -372,11 +394,11 @@ impl Call {
                 let base_slang_type = base
                     .get_type()
                     .expect("base of array push has a resolved type");
-                let value_argument = arguments.iter().next();
+                let value_argument = arguments.first();
                 let (place, _) = scope.expression_place(&base);
 
                 if let Type::Bytes(_) = &base_slang_type
-                    && let Some(value_argument) = &value_argument
+                    && let Some(value_argument) = value_argument
                 {
                     let appended = scope.converted(
                         value_argument,
@@ -411,7 +433,7 @@ impl Call {
                 let Some(value_argument) = value_argument else {
                     return Some(new_slot);
                 };
-                Place::from(new_slot).store(scope.converted(&value_argument, element_type), scope);
+                Place::from(new_slot).store(scope.converted(value_argument, element_type), scope);
                 None
             }
             Some(BuiltIn::BytesConcat | BuiltIn::StringConcat) => {
@@ -428,7 +450,7 @@ impl Call {
     /// look a registered signature up by.
     fn function_pointer<'context>(
         call: &FunctionCallExpression,
-        arguments: &PositionalArguments,
+        arguments: &[Expression],
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
         let callee = call.operand();
@@ -440,7 +462,7 @@ impl Call {
         let converted: Vec<Value<'context>> = arguments
             .iter()
             .zip(&function_type.parameters)
-            .map(|(argument, &parameter_type)| scope.converted(&argument, parameter_type))
+            .map(|(argument, &parameter_type)| scope.converted(argument, parameter_type))
             .collect();
         pointer.indirect_call(&converted, &function_type.results, scope)
     }

--- a/solx-slang/src/contract/function/statement/variable_declaration.rs
+++ b/solx-slang/src/contract/function/statement/variable_declaration.rs
@@ -30,8 +30,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     }
 
     /// A single-typed variable declaration. An explicit initializer is evaluated before the slot is
-    /// allocated, matching solc's order; an absent one default-initializes the slot to the type's
-    /// default value.
+    /// allocated; an absent one default-initializes the slot to the type's default value.
     pub fn single_typed_declaration(&mut self, node: &SingleTypedDeclaration) {
         let declared_type = self.typing(node.declaration().get_type());
         match node.value() {

--- a/solx-slang/src/contract/storage_slot.rs
+++ b/solx-slang/src/contract/storage_slot.rs
@@ -8,9 +8,8 @@ use slang_solidity_v2::abi::StorageItem;
 /// Storage location of a state variable in contract storage.
 #[derive(Debug, Clone)]
 pub struct StorageSlot {
-    /// MLIR symbol name, formatted as `{label}_{node_id}` to match solc.
-    /// The slang AST node id disambiguates like-named variables across
-    /// inherited contracts.
+    /// MLIR symbol name, formatted as `{label}_{node_id}`. The slang AST node
+    /// id disambiguates like-named variables across inherited contracts.
     pub name: String,
     /// 256-bit storage slot index.
     pub slot: U256,

--- a/solx-slang/src/scope/function.rs
+++ b/solx-slang/src/scope/function.rs
@@ -46,7 +46,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// Binds a named local: allocates its stack pointer, stores the value its initializer yields,
     /// and defines the binding in the current scope. The initializer runs after the allocation so
-    /// the slot precedes the value that initializes it, matching solc's emission order.
+    /// the slot precedes the value that initializes it.
     pub fn define_local(
         &mut self,
         name: &str,

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -20,11 +20,11 @@ use crate::scope::source_unit::SourceUnitScope;
 
 impl<'context> SourceUnitScope<'context> {
     /// Lowers every contract the unit deploys into standard-JSON contract outputs keyed by contract
-    /// name, each in its own MLIR module off the file's melior context, as solc emits one module per
-    /// contract. An abstract contract and an interface deploy nothing and produce no module. A
-    /// contract with a contract base is skipped because emission collects only the contract's own
-    /// state and functions: an interface base carries nothing to inherit, a contract base carries
-    /// state and bodies that would be silently dropped.
+    /// name, each in its own MLIR module off the file's melior context. An abstract contract and an
+    /// interface deploy nothing and produce no module. A contract with a contract base is skipped
+    /// because emission collects only the contract's own state and functions: an interface base
+    /// carries nothing to inherit, a contract base carries state and bodies that would be silently
+    /// dropped.
     ///
     /// # Errors
     ///

--- a/solx/tests/cli/stack_too_deep.rs
+++ b/solx/tests/cli/stack_too_deep.rs
@@ -2,6 +2,7 @@
 //! CLI tests for stack-too-deep handling.
 //!
 
+#[cfg(feature = "solc")]
 use predicates::prelude::*;
 
 #[cfg(feature = "solc")]

--- a/tests/solidity/simple/constant_expressions/bitwise.sol
+++ b/tests/solidity/simple/constant_expressions/bitwise.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "ignore": true, "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {

--- a/tests/solidity/simple/evaluation_order/named_arguments.sol
+++ b/tests/solidity/simple/evaluation_order/named_arguments.sol
@@ -1,0 +1,44 @@
+//! { "modes": [ "E" ], "cases": [ {
+//!     "name": "call",
+//!     "inputs": [ { "method": "call", "calldata": [] } ],
+//!     "expected": [ "123", "123" ]
+//! }, {
+//!     "name": "struct_constructor",
+//!     "inputs": [ { "method": "struct_constructor", "calldata": [] } ],
+//!     "expected": [ "123", "123" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    struct S {
+        uint256 a;
+        uint256 b;
+        uint256 c;
+    }
+
+    uint256 order;
+
+    function t(uint256 n) internal returns (uint256) {
+        order = order * 10 + n;
+        return n;
+    }
+
+    function triple(uint256 a, uint256 b, uint256 c) internal pure returns (uint256) {
+        return a * 100 + b * 10 + c;
+    }
+
+    function call() public returns (uint256, uint256) {
+        order = 0;
+        uint256 result = triple({c: t(3), a: t(1), b: t(2)});
+        return (result, order);
+    }
+
+    function struct_constructor() public returns (uint256, uint256) {
+        order = 0;
+        S memory s = S({c: t(3), a: t(1), b: t(2)});
+        return (s.a * 100 + s.b * 10 + s.c, order);
+    }
+}


### PR DESCRIPTION
Completes named-argument emission for every callee kind the frontend lowers today:

- `f({y: .., x: ..})` on a direct call and `S({b: .., a: ..})` on a struct constructor evaluate their arguments in the callee’s parameter and struct-member declaration order, the order legacy solc evaluates them in, resolved through the node id each label binds to so an overloaded callee is selected by its binding and never by name.
- `emit E({..})` and `revert E({..})` order through that same binding instead of matching parameter names as strings.
- The empty `f({})` braces order against no declarations, so every callee kind that declares no parameters lowers them as its no-argument form: `revert({})` to `sol.revert`, `array.push({})` and `array.pop({})` to `sol.push` and `sol.pop`, and a call through an internal function pointer to `sol.icall`.

Also optimizes and de-duplicates some macro:

- `sol_ops!` takes a `checked(CheckedOp)` marker on the declaration itself, so the checked/unchecked arithmetic pair is stamped by the same terminal rule as every other method rather than by a dedicated one, the `checked: bool` selector threaded through the operation slot.
- `mlir_op!` absorbs `mlir_op_void!`, a `; ()` tail marking the value-less form.

Suppresses warnings from the dialect that have been polluting our build and CI logs:

- `sol_attr_stubs.cpp` takes the MLIR headers through `-isystem`, so the `-Wunused-parameter` wall their tblgen output raises no longer lands on every build.
