### PR TITLE
chore(deps): source tblgen from NomicFoundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "melior"
 version = "0.26.9"
-source = "git+https://github.com/NomicFoundation/melior?rev=1e6f01701b344bec2458ac938b661db669cf27a2#1e6f01701b344bec2458ac938b661db669cf27a2"
+source = "git+https://github.com/NomicFoundation/melior?rev=d188691b0620f91ff83e98cdbdf60507b2ee37d9#d188691b0620f91ff83e98cdbdf60507b2ee37d9"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "melior-macro"
 version = "0.19.5"
-source = "git+https://github.com/NomicFoundation/melior?rev=1e6f01701b344bec2458ac938b661db669cf27a2#1e6f01701b344bec2458ac938b661db669cf27a2"
+source = "git+https://github.com/NomicFoundation/melior?rev=d188691b0620f91ff83e98cdbdf60507b2ee37d9#d188691b0620f91ff83e98cdbdf60507b2ee37d9"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",
@@ -5128,7 +5128,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tblgen"
 version = "0.8.1"
-source = "git+https://github.com/hedgar2017/tblgen-rs?rev=56ad078a9bfc3ee785d56ef63bb923425ce1e088#56ad078a9bfc3ee785d56ef63bb923425ce1e088"
+source = "git+https://github.com/NomicFoundation/tblgen-rs?rev=56ad078a9bfc3ee785d56ef63bb923425ce1e088#56ad078a9bfc3ee785d56ef63bb923425ce1e088"
 dependencies = [
  "bindgen",
  "cc",

--- a/deny.toml
+++ b/deny.toml
@@ -79,7 +79,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/NomicFoundation/inkwell",
     "https://github.com/NomicFoundation/llvm-sys.rs",
+    "https://github.com/NomicFoundation/tblgen-rs",
     "https://github.com/NomicFoundation/melior",
     "https://github.com/NomicFoundation/slang",
-    "https://github.com/hedgar2017/tblgen-rs",
 ]

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -13,7 +13,7 @@ cc = "1.2.60"
 anyhow.workspace = true
 clap.workspace = true
 num.workspace = true
-melior = { git = "https://github.com/NomicFoundation/melior", rev = "1e6f01701b344bec2458ac938b661db669cf27a2", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "d188691b0620f91ff83e98cdbdf60507b2ee37d9", features = ["ods-dialects", "helpers"] }
 serde.workspace = true
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==


### PR DESCRIPTION
Moves `tblgen` off the personal `hedgar2017` fork and onto `NomicFoundation/tblgen-rs`, so every git source we build from is org-owned.

It is not a direct dependency — the fork URL is hard-coded in melior, so it was changed there (NomicFoundation/melior@d188691b) rather than overridden here with a `[patch]`. This PR bumps the melior rev to pick that up and swaps the `deny.toml` allow-list entry to match. The tblgen rev is unchanged, so the compiled code is identical; only the fetch URL differs.
