### PR TITLE
fix(slang): type a pushed reference element as its own place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3428,7 +3428,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4097,7 +4097,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,8 +4577,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slang_solidity_v2"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4590,8 +4590,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_ast"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4607,8 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_common"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4621,13 +4621,13 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_cst"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 
 [[package]]
 name = "slang_solidity_v2_ir"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4635,8 +4635,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_parser"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4649,8 +4649,8 @@ dependencies = [
 
 [[package]]
 name = "slang_solidity_v2_semantic"
-version = "1.3.7"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=c0c62aea7e0782bc21078450ae7d425699cda725#c0c62aea7e0782bc21078450ae7d425699cda725"
+version = "1.3.8"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -5013,7 +5013,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5148,7 +5147,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5157,7 +5156,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5789,7 +5788,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3428,7 +3428,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4097,7 +4097,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4578,7 +4578,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4622,12 +4622,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=397657a4b9fc98ca1055f84c3dfd79bf5aac2b12#397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=820f7c12c70ec2a97e4b2463e91e6c6ac68ad289#820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -5013,6 +5013,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5147,7 +5148,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5156,7 +5157,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5788,7 +5789,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "c0c62aea7e0782bc21078450ae7d425699cda725"
+rev = "397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "397657a4b9fc98ca1055f84c3dfd79bf5aac2b12"
+rev = "820f7c12c70ec2a97e4b2463e91e6c6ac68ad289"

--- a/solx-mlir/sol_attr_stubs.cpp
+++ b/solx-mlir/sol_attr_stubs.cpp
@@ -187,6 +187,10 @@ bool solxIsScalarType(MlirType ty) {
     return mlir::sol::isScalar(unwrap(ty));
 }
 
