### PR TITLE
fix(solc): preserve standard JSON input on errors

### DIFF
--- a/solx/src/solc.rs
+++ b/solx/src/solc.rs
@@ -101,7 +101,10 @@ impl solx_core::Frontend for Solc {
         input_json.settings.optimizer.mode = None;
         input_json.settings.optimizer.size_fallback = None;
 
-        let input_string = serde_json::to_string(input_json)
+        let input_string = serde_json::to_string(input_json);
+        input_json.settings.output_selection = original_output_selection;
+        input_json.settings.optimizer = original_optimizer;
+        let input_string = input_string
             .map_err(|error| anyhow::anyhow!("solc standard JSON input serialization: {error}"))?;
         let input_c_string = CString::new(input_string)
             .map_err(|error| anyhow::anyhow!("solc standard JSON input CString: {error}"))?;
@@ -204,8 +207,6 @@ impl solx_core::Frontend for Solc {
             }
         };
 
-        input_json.settings.output_selection = original_output_selection;
-        input_json.settings.optimizer = original_optimizer;
         solc_output
             .errors
             .retain(|error| match error.error_code.as_deref() {

--- a/solx/tests/mod.rs
+++ b/solx/tests/mod.rs
@@ -8,3 +8,5 @@ mod cli;
 mod common;
 #[cfg(feature = "solc")]
 mod debug_info;
+#[cfg(feature = "solc")]
+mod solc;

--- a/solx/tests/solc/mod.rs
+++ b/solx/tests/solc/mod.rs
@@ -1,0 +1,31 @@
+//!
+//! The `solc` frontend tests.
+//!
+
+use solx_core::Frontend;
+
+///
+/// `standard_json` narrows `output_selection` and clears the optimizer mode for `solc`,
+/// then restores both once `solc` returns. An early return between the two leaves the
+/// caller's input carrying solc's selection instead of its own. An interior NUL byte in
+/// the base path fails after the mutation without entering `solc`, so the restore is
+/// pinned without linking `solc` behavior into the assertion.
+///
+#[test]
+fn standard_json_restores_input_settings_on_error() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let mut input = solx_standard_json::Input::try_from(Some(std::path::Path::new(
+        crate::common::standard_json!("solidity.json"),
+    )))?;
+    let original = serde_json::to_value(&input)?;
+
+    let error = solx::Solc::default()
+        .standard_json(&mut input, true, Some("abc\0def"), &[], None)
+        .expect_err("a base path with an interior NUL byte is rejected");
+
+    assert!(error.to_string().contains("solc base path CString"));
+    assert_eq!(serde_json::to_value(&input)?, original);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes https://github.com/NomicFoundation/solx/issues/643

## Description

`Solc::standard_json` temporarily adjusts the output selection and optimizer settings before passing the input to solc.

Previously, these fields were restored only after the complete invocation and output parsing succeeded. Errors produced while preparing paths, invoking solc, or parsing its output therefore left the caller-provided input modified.

This change captures the result of the fallible solc invocation, restores the original input settings, and only then propagates the result.

## Testing

Added a regression test that:

- invokes `Solc::standard_json` with a base path containing an interior NUL byte;
- verifies that the call returns an error;
- verifies that the complete standard JSON input remains unchanged.