### PR TITLE
ci(windows): enable git core.longpaths so cargo can check out slang

### DIFF
--- a/.github/actions/prepare-msys/action.yml
+++ b/.github/actions/prepare-msys/action.yml
@@ -39,6 +39,11 @@ runs:
     - name: Prepare env
       shell: msys2 {0}
       run: |
+        # cargo's libgit2 enforces the 260-char MAX_PATH when checking out
+        # git dependencies, and slang's generated snapshot paths exceed it.
+        # Written here so it lands in the msys2 HOME that the `msys2 {0}`
+        # cargo steps resolve as the global git config.
+        git config --global core.longpaths true
         rustup set default-host x86_64-pc-windows-gnu
         echo '${{ steps.msys2.outputs.msys2-location }}\mingw64\bin' >> "${GITHUB_PATH}"
         echo "${USERPROFILE}\\.cargo\\bin" >> "${GITHUB_PATH}"


### PR DESCRIPTION
cargo's bundled libgit2 enforces the 260-char `MAX_PATH` when checking out git dependencies. The `slang_solidity_v2` dependency's generated snapshot files exceed it — the longest path under `.cargo/git/checkouts` reaches 265 chars — so `cargo fetch` fails on Windows before any test runs:

```
error: failed to get `slang_solidity_v2` as a dependency of package `solx-utils v0.1.7`
Caused by: path too long: 'C:/Users/runneradmin/.cargo/git/checkouts/slang-86cb5cfcb4fc5b9a/ad18c38/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/external_declaration_shadowing/yul_variable_shadows_blobhash_before_introduction/generated/solc/05-constantinople-success.txt'; class=Filesystem (30)
```

Failing run: https://github.com/NomicFoundation/solx/actions/runs/31715128422

With `core.longpaths` set, libgit2 switches to `\\?\`-prefixed paths and skips the limit. The config is written from the msys2 shell in `prepare-msys` because the `msys2 {0}` cargo steps resolve the global git config through the msys2 `HOME`.

Verified on the `feat-slang-state-var-getters` branch, where the Windows leg went from red to green with this commit: https://github.com/NomicFoundation/solx/actions/runs/31732402903