+bool solxIsPointerType(MlirType ty) {
+    return mlir::isa<mlir::sol::PointerType>(unwrap(ty));
+}
+
 uint32_t solxTypeDataLocation(MlirType ty) {
     return static_cast<uint32_t>(mlir::sol::getDataLocation(unwrap(ty)));
 }

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -199,6 +199,10 @@ unsafe extern "C" {
     /// address-like, or bytes-like.
     pub fn solxIsScalarType(ty: mlir_sys::MlirType) -> bool;
 
+    /// Whether the type is a `sol::PointerType`, as opposed to a reference type that is its
+    /// own place.
+    pub fn solxIsPointerType(ty: mlir_sys::MlirType) -> bool;
+
     /// Returns the data location of a located reference type, in the same encoding the
     /// type constructors take.
     pub fn solxTypeDataLocation(ty: mlir_sys::MlirType) -> u32;

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -257,6 +257,12 @@ impl<'context> Type<'context> {
         unsafe { ffi::solxIsScalarType(self.inner.to_raw()) }
     }
 
+    /// Whether this is a `sol::PointerType`, as opposed to a reference type that is its own
+    /// place.
+    pub fn is_pointer(self) -> bool {
+        unsafe { ffi::solxIsPointerType(self.inner.to_raw()) }
+    }
+
     /// The data location a located reference type carries, decoded from the constructors' FFI
     /// encoding.
     pub fn data_location(self) -> DataLocation {

--- a/solx-mlir/tests/lit/abi_coding.sol
+++ b/solx-mlir/tests/lit/abi_coding.sol
@@ -66,8 +66,7 @@
 // CHECK:   sol.decode %{{.*}} : !sol.string<Memory> -> ui256, !sol.string<Memory>
 
 // CHECK: sol.func @{{.*decodeAddress.*}}
-// CHECK:   %[[PAYABLE:.*]] = sol.decode %{{.*}} : !sol.string<Memory> -> !sol.address<payable>
-// CHECK:   sol.address_cast %[[PAYABLE]] : !sol.address<payable> to !sol.address
+// CHECK:   sol.decode %{{.*}} : !sol.string<Memory> -> !sol.address
 
 // CHECK: sol.func @{{.*decodeStorage.*}}
 // CHECK:   %[[SLOT:.*]] = sol.addr_of @{{.*}} : !sol.string<Storage>

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -23,6 +23,20 @@
 // CHECK:   sol.cadd %{{.*}}, %{{.*}} : ui256
 // CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
 
+// CHECK: sol.func {{.*}}pushStructMember
+// CHECK:   sol.push %{{.*}} : !sol.array<? x !sol.struct<(ui256, ui256), Storage>, Storage> -> !sol.struct<(ui256, ui256), Storage>
+// CHECK:   sol.gep %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Storage>, ui64, !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func {{.*}}pushStructValue
+// CHECK:   sol.push %{{.*}} : !sol.array<? x !sol.struct<(ui256, ui256), Storage>, Storage> -> !sol.struct<(ui256, ui256), Storage>
+// CHECK:   sol.copy %{{.*}}, %{{.*}} : !sol.struct<(ui256, ui256), Memory>, !sol.struct<(ui256, ui256), Storage>
+
+// CHECK: sol.func {{.*}}pushNested
+// CHECK:   sol.push %{{.*}} : !sol.array<? x !sol.array<? x ui256, Storage>, Storage> -> !sol.array<? x ui256, Storage>
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
 // CHECK: sol.func {{.*}}pushByte
 // CHECK:   sol.push_string %{{.*}}, %{{.*}} : <Storage>, !sol.fixedbytes<1>
 
@@ -42,8 +56,15 @@
 // CHECK:   sol.array_lit %{{.*}}, %{{.*}}, %{{.*}} : (ui256, ui256, ui256) -> !sol.array<3 x ui256, Memory>
 
 contract C {
+    struct Y {
+        uint256 a;
+        uint256 b;
+    }
+
     uint256[] arr;
     bytes data;
+    Y[] records;
+    uint256[][] nested;
 
     function pushValue(uint256 x) public {
         arr.push(x);
@@ -63,6 +84,18 @@ contract C {
 
     function pushCompound(uint256 x) public {
         arr.push() += x;
+    }
+
+    function pushStructMember() public {
+        records.push().a = 1;
+    }
+
+    function pushStructValue() public {
+        records.push(Y(1, 2));
+    }
+
+    function pushNested() public {
+        nested.push().push(2);
     }
 
     function pushByte(bytes1 element) public {

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -806,32 +806,50 @@ impl Call {
                     return Vec::new();
                 }
 
-                let (element_type, slang_location) = match &base_slang_type {
-                    Type::Array(array_type) => (
-                        scope.resolve_type(&array_type.element_type(), None),
-                        array_type.location(),
-                    ),
+                let (element_type, slot_type) = match &base_slang_type {
+                    Type::Array(array_type) => {
+                        let element_slang_type = array_type.element_type();
+                        let element_type = scope.resolve_type(&element_slang_type, None);
+                        (
+                            element_type,
+                            scope.pointer_type(
+                                &element_slang_type,
+                                element_type,
+                                solx_utils::DataLocation::from_slang(array_type.location(), None),
+                            ),
+                        )
+                    }
                     Type::Bytes(bytes_type) => {
-                        (MlirType::byte(scope.melior), bytes_type.location())
+                        let element_type = MlirType::byte(scope.melior);
+                        (
+                            element_type,
+                            MlirType::pointer(
+                                scope.melior,
+                                element_type,
+                                solx_utils::DataLocation::from_slang(bytes_type.location(), None),
+                            ),
+                        )
                     }
                     other => unreachable!(
                         "Solidity's .push is a member of dynamic arrays and bytes only; got {:?}",
                         std::mem::discriminant(other)
                     ),
                 };
-                let new_slot = place.push(
-                    MlirType::pointer(
-                        scope.melior,
-                        element_type,
-                        solx_utils::DataLocation::from_slang(slang_location, None),
-                    ),
-                    scope,
-                );
+                let new_slot = place.push(slot_type, scope);
 
                 let Some(value_argument) = value_argument else {
                     return vec![new_slot];
                 };
-                Place::from(new_slot).store(scope.converted(value_argument, element_type), scope);
+                let place = Place::from(new_slot);
+                if let Expression::StringExpression(_) = value_argument
+                    && element_type.is_bytes_like()
+                {
+                    let value = scope.converted(value_argument, element_type);
+                    place.assign(value, element_type, scope);
+                    return Vec::new();
+                }
+                let value = scope.expression(value_argument);
+                place.assign(value, element_type, scope);
                 Vec::new()
             }
             Some(BuiltIn::BytesConcat | BuiltIn::StringConcat) => {
@@ -916,7 +934,7 @@ impl Call {
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `arr.push()` is the sole call assignable in place position; the slot it grows is the value the
-    /// push emits, and its element type is that slot's pointee.
+    /// push emits, whose type is the element's own place unless it points to one.
     pub fn function_call_place(
         &mut self,
         node: &FunctionCallExpression,
@@ -925,7 +943,13 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .into_iter()
             .next()
             .expect("an array push in place position yields the new element's slot");
-        (Place::from(slot), slot.r#type().element_type(0))
+        let slot_type = slot.r#type();
+        let element_type = if slot_type.is_pointer() {
+            slot_type.element_type(0)
+        } else {
+            slot_type
+        };
+        (Place::from(slot), element_type)
     }
 
     /// Calls the function a `using {f as op} for T global;` directive binds an operator to. Being a

--- a/solx-slang/src/contract/function/statement/try_statement.rs
+++ b/solx-slang/src/contract/function/statement/try_statement.rs
@@ -23,7 +23,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
         let (mut panic, mut error, mut fallback) = (None, None, None);
         for clause in node.catch_clauses().iter() {
-            match clause.kind().expect("slang classifies every catch clause") {
+            match clause.kind() {
                 CatchClauseKind::Panic => panic = Some(clause),
                 CatchClauseKind::Error => error = Some(clause),
                 CatchClauseKind::LowLevel => fallback = Some(clause),
@@ -33,7 +33,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             status,
             panic.is_some(),
             error.is_some(),
-            fallback.as_ref().map(|clause| match clause.error() {
+            fallback.as_ref().map(|clause| match clause.parameters() {
                 Some(_) => FallbackRegion::ReturnData,
                 None => FallbackRegion::Unbound,
             }),
@@ -70,8 +70,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
 
     /// A catch clause's body, its declared parameter bound from the region's block argument.
     fn catch_clause(&mut self, node: &CatchClause) {
-        if let Some(error) = node.error()
-            && let Some(parameter) = error.parameters().iter().next()
+        if let Some(parameters) = node.parameters()
+            && let Some(parameter) = parameters.iter().next()
             && let Some(name) = parameter.name()
         {
             let declared_type = self.typing(parameter.get_type());

--- a/solx-tester/src/compilers/solidity/slang_ast.rs
+++ b/solx-tester/src/compilers/solidity/slang_ast.rs
@@ -74,7 +74,7 @@ impl SlangAst {
                     continue;
                 };
                 if let Pragma::AbicoderPragma(pragma) = directive.pragma()
-                    && matches!(pragma.version(), AbicoderVersion::AbicoderV1Keyword(_))
+                    && matches!(pragma.version(), AbicoderVersion::V1)
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes the array push lowering fabricating `!sol.ptr<element, Storage>` slots for reference-typed elements, against the `Sol_GepOp` rule that a reference in storage is its own place.

- **`s.push().a = 1`** no longer crashes the Sol pass pipeline: the slot type comes from `SourceUnitScope::pointer`, the rule's owner, so a struct element's slot is the struct itself and the member `gep` lowers.
- **`nested.push().push(2)`** no longer crashes: the inner push sees the array place instead of a pointer to it.
- **`s.push(Y(1, 2))`** was silently mis-lowered — a single-word store of the memory pointer into a two-slot struct; it now assigns through `Place::assign` and takes the `sol.copy` branch.
- The place path (`push() = v`) reads the element back off the slot alone — the pointee where the slot points at one, the slot itself otherwise — inverting `SourceUnitScope::pointer` rather than consulting the binder a second time. `Type::is_pointer` is the `sol::PointerType` predicate this needs.

Three new dual-oracle cases join `array_string_ops.sol` (`pushStructMember`, `pushStructValue`, `pushNested`). Tester: 8792 → 8825 passing against the same base, zero regressed files. Pre-existing and untouched: push in value position (`uint y = arr.push();`, `push_no_args_1d/2d`).
