### PR TITLE
refactor(slang): spell a bytes push slot `!sol.fixedbytes<1>`

### DIFF
--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -122,10 +122,6 @@ unsafe extern "C" {
     /// 2=Memory, 3=Stack, 4=Immutable, 5=Transient).
     pub fn solxCreateStringType(context: MlirContext, data_location: u32) -> mlir_sys::MlirType;
 
-    /// Creates the `sol::ByteType` singleton (`!sol.byte`), the element a dynamic `bytes`
-    /// push yields.
-    pub fn solxCreateByteType(context: MlirContext) -> mlir_sys::MlirType;
-
     /// Creates a `sol::FixedBytesType` of the given byte width.
     pub fn solxCreateFixedBytesType(context: MlirContext, size: u32) -> mlir_sys::MlirType;
 

--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -116,12 +116,6 @@ impl<'context> Type<'context> {
         })
     }
 
-    /// The `sol::ByteType` singleton (`!sol.byte`), the element a dynamic `bytes` push yields,
-    /// distinct from the one-byte `bytes1`.
-    pub fn byte(context: &'context melior::Context) -> Self {
-        Self::new(unsafe { MlirType::from_raw(ffi::solxCreateByteType(context.to_raw())) })
-    }
-
     /// A `sol::FixedBytesType` of the given byte width.
     pub fn fixed_bytes(context: &'context melior::Context, width: usize) -> Self {
         Self::new(unsafe {

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -1,5 +1,7 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// solc's print-init types a `bytes` push slot `!sol.byte`, which solx spells
+// `!sol.fixedbytes<1>` — their cast lowers as a no-op — so this is solx-only.
 
 // CHECK: sol.func {{.*}}pushValue
 // CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
@@ -41,7 +43,7 @@
 // CHECK:   sol.push_string %{{.*}}, %{{.*}} : <Storage>, !sol.fixedbytes<1>
 
 // CHECK: sol.func {{.*}}pushByteEmpty
-// CHECK:   sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
+// CHECK:   sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.fixedbytes<1>, Storage>
 
 // CHECK: sol.func {{.*}}popLast
 // CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -820,7 +820,8 @@ impl Call {
                         )
                     }
                     Type::Bytes(bytes_type) => {
-                        let element_type = MlirType::byte(scope.melior);
+                        let element_type =
+                            MlirType::fixed_bytes(scope.melior, solx_utils::BYTE_LENGTH_BYTE);
                         (
                             element_type,
                             MlirType::pointer(
@@ -934,7 +935,7 @@ impl Call {
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// `arr.push()` is the sole call assignable in place position; the slot it grows is the value the
-    /// push emits. The binder types a `bytes` element `bytes1` where the dialect stores a byte.
+    /// push emits, typed by the binder as the array's element.
     pub fn function_call_place(
         &mut self,
         node: &FunctionCallExpression,
@@ -943,13 +944,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .into_iter()
             .next()
             .expect("an array push in place position yields the new element's slot");
-        let slang_type = node.get_type().expect("the binder types every expression");
-        let element_type = if slang_type.is_reference_type() {
-            self.resolve_type(&slang_type, None)
-        } else {
-            slot.r#type().element_type(0)
-        };
-        (Place::from(slot), element_type)
+        (Place::from(slot), self.typing(node.get_type()))
     }
 
     /// Calls the function a `using {f as op} for T global;` directive binds an operator to. Being a


### PR DESCRIPTION
Stacked on #637. Retires `!sol.byte` from solx's own vocabulary: the `bytes` push slot is spelled `!sol.fixedbytes<1>` (the binder's `bytes1`), which deletes the `MlirType::byte` constructor, its FFI binding, and the place path's byte/bytes1 branch — `function_call_place` takes the binder's typing unconditionally. `array_string_ops.sol` becomes solx-only, since solc's print-init still types the slot `!sol.byte`.

**Blocked on solx-llvm** unifying the byte/bytes1 packed-storage canonicalization: the two spellings cast as a no-op at value level, but the packing/cleanup arms (`EVMUtil.cpp` byte exemptions, the `mstore8` path) distinguish them in places, so until the dialect change lands a pushed byte mis-packs against the byte-typed reader — `semanticTests/array/push/push_no_args_bytes.sol[a:4]` fails on this branch, verified by execution. Index-access byte places stay C-derived via `getEltType` and are untouched either way.

Do not merge before the solx-llvm unification; re-run the full tester against it first